### PR TITLE
Don't be so picky about results of file-watching (fixes #6)

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -409,13 +409,8 @@ function revise_file_queued(file)
             return nothing
         end
     end
-    event = watch_file(file)
-    if event.changed
-        push!(revision_queue, file)
-    else
-        warn(file, " changed in ways that Revise cannot track. You will likely have to restart your Julia session.")
-        return nothing
-    end
+    watch_file(file)  # will block here until the file changes
+    push!(revision_queue, file)
     @schedule revise_file_queued(file)
 end
 


### PR DESCRIPTION
Vim seems to trigger "renamed" rather than "changed", so it's probably better not to worry about the return value. If the file can't be found another error will catch it anyway.