### PR TITLE
Handle cases were include paths are saved to a var

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -369,6 +369,8 @@ function parse_expr!(md::ModDict, ex::Expr, file::Symbol, mod::Module, path)
             if isa(filename, String)
                 dir, fn = splitdir(filename)
                 parse_source(joinpath(path, filename), mod, joinpath(path, dir))
+            elseif isa(filename, Symbol)
+                filename = eval(mod, filename)
             elseif isa(filename, Expr)
                 try
                     filename = eval(mod, macroreplace(filename, file))


### PR DESCRIPTION
Importing SymEngine (which is a dependency of DifferentialEquations) with Revise currently fails:

```julia
julia> using Revise; using SymEngine

ERROR: deps_file not recognized
Stacktrace:
 [1] parse_expr!(::Dict{Module,Set{Revise.RelocatableExpr}}, ::Expr, ::Symbol, ::Module, ::String) at C:\Users\heichhorn\.julia\v0.6\Revise\src\Revise.jl:384
 [2] parse_source!(::Dict{Module,Set{Revise.RelocatableExpr}}, ::Expr, ::Symbol, ::Module, ::String) at C:\Users\heichhorn\.julia\v0.6\Revise\src\Revise.jl:348
 [3] parse_expr!(::Dict{Module,Set{Revise.RelocatableExpr}}, ::Expr, ::Symbol, ::Module, ::String) at C:\Users\heichhorn\.julia\v0.6\Revise\src\Revise.jl:365
 [4] parse_source!(::Dict{Module,Set{Revise.RelocatableExpr}}, ::String, ::Symbol, ::Int64, ::Module, ::String) at C:\Users\heichhorn\.julia\v0.6\Revise\src\Revise.jl:338
 [5] parse_source!(::Dict{Module,Set{Revise.RelocatableExpr}}, ::String, ::Module, ::String) at C:\Users\heichhorn\.julia\v0.6\Revise\src\Revise.jl:320
 [6] parse_source(::String, ::Module, ::String) at C:\Users\heichhorn\.julia\v0.6\Revise\src\Revise.jl:303
 [7] parse_pkg_files(::Symbol) at C:\Users\heichhorn\.julia\v0.6\Revise\src\Revise.jl:276
 [8] watch_package(::Symbol) at C:\Users\heichhorn\.julia\v0.6\Revise\src\Revise.jl:397
 [9] require(::Symbol) at .\loading.jl:401
```

This is because they include their `deps.jl` in the following way:

```julia
const deps_file = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
include(deps_file)
```

This PR adds a branch that evals symbols encountered in `include` statements.