### PR TITLE
Use OrderedSet

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+DataStructures

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,7 +121,7 @@ __precompile__($pcflag)
 
 module $modname
 
-export $(fbase)1, $(fbase)2, $(fbase)3, $(fbase)4, $(fbase)5, using_mac$(fbase)
+export $(fbase)1, $(fbase)2, $(fbase)3, $(fbase)4, $(fbase)5, using_macro_$(fbase)
 
 $(fbase)1() = 1
 
@@ -131,13 +131,15 @@ include(joinpath(@__DIR__, "subdir", "file4.jl"))
 otherfile = "file5.jl"
 include(otherfile)
 
-# Evaluation ordering check: the code update below will change the `$(fbase)1()` and
-# `using_mac()` definitions.  If the latter is updated before the former, then the
-# macroexpansion will return 1, and the test will fail.
-macro mac$(fbase)()
-    return $(fbase)1()
+# Update order check: modifying `some_macro_` to return -6 doesn't change the
+# return value of `using_macro_` (issue #20) unless `using_macro_` is also updated,
+# *in this order*:
+#   1. update the `@some_macro_` definition
+#   2. update the `using_macro_` definition
+macro some_macro_$(fbase)()
+    return 6
 end
-using_mac$(fbase)() = @mac$(fbase)()
+using_macro_$(fbase)() = @some_macro_$(fbase)()
 
 end
 """)
@@ -159,13 +161,13 @@ end
             fn1, fn2 = Symbol("$(fbase)1"), Symbol("$(fbase)2")
             fn3, fn4 = Symbol("$(fbase)3"), Symbol("$(fbase)4")
             fn5 = Symbol("$(fbase)5")
-            fn6 = Symbol("using_mac$(fbase)")
+            fn6 = Symbol("using_macro_$(fbase)")
             @eval @test $(fn1)() == 1
             @eval @test $(fn2)() == 2
             @eval @test $(fn3)() == 3
             @eval @test $(fn4)() == 4
             @eval @test $(fn5)() == 5
-            @eval @test $(fn6)() == $(fn1)()
+            @eval @test $(fn6)() == 6
             sleep(0.1)  # to ensure that the file watching has kicked in
             # Change the definition of function 1 (easiest to just rewrite the whole file)
             open(joinpath(dn, modname*".jl"), "w") do io
@@ -179,10 +181,12 @@ include("subdir/file3.jl")
 include(joinpath(@__DIR__, "subdir", "file4.jl"))
 otherfile = "file5.jl"
 include(otherfile)
-macro mac$(fbase)()
-    return $(fbase)1()
+
+macro some_macro_$(fbase)()
+    return -6
 end
-using_mac$(fbase)() = @mac$(fbase)()+0
+using_macro_$(fbase)() = @some_macro_$(fbase)() + 0  # + 0 to force a revision
+
 end
 """)  # just for fun we skipped the whitespace
             end
@@ -192,7 +196,7 @@ end
             @eval @test $(fn3)() == 3
             @eval @test $(fn4)() == 4
             @eval @test $(fn5)() == 5
-            @eval @test $(fn6)() == $(fn1)()
+            @eval @test $(fn6)() == -6
             # Redefine function 2
             open(joinpath(dn, "file2.jl"), "w") do io
                 println(io, "$(fbase)2() = -2")
@@ -203,7 +207,7 @@ end
             @eval @test $(fn3)() == 3
             @eval @test $(fn4)() == 4
             @eval @test $(fn5)() == 5
-            @eval @test $(fn6)() == $(fn1)()
+            @eval @test $(fn6)() == -6
             open(joinpath(dn, "subdir", "file3.jl"), "w") do io
                 println(io, "$(fbase)3() = -3")
             end
@@ -213,7 +217,7 @@ end
             @eval @test $(fn3)() == -3
             @eval @test $(fn4)() == 4
             @eval @test $(fn5)() == 5
-            @eval @test $(fn6)() == $(fn1)()
+            @eval @test $(fn6)() == -6
             open(joinpath(dn, "subdir", "file4.jl"), "w") do io
                 println(io, "$(fbase)4() = -4")
             end
@@ -223,7 +227,7 @@ end
             @eval @test $(fn3)() == -3
             @eval @test $(fn4)() == -4
             @eval @test $(fn5)() == 5
-            @eval @test $(fn6)() == $(fn1)()
+            @eval @test $(fn6)() == -6
             open(joinpath(dn, "file5.jl"), "w") do io
                 println(io, "$(fbase)5() = -5")
             end
@@ -233,7 +237,7 @@ end
             @eval @test $(fn3)() == -3
             @eval @test $(fn4)() == -4
             @eval @test $(fn5)() == -5
-            @eval @test $(fn6)() == $(fn1)()
+            @eval @test $(fn6)() == -6
         end
         # Remove the precompiled file
         rm(joinpath(Base.LOAD_CACHE_PATH[1], "PC.ji"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Revise
 using Base.Test
+using DataStructures: OrderedSet
 
 to_remove = String[]
 
@@ -33,7 +34,7 @@ to_remove = String[]
         warnfile = joinpath(tempdir(), randstring(10))
         open(warnfile, "w") do io
             redirect_stderr(io) do
-                md = Revise.ModDict(Main=>Set{Revise.RelocatableExpr}())
+                md = Revise.ModDict(Main=>OrderedSet{Revise.RelocatableExpr}())
                 @test !Revise.parse_source!(md, """
 f(x) = 1
 g(x) = 2
@@ -71,7 +72,7 @@ k(x) = 4
             cube(x) = x^3
             fourth(x) = x^4  # this is an addition to the file
         end)
-        @test isequal(revmd[ReviseTest], Set(collectexprs(cmp)))
+        @test isequal(revmd[ReviseTest], OrderedSet(collectexprs(cmp)))
 
         Revise.eval_revised(revmd)
         @test ReviseTest.cube(2) == 8

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,6 +130,10 @@ include("subdir/file3.jl")
 include(joinpath(@__DIR__, "subdir", "file4.jl"))
 otherfile = "file5.jl"
 include(otherfile)
+
+# Evaluation ordering check: the code update below will change the `$(fbase)1()` and
+# `using_mac()` definitions.  If the latter is updated before the former, then the
+# macroexpansion will return 1, and the test will fail.
 macro mac$(fbase)()
     return $(fbase)1()
 end


### PR DESCRIPTION
We could then add a user-facing function that forces reloading every rex in a module. This would be a work-around for the macro/generated function issues.

On both master and this branch, I'm getting a failure, four times out of five:

```julia
Cleanup: Test Failed
  Expression: contains(readstring(warnfile), "is not an existing directory")
Stacktrace:
 [1] macro expansion at /Users/cedric/.julia/v0.6/Revise/test/runtests.jl:457 [inlined]
 [2] macro expansion at ./test.jl:860 [inlined]
 [3] macro expansion at /Users/cedric/.julia/v0.6/Revise/test/runtests.jl:445 [inlined]
 [4] macro expansion at ./test.jl:860 [inlined]
```

I haven't investigated, but I printed `warnfile`, and it's empty.