### PR TITLE
revise(module) to force reevaluating every expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ There are some kinds of changes that Revise cannot incorporate into a running Ju
 
 - changes to type definitions
 - function or method deletions
-- changes to macros that affect method definitions
 - file or module renames
+- changes to macros that affect method definitions, or to functions that affect generated
+function expansion. To work around this issue, you may explicitly call `revise(module)`
+to force reevaluating every definition in `module`.
 - changes in files that are omitted by Revise (you should see a warning about these). Revise has to be able to statically parse the paths in your package; statements like `include("file2.jl")` are easy but `include(string((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "build_h.jl"))` cannot be handled.
 
 These kinds of changes require that you restart your Julia session.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ Julia's `Base` module: just say `Revise.track(Base)`. You'll see
 warnings about some files that are not tracked (see more information
 below).
 
-## Related packages
-
-See also [ClobberingReload](https://github.com/cstjean/ClobberingReload.jl).
-
 ## Manual revision
 
 By default, Revise processes any modified source files every time you enter

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -619,7 +619,7 @@ Reevaluate every definition in `mod`, whether it was changed or not. This is use
 to propagate an updated macro definition, or to force recompiling generated functions.
 """
 function revise(mod::Module)
-    for file in parse_pkg_files(Symbol(mod))
+    for file in module2files[Symbol(mod)]
         eval_revised(file2modules[file].md)
     end
 end

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -613,6 +613,18 @@ function revise()
 end
 
 """
+    revise(mod::Module)
+
+Reevaluate every definition in `mod`, whether it was changed or not. This is useful
+to propagate an updated macro definition, or to force recompiling generated functions.
+"""
+function revise(mod::Module)
+    for file in parse_pkg_files(Symbol(mod))
+        eval_revised(file2modules[file].md)
+    end
+end
+
+"""
     Revise.track(mod::Module, file::AbstractString)
     Revise.track(file::AbstractString)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,7 +189,7 @@ include(otherfile)
 macro some_macro_$(fbase)()
     return -6
 end
-using_macro_$(fbase)() = @some_macro_$(fbase)() + 0  # + 0 to force a revision
+using_macro_$(fbase)() = @some_macro_$(fbase)()
 
 end
 """)  # just for fun we skipped the whitespace
@@ -200,6 +200,8 @@ end
             @eval @test $(fn3)() == 3
             @eval @test $(fn4)() == 4
             @eval @test $(fn5)() == 5
+            @eval @test $(fn6)() == 6      # because it hasn't been re-macroexpanded
+            revise(eval(Symbol(modname)))
             @eval @test $(fn6)() == -6
             # Redefine function 2
             open(joinpath(dn, "file2.jl"), "w") do io


### PR DESCRIPTION
As suggested in https://github.com/timholy/Revise.jl/pull/33#issue-247406423

Issues:

- I like `revise(module)` as a verb, but it's not entirely obvious what it's going to do.  `forcerevise(module)`? 
- Both here and in TraceCalls.jl, I get the module files from `parse_pkg_files`, which seems a tad wasteful given that those files were already parsed. We could maintain `module2files`.
- `revise(module)` triggers a lot of redefinition warnings. In ClobberingReload I use [this code](https://github.com/cstjean/ClobberingReload.jl/blob/master/src/scrub_stderr.jl). We could move over `scrub_stderr` to Revise.jl

This is a work-around for #20 and #31, I'll leave you to decide if you want to close these issues. 