### PR TITLE
Add module2files

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -266,6 +266,7 @@ function eval_revised(revmd::ModDict)
 end
 
 const file2modules = Dict{String,FileModules}()
+const module2files = Dict{Symbol,Vector{String}}()
 const new_files = String[]
 
 function parse_pkg_files(modsym::Symbol)
@@ -285,6 +286,7 @@ function parse_pkg_files(modsym::Symbol)
         parse_source(mainfile, Main, dirname(mainfile))
         files = new_files
     end
+    module2files[modsym] = copy(files)
     files
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,6 +242,13 @@ end
             @eval @test $(fn4)() == -4
             @eval @test $(fn5)() == -5
             @eval @test $(fn6)() == -6
+            # Check module2files
+            files = [joinpath(dn, modname*".jl"), joinpath(dn, "file2.jl"),
+                     joinpath(dn, "subdir", "file3.jl"),
+                     joinpath(dn, "subdir", "file4.jl"),
+                     joinpath(dn, "file5.jl")]
+            # FIXME: ideally `module2files[...]` and `files` should be in the same order.
+            @test Set(Revise.module2files[Symbol(modname)]) == Set(files)
         end
         # Remove the precompiled file
         rm(joinpath(Base.LOAD_CACHE_PATH[1], "PC.ji"))


### PR DESCRIPTION
This is the easiest definition to support #41. I wish that `parse_pkg_files` returned the files in evaluation order, but I can't quite follow its logic to fix it. In any case, I don't think the order matters for #41: if I modify a macro's definition in MyModule.jl and call `revise(MyModule)`, the macro will be updated by the regular `revise()` call before `revise(MyModule)` is executed.

Alternatively, we could define `module2files` as an inverse of `file2modules`, but it's not as straight-forward, and I didn't see any upside.