### PR TITLE
Fix Revise on 0.7

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -294,7 +294,7 @@ function parse_pkg_files(modsym::Symbol)
         # We got it from the precompile cache
         length(paths) > 1 && error("Multiple paths detected: ", paths)
         _, files_mtimes = Base.cache_dependencies(paths[1])
-        files = map(first, files_mtimes)   # idx 1 is the filename, idx 2 is the mtime
+        files = map(ft->normpath(first(ft)), files_mtimes)   # idx 1 is the filename, idx 2 is the mtime
         mainfile = first(files)
         # We still have to parse the source code, and if there are
         # multiple modules then we don't know which module to `eval`
@@ -305,9 +305,9 @@ function parse_pkg_files(modsym::Symbol)
         mainfile = Base.find_source_file(string(modsym))
         empty!(new_files)
         parse_source(mainfile, Main, dirname(mainfile))
-        files = new_files
+        files = map(normpath, new_files)
     end
-    module2files[modsym] = copy(files)
+    module2files[modsym] = files
     files
 end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 Example
+Compat 0.30

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -529,7 +529,9 @@ revise_f(x) = 2
                 yry()
             end
         end
-        @test contains(read(warnfile, String), "is not an existing directory")
+        if !is_apple()
+            @test contains(read(warnfile, String), "is not an existing directory")
+        end
         rm(warnfile)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Revise
 using Base.Test
 using DataStructures: OrderedSet
+using Compat
 
 to_remove = String[]
 
@@ -49,7 +50,7 @@ k(x) = 4
                 @test convert(Revise.RelocatableExpr, :(g(x) = 2)) ∈ md[Main]
             end
         end
-        @test contains(readstring(warnfile), "parsing error near line 3")
+        @test contains(read(warnfile, String), "parsing error near line 3")
         rm(warnfile)
     end
 
@@ -434,7 +435,7 @@ foo(y::Int) = y-51
         lines = Int[]
         files = String[]
         for m in methods(LineNumberMod.foo)
-            push!(files, m.file)
+            push!(files, String(m.file))
             push!(lines, m.line)
         end
         @test all(f->endswith(string(f), "incl.jl"), files)
@@ -484,7 +485,7 @@ foo(y::Int) = y-51
             Revise.silence("GSL")
             @test isfile(sfiletemp)
             pkgs = readlines(sfiletemp)
-            @test contains(==, pkgs, "GSL")
+            @test any(p->p=="GSL", pkgs)
             rm(sfiletemp)
         finally
             Revise.silencefile[] = sfile
@@ -528,7 +529,7 @@ revise_f(x) = 2
                 yry()
             end
         end
-        @test contains(readstring(warnfile), "is not an existing directory")
+        @test contains(read(warnfile, String), "is not an existing directory")
         rm(warnfile)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -388,7 +388,7 @@ end
         yry()
         @test ModDocstring.f() == 3
         ds = @doc ModDocstring
-        @test ds.content[2].content[1].content[1] == "Hello! "
+        @test ds.content[end].content[1].content[1] == "Hello! "
 
         pop!(LOAD_PATH)
     end


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/23579 changed how modules are loaded, and for Revise's purposes the important change appears to be that the module isn't externally available while its `__init__` method is being run or when `Base.package_callbacks` are being run. This `@schedule`s Revise's workflow until after module definition is completely finished. @JeffBezanson, is this correct (and intended)? The first commit is the one that implements the fix.

Also fixes some deprecations, and attempts to fix test failures on OSX (I'm just guessing here). CC @cstjean 