### PR TITLE
Eliminate need to parse include paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7.0-DEV.2062
 DataStructures

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7.0-DEV.2062
+julia 0.7.0-DEV.2214
 DataStructures

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7.0-DEV.2214
+julia 0.7.0-DEV.2359
 DataStructures

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -124,7 +124,10 @@ function parse_pkg_files(modsym::Symbol)
         _, mods_files_mtimes = Base.parse_cache_header(paths[1])
         for (modname, fname, _) in mods_files_mtimes
             modname == "#__external__" && continue
-            mod = Base.root_module(Symbol(modname))
+            modnames = split(modname, '.')
+            rootmodname = modnames[1]
+            rootmod = Base.root_module(Symbol(rootmodname))
+            mod = rootmodname == modname ? rootmod : getfield(rootmod, Symbol(join(modnames[2:end], '.')))
             # For precompiled packages, we can read the source later (whenever we need it)
             # from the *.ji cachefile.
             push!(file2modules, fname=>FileModules(mod, ModDict(), paths[1]))

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -5,6 +5,7 @@ module Revise
 VERSION >= v"0.7.0-DEV.2359" && using FileWatching
 
 using DataStructures: OrderedSet
+using FileWatching
 
 export revise
 

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -8,193 +8,34 @@ using DataStructures: OrderedSet
 
 export revise
 
-const revision_queue = Set{String}()  # file names that have changed since last revision
-# Some platforms (OSX) have trouble watching too many files. So we
-# watch parent directories, and keep track of which files in them
-# should be tracked.
-mutable struct WatchList
-    timestamp::Float64         # unix time of last revision
-    trackedfiles::Set{String}
-end
+include("relocatable_exprs.jl")
+include("types.jl")
+include("parsing.jl")
+
+### Globals to keep track of state
+# revision_queue holds the names of files that we need to revise, meaning that these
+# files have changed since we last processed a revision. This list gets populated
+# by callbacks that watch directories for updates.
+const revision_queue = Set{String}()
+# watched_files[dirname] returns the list of files in dirname that we're monitoring for changes
 const watched_files = Dict{String,WatchList}()
+
+# file2modules is indexed by absolute paths of files, and provides access to the parsed
+# source code defined in the file. The expressions in the source code are organized by the
+# module in which they should be evaluated.
+const file2modules = Dict{String,FileModules}()
+# module2files holds the list of filenames used to define a particular module
+const module2files = Dict{Symbol,Vector{String}}()
+
+# included_files gets populated by callbacks we register with `include`. It's used
+# to track non-precompiled packages.
+const included_files = Tuple{Module,String}[]  # (module, filename)
 
 ## For excluding packages from tracking by Revise
 const dont_watch_pkgs = Set{Symbol}()
 const silence_pkgs = Set{Symbol}()
 const depsdir = joinpath(dirname(@__DIR__), "deps")
 const silencefile = Ref(joinpath(depsdir, "silence.txt"))  # Ref so that tests don't clobber
-
-## Structures to manipulate parsed files
-
-# We will need to detect new function bodies, compare function bodies
-# to see if they've changed, etc.  This has to be done "blind" to the
-# line numbers at which the functions are defined.
-#
-# Now, we could just discard line numbers from expressions, but that
-# would have a very negative effect on the quality of backtraces. So
-# we keep them, but introduce machinery to compare expressions without
-# concern for line numbers.
-#
-# To reduce the performance overhead of this package, we try to
-# achieve this goal with minimal copying of data.
-
-"""
-A `RelocatableExpr` is exactly like an `Expr` except that comparisons
-between `RelocatableExpr`s ignore line numbering information.
-"""
-mutable struct RelocatableExpr
-    head::Symbol
-    args::Vector{Any}
-    typ::Any
-
-    RelocatableExpr(head::Symbol, args::Vector{Any}) = new(head, args)
-    RelocatableExpr(head::Symbol, args...) = new(head, [args...])
-end
-
-# Works in-place and hence is unsafe. Only for internal use.
-Base.convert(::Type{RelocatableExpr}, ex::Expr) = relocatable!(ex)
-
-function relocatable!(ex::Expr)
-    rex = RelocatableExpr(ex.head, relocatable!(ex.args))
-    rex.typ = ex.typ
-    rex
-end
-
-function relocatable!(args::Vector{Any})
-    for (i, a) in enumerate(args)
-        if isa(a, Expr)
-            args[i] = relocatable!(a::Expr)
-        end   # do we need to worry about QuoteNodes?
-    end
-    args
-end
-
-function Base.convert(::Type{Expr}, rex::RelocatableExpr)
-    # This makes a copy. Used for `eval`, where we don't want to
-    # mutate the cached represetation.
-    ex = Expr(rex.head)
-    ex.args = Base.copy_exprargs(rex.args)
-    ex.typ = rex.typ
-    ex
-end
-Base.copy_exprs(rex::RelocatableExpr) = convert(Expr, rex)
-
-# Implement the required comparison functions. `hash` is needed for Dicts.
-function Base.:(==)(a::RelocatableExpr, b::RelocatableExpr)
-    a.head == b.head && isequal(LineSkippingIterator(a.args), LineSkippingIterator(b.args))
-end
-
-const hashrex_seed = UInt == UInt64 ? 0x7c4568b6e99c82d9 : 0xb9c82fd8
-Base.hash(x::RelocatableExpr, h::UInt) = hash(LineSkippingIterator(x.args),
-                                              hash(x.head, h + hashrex_seed))
-
-# We could just collect all the non-line statements to a Vector, but
-# doing things in-place will be more efficient.
-
-struct LineSkippingIterator
-    args::Vector{Any}
-end
-
-Base.start(iter::LineSkippingIterator) = skip_to_nonline(iter.args, 1)
-Base.done(iter::LineSkippingIterator, i) = i > length(iter.args)
-Base.next(iter::LineSkippingIterator, i) = (iter.args[i], skip_to_nonline(iter.args, i+1))
-
-function skip_to_nonline(args, i)
-    while true
-        i > length(args) && return i
-        ex = args[i]
-        if isa(ex, RelocatableExpr) && (ex::RelocatableExpr).head == :line
-            i += 1
-        elseif isa(ex, LineNumberNode)
-            i += 1
-        else
-            return i
-        end
-    end
-end
-
-function Base.isequal(itera::LineSkippingIterator, iterb::LineSkippingIterator)
-    # We could use `zip` here except that we want to insist that the
-    # iterators also have the same length.
-    ia, ib = start(itera), start(iterb)
-    while !done(itera, ia) && !done(iterb, ib)
-        vala, ia = next(itera, ia)
-        valb, ib = next(iterb, ib)
-        if isa(vala, RelocatableExpr) && isa(valb, RelocatableExpr)
-            vala = vala::RelocatableExpr
-            valb = valb::RelocatableExpr
-            vala.head == valb.head || return false
-            isequal(LineSkippingIterator(vala.args), LineSkippingIterator(valb.args)) || return false
-        else
-            isequal(vala, valb) || return false
-        end
-    end
-    done(itera, ia) && done(iterb, ib)
-end
-
-const hashlsi_seed = UInt == UInt64 ? 0x533cb920dedccdae : 0x2667c89b
-function Base.hash(iter::LineSkippingIterator, h::UInt)
-    h += hashlsi_seed
-    for x in iter
-        h += hash(x, h)
-    end
-    h
-end
-
-"""
-
-A `ModDict` is a `Dict{Module,Set{RelocatableExpr}}`. It is used to
-organize expressions according to their module of definition. We use a
-Set so that it is easy to find the differences between two `ModDict`s.
-
-See also [`FileModules`](@ref).
-"""
-const ModDict = Dict{Module,OrderedSet{RelocatableExpr}}
-
-"""
-    FileModules(topmod::Module, md::ModDict)
-
-Structure to hold the per-module expressions found when parsing a
-single file.  `topmod` is the current module when the file is
-parsed. `md` holds the evaluatable statements, organized by the module
-of their occurance. In particular, if the file defines one or
-more new modules, then `md` contains key/value pairs for each
-module. If the file does not define any new modules, `md[topmod]` is
-the only entry in `md`.
-
-# Example:
-
-Suppose MyPkg.jl has a file that looks like this:
-
-```julia
-__precompile__(true)
-
-module MyPkg
-
-foo(x) = x^2
-
-end
-```
-
-Then if this module is loaded from `Main`, schematically the
-corresponding `fm::FileModules` looks something like
-
-```julia
-fm.topmod = Main
-fm.md = Dict(Main=>OrderedSet([:(__precompile__(true))]),
-             Main.MyPkg=>OrderedSet[:(foo(x) = x^2)])
-```
-because the precompile statement occurs in `Main`, and the definition of
-`foo` occurs in `Main.MyPkg`.
-
-To create a `FileModules` from a source file, see [`parse_source`](@ref).
-"""
-struct FileModules
-    topmod::Module
-    md::ModDict
-end
-
-# Now it's easy to find the revised statements
 
 """
     revmod = revised_statements(new_defs, old_defs)
@@ -227,36 +68,20 @@ function revised_statements!(revmd::ModDict, mod::Module,
         if isa(stmt, RelocatableExpr)
             stmt = stmt::RelocatableExpr
             @assert stmt.head != :module
-            # if stmt.head == :module
-            #     # We have to recurse into module definitions
-            #     modsym = _module_name(stmt)
-            #     oldstmt = find_module_def(olddefs, modsym)
-            #     revised_statements!(revmd, getfield(mod, modsym)::Module,
-            #                         Set(stmt.args), Set(oldstmt.args))
-            # else
-                if stmt ∉ olddefs
-                    if !haskey(revmd, mod)
-                        revmd[mod] = OrderedSet{RelocatableExpr}()
-                    end
-                    push!(revmd[mod], stmt)
+            if stmt ∉ olddefs
+                if !haskey(revmd, mod)
+                    revmd[mod] = OrderedSet{RelocatableExpr}()
                 end
-            # end
+                push!(revmd[mod], stmt)
+            end
         end
     end
     revmd
 end
 
-# function find_module_def(s::Set, modsym::Symbol)
-#     for ex in s
-#         if ex.head == :module && _module_name(ex) == modsym
-#             return ex
-#         end
-#     end
-#     error("definition for module $modsym not found in $s")
-# end
-
 function eval_revised(revmd::ModDict)
     for (mod, exprs) in revmd
+        mod = mod == Base.__toplevel__ ? Main : mod
         for rex in exprs
             ex = convert(Expr, rex)
             try
@@ -269,10 +94,6 @@ function eval_revised(revmd::ModDict)
     end
 end
 
-const file2modules = Dict{String,FileModules}()
-const module2files = Dict{Symbol,Vector{String}}()
-const new_files = String[]
-
 function use_compiled_modules()
     @static if VERSION >= v"0.7.0-DEV.1698"
         return Base.JLOptions().use_compiled_modules != 0
@@ -281,260 +102,81 @@ function use_compiled_modules()
     end
 end
 
+"""
+    parse_pkg_files(modsym)
+
+This function gets called by `watch_package` and runs when a package is first loaded.
+Its job is to organize the files and expressions defining the module so that later we can
+detect and process revisions.
+"""
 function parse_pkg_files(modsym::Symbol)
     paths = String[]
     if use_compiled_modules()
-        # If we can, let's use the precompile cache. That is
-        # guaranteed to have a complete list of the included files,
-        # something that can't be guaranteed if we rely on parsing:
-        #     for file in files
-        #         include(file)
-        #     end
-        # isn't something that Revise can handle. Unfortunately we
-        # can't fully exploit this just yet, see below.
         paths = Base.find_all_in_cache_path(modsym)
     end
+    files = String[]
     if !isempty(paths)
-        # We got it from the precompile cache
+        # We got the top-level file from the precompile cache
         length(paths) > 1 && error("Multiple paths detected: ", paths)
-        _, files_mtimes = Base.cache_dependencies(paths[1])
-        files = map(ft->normpath(first(ft)), files_mtimes)   # idx 1 is the filename, idx 2 is the mtime
-        mainfile = first(files)
-        # We still have to parse the source code, and if there are
-        # multiple modules then we don't know which module to `eval`
-        # them into.
-        parse_source(mainfile, Main, dirname(mainfile))
+        _, mods_files_mtimes = Base.parse_cache_header(paths[1])
+        for (modname, fname, _) in mods_files_mtimes
+            modname == "#__external__" && continue
+            mod = Base.root_module(Symbol(modname))
+            pr = parse_source(fname, mod)
+            if isa(pr, Pair)
+                push!(file2modules, pr)
+            end
+            push!(files, fname)
+        end
     else
-        # Non-precompiled package, so we learn the list of files through parsing
-        mainfile = Base.find_source_file(string(modsym))
-        empty!(new_files)
-        parse_source(mainfile, Main, dirname(mainfile))
-        files = map(normpath, new_files)
+        # Non-precompiled package(s). Here we rely on the `include` callbacks to have
+        # already populated `included_files`; all we have to do is collect the relevant
+        # files. The main trick here is that since `using` is recursive, `included_files`
+        # might contain files associated with many different packages. We have to figure
+        # out which correspond to `modsym`, which we do by:
+        #   - checking the module in which each file is evaluated. This suffices to
+        #     detect "supporting" files, i.e., those `included` within the module
+        #     definition.
+        #   - checking the filename. Since the "top level" file is evaluated into Main,
+        #     we can't use the module-of-evaluation to find it. Here we hope that the
+        #     top-level filename follows convention and matches the module. TODO?: it's
+        #     possible that this needs to be supplemented with parsing.
+        i = 1
+        modstring = string(modsym)
+        while i <= length(included_files)
+            mod, fname = included_files[i]
+            modname = String(Symbol(mod))
+            if startswith(modname, modstring) || endswith(fname, modstring*".jl")
+                pr = parse_source(fname, mod)
+                if isa(pr, Pair)
+                    push!(file2modules, pr)
+                end
+                push!(files, normpath(fname))
+                deleteat!(included_files, i)
+            else
+                i += 1
+            end
+        end
     end
     module2files[modsym] = files
     files
 end
 
-"""
-    md = parse_source(file::AbstractString, mod::Module, path)
-
-Parse the source `file`, returning a `ModuleDict` `md` containing the
-set of RelocatableExprs for each module defined in `file`. `mod` is
-the "parent" module for the file; if `file` defines more module(s)
-then these will all have separate entries in `md`.
-
-Set `path` to be the directory name of `file` if you want to recurse
-into any `include`d files and add them to `Revise.file2modules`. (This
-is appropriate for when you parse a package/module definition upon
-initial load.) Otherwise set `path=nothing`.
-
-If parsing `file` fails, `nothing` is returned.
-"""
-function parse_source(file::AbstractString, mod::Module, path)
-    # Create a blank ModDict to store the expressions. Parsing will "fill" this.
-    md = ModDict(mod=>OrderedSet{RelocatableExpr}())
-    nfile = normpath(file)
-    if path != nothing
-        # Parsing is recursive (depth-first), so to preserve the order
-        # we add `file` to the list now
-        push!(new_files, nfile)
-    end
-    if !parse_source!(md, file, mod, path)
-        pop!(new_files)  # since it failed, remove it from the list
-        return nothing
-    end
-    fm = FileModules(mod, md)
-    if path != nothing
-        file2modules[nfile] = fm
-    end
-    fm
-end
-
-"""
-    success = parse_source!(md::ModDict, file, mod::Module, path)
-
-Top-level parsing of `file` as included into module
-`mod`. Successfully-parsed expressions will be added to `md`. Returns
-`true` if parsing finished successfully.
-
-See also [`parse_source`](@ref).
-"""
-function parse_source!(md::ModDict, file::AbstractString, mod::Module, path)
-    if !isfile(file)
-        warn("omitting ", file, " from revision tracking")
-        return false
-    end
-    if VERSION >= v"0.7.0-DEV.1053"
-        parse_source!(md, read(file, String), Symbol(file), 1, mod, path)
-    else
-        parse_source!(md, readstring(file), Symbol(file), 1, mod, path)
-    end
-end
-
-"""
-    success = parse_source!(md::ModDict, src::AbstractString, file::Symbol, pos::Integer, mod::Module, path)
-
-Parse a string `src` obtained by reading `file` as a single
-string. `pos` is the 1-based byte offset from which to begin parsing `src`.
-
-See also [`parse_source`](@ref).
-"""
-function parse_source!(md::ModDict, src::AbstractString, file::Symbol, pos::Integer, mod::Module, path)
-    local ex, oldpos
-    # Since `parse` doesn't keep track of line numbers (it works
-    # expression-by-expression), to ensure good backtraces we have to
-    # keep track of them here. For each expression we parse, we count
-    # the number of linefeed characters that occurred between the
-    # beginning and end of the portion of the string consumed to parse
-    # the expression.
-    line_offset = 0
-    while pos < endof(src)
-        try
-            oldpos = pos
-            ex, pos = Meta.parse(src, pos; greedy=true)
-        catch err
-            ex, posfail = Meta.parse(src, pos; greedy=true, raise=false)
-            warn(STDERR, "omitting ", file, " due to parsing error near line ",
-                 line_offset + count(c->c=='\n', SubString(src, oldpos, posfail)) + 1)
-            showerror(STDERR, err)
-            println(STDERR)
-            return false
-        end
-        if isa(ex, Expr)
-            ex = ex::Expr
-            fix_line_statements!(ex, file, line_offset)  # fixes the backtraces
-            parse_expr!(md, ex, file, mod, path)
-        end
-        # Update the number of lines
-        line_offset += count(c->c=='\n', SubString(src, oldpos, pos-1))
-    end
-    true
-end
-
-"""
-    success = parse_source!(md::ModDict, ex::Expr, file, mod::Module, path)
-
-For a `file` that defines a sub-module, parse the body `ex` of the
-sub-module.  `mod` will be the module into which this sub-module is
-evaluated (i.e., included). Successfully-parsed expressions will be
-added to `md`. Returns `true` if parsing finished successfully.
-
-See also [`parse_source`](@ref).
-"""
-function parse_source!(md::ModDict, ex::Expr, file::Symbol, mod::Module, path)
-    @assert ex.head == :block
-    for a in ex.args
-        if isa(a, Expr)
-            parse_expr!(md, a::Expr, file, mod, path)
+# A near-duplicate of some of the functionality of parse_pkg_files
+# This gets called for silenced packages, to make sure they don't "contaminate"
+# included_files
+function remove_from_included_files(modsym::Symbol)
+    i = 1
+    modstring = string(modsym)
+    while i <= length(included_files)
+        mod, fname = included_files[i]
+        modname = String(Symbol(mod))
+        if startswith(modname, modstring) || endswith(fname, modstring*".jl")
+            deleteat!(included_files, i)
+        else
+            i += 1
         end
     end
-    md
-end
-
-"""
-    parse_expr!(md::ModDict, ex::Expr, file::Symbol, mod::Module, path)
-
-Recursively parse the expressions in `ex`, iterating over blocks,
-sub-module definitions, `include` statements, etc. Successfully parsed
-expressions are added to `md` with key `mod`, and any sub-modules will
-be stored in `md` using appropriate new keys. This accomplishes three main
-tasks:
-
-* add parsed expressions to the source-code cache (so that later we can detect changes)
-* determine the module into which each parsed expression is `eval`uated into
-* detect `include` statements so that we know to recurse into
-  additional files, attempting to extract accurate path information
-  even when using constructs such as `@__FILE__`.
-"""
-function parse_expr!(md::ModDict, ex::Expr, file::Symbol, mod::Module, path)
-    if ex.head == :block
-        for a in ex.args
-            parse_expr!(md, a, file, mod, path)
-        end
-        return md
-    end
-    macroreplace!(ex, String(file))
-    if ex.head == :line
-        return md
-    elseif ex.head == :module
-        parse_module!(md, ex, file, mod, path)
-    elseif isdocexpr(ex) && isa(ex.args[nargs_docexpr], Expr) && ex.args[nargs_docexpr].head == :module
-        # Module with a docstring (issue #8)
-        # Split into two expressions, a module definition followed by
-        # `"docstring" newmodule`
-        newmod = parse_module!(md, ex.args[nargs_docexpr], file, mod, path)
-        ex.args[nargs_docexpr] = Symbol(newmod)
-        push!(md[mod], convert(RelocatableExpr, ex))
-    elseif ex.head == :call && ex.args[1] == :include
-        # Extract the filename. This is easy if it's a simple string,
-        # but if it involves `joinpath` expressions or other such
-        # shenanigans, it's a little trickier.
-        # Unfortunately expressions like `include(filename)` where
-        # `filename` is a variable cannot be handled. Such files are not tracked.
-        if path != nothing
-            filename = ex.args[end]
-            if isa(filename, AbstractString)
-            elseif isa(filename, Symbol)
-                if isdefined(mod, filename)
-                    filename = getfield(mod, filename)
-                    if !isa(filename, AbstractString)
-                        warn(filename, " is not a string")
-                        return md
-                    end
-                else
-                    warn("unable to resolve filename ", filename)
-                    return md
-                end
-            elseif isa(filename, Expr)
-                try
-                    filename = eval(mod, filename)
-                catch
-                    warn("could not parse `include` expression ", filename)
-                    return md
-                end
-            else
-                error(filename, " not recognized")
-            end
-            if !isabspath(filename)
-                filename = joinpath(path, filename)
-            end
-            dir, fn = splitdir(filename)
-            parse_source(filename, mod, joinpath(path, dir))
-        end
-        # Note that if path == nothing (we're parsing the file to
-        # detect changes compared to the cached version), then we skip
-        # the include statement.
-    else
-        # Any expression that *doesn't* define line numbers, new
-        # modules, or include new files must be "real code." Add it to
-        # the cache.
-        push!(md[mod], convert(RelocatableExpr, ex))
-    end
-    md
-end
-
-"""
-    newmod = parse_module!(md::ModDict, ex::Expr, file, mod::Module, path)
-
-Parse an expression `ex` that defines a new module `newmod`. This
-module is "parented" by `mod`. Source-code expressions are added to
-`md` under the appropriate module name.
-"""
-function parse_module!(md::ModDict, ex::Expr, file::Symbol, mod::Module, path)
-    mod = moduleswap(mod)
-    mname = _module_name(ex)
-    if !isdefined(mod, mname)
-        eval(mod, ex)
-    end
-    newmod = getfield(mod, mname)
-    md[newmod] = OrderedSet{RelocatableExpr}()
-    parse_source!(md, ex.args[3], file, newmod, path)  # recurse into the body of the module
-    newmod
-end
-if VERSION >= v"0.7.0-DEV.1877"
-    moduleswap(mod) = mod == Base.__toplevel__ ? Main : mod
-else
-    moduleswap(mod) = mod
 end
 
 function watch_files_via_dir(dirname)
@@ -551,6 +193,12 @@ function watch_files_via_dir(dirname)
     latestfiles
 end
 
+"""
+    watch_package(modsym)
+
+This function gets called via a callback registered with `Base.require`, at the completion
+of module-loading by `using` or `import`.
+"""
 function watch_package(modsym::Symbol)
     # Because the callbacks are made with `invokelatest`, for reasons of performance
     # we need to make sure this function is fast to compile. By hiding the real
@@ -563,13 +211,9 @@ function _watch_package(modsym::Symbol)
         if modsym ∉ silence_pkgs
             warn("$modsym is excluded from watching by Revise. Use Revise.silence(\"$modsym\") to quiet this warning.")
         end
+        remove_from_included_files(modsym)
         return nothing
     end
-    @schedule watch_package_impl(modsym)
-    nothing
-end
-
-function watch_package_impl(modsym)
     files = parse_pkg_files(modsym)
     process_parsed_files(files)
 end
@@ -611,8 +255,9 @@ function revise_file_now(file0)
         error(file, " is not currently being tracked.")
     end
     oldmd = file2modules[file]
-    newmd = parse_source(file, oldmd.topmod, nothing)
-    if newmd != nothing
+    pr = parse_source(file, oldmd.topmod)
+    if pr != nothing
+        newmd = pr.second
         revmd = revised_statements(newmd.md, oldmd.md)
         try
             eval_revised(revmd)
@@ -655,14 +300,17 @@ end
     Revise.track(file::AbstractString)
 
 Watch `file` for updates and [`revise`](@ref) loaded code with any
-changes. If `mod` is omitted it defaults to `Main`.
+changes. `mod` is the module into which `file` is evaluated; if omitted,
+it defaults to `Main`.
 """
 function track(mod::Module, file::AbstractString)
     isfile(file) || error(file, " is not a file")
-    empty!(new_files)
     file = normpath(abspath(file))
-    parse_source(file, mod, dirname(file))
-    process_parsed_files(new_files)
+    pr = parse_source(file, mod)
+    if isa(pr, Pair)
+        push!(file2modules, pr)
+    end
+    process_parsed_files((file,))
 end
 track(file::AbstractString) = track(Main, file)
 
@@ -680,9 +328,10 @@ At present some files in Base are not trackable, see the README.
 """
 function track(mod::Module)
     if mod == Base
-        empty!(new_files)
-        parse_source(sysimg_path, Main, dirname(sysimg_path))
-        process_parsed_files(new_files)
+        error("Base tracking is currently broken")
+        # empty!(new_files)
+        # parse_source(sysimg_path, Main, dirname(sysimg_path))
+        # process_parsed_files(new_files)
     else
         error("no Revise.track recipe for module ", mod)
     end
@@ -709,8 +358,6 @@ end
 silence(pkg::AbstractString) = silence(Symbol(pkg))
 
 ## Utilities
-
-_module_name(ex::Expr) = ex.args[2]
 
 function fix_line_statements!(ex::Expr, file::Symbol, line_offset::Int=0)
     if ex.head == :line
@@ -751,10 +398,6 @@ function macroreplace!(ex::Expr, filename)
 end
 macroreplace!(s, filename) = s
 
-const nargs_docexpr = VERSION < v"0.7.0-DEV.328" ? 3 : 4
-isdocexpr(ex) = ex.head == :macrocall && ex.args[1] == GlobalRef(Core, Symbol("@doc")) &&
-           length(ex.args) >= nargs_docexpr
-
 function steal_repl_backend(backend = Base.active_repl_backend)
     # terminate the current backend
     put!(backend.repl_channel, (nothing, -1))
@@ -779,6 +422,7 @@ function steal_repl_backend(backend = Base.active_repl_backend)
 end
 
 function __init__()
+    Base.register_root_module(Symbol("Base.__toplevel__"), Base.__toplevel__)
     if isfile(silencefile[])
         pkgs = readlines(silencefile[])
         for pkg in pkgs
@@ -786,6 +430,8 @@ function __init__()
         end
     end
     push!(Base.package_callbacks, watch_package)
+    push!(Base.include_callbacks,
+        (mod::Module, fn::AbstractString) -> push!(included_files, (mod, String(fn))))
     mode = get(ENV, "JULIA_REVISE", "auto")
     if mode == "auto"
         if isdefined(Base, :active_repl_backend)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,0 +1,162 @@
+"""
+    md = parse_source(file::AbstractString, mod::Module)
+
+Parse the source `file`, returning a `ModuleDict` `md` containing the
+set of RelocatableExprs for each module used to evaluate code in `file`.
+`mod` is the "parent" module for the file; if `file` defines more module(s)
+then these will all have separate entries in `md`.
+
+If parsing `file` fails, `nothing` is returned.
+"""
+function parse_source(file::AbstractString, mod::Module)
+    # Create a blank ModDict to store the expressions. Parsing will "fill" this.
+    md = ModDict(mod=>OrderedSet{RelocatableExpr}())
+    nfile = normpath(file)
+    parse_source!(md, file, mod) || return nothing
+    fm = FileModules(mod, md)
+    nfile => fm
+end
+
+"""
+    success = parse_source!(md::ModDict, file, mod::Module)
+
+Top-level parsing of `file` as included into module
+`mod`. Successfully-parsed expressions will be added to `md`. Returns
+`true` if parsing finished successfully.
+
+See also [`parse_source`](@ref).
+"""
+function parse_source!(md::ModDict, file::AbstractString, mod::Module)
+    if !isfile(file)
+        warn("omitting ", file, " from revision tracking")
+        return false
+    end
+    parse_source!(md, read(file, String), Symbol(file), 1, mod)
+end
+
+"""
+    success = parse_source!(md::ModDict, src::AbstractString, file::Symbol, pos::Integer, mod::Module)
+
+Parse a string `src` obtained by reading `file` as a single
+string. `pos` is the 1-based byte offset from which to begin parsing `src`.
+
+See also [`parse_source`](@ref).
+"""
+function parse_source!(md::ModDict, src::AbstractString, file::Symbol, pos::Integer, mod::Module)
+    local ex, oldpos
+    # Since `parse` doesn't keep track of line numbers (it works
+    # expression-by-expression), to ensure good backtraces we have to
+    # keep track of them here. For each expression we parse, we count
+    # the number of linefeed characters that occurred between the
+    # beginning and end of the portion of the string consumed to parse
+    # the expression.
+    line_offset = 0
+    while pos < endof(src)
+        try
+            oldpos = pos
+            ex, pos = parse(src, pos; greedy=true)
+        catch err
+            ex, posfail = parse(src, pos; greedy=true, raise=false)
+            warn(STDERR, "omitting ", file, " due to parsing error near line ",
+                 line_offset + count(c->c=='\n', SubString(src, oldpos, posfail)) + 1)
+            showerror(STDERR, err)
+            println(STDERR)
+            return false
+        end
+        if isa(ex, Expr)
+            ex = ex::Expr
+            fix_line_statements!(ex, file, line_offset)  # fixes the backtraces
+            parse_expr!(md, ex, file, mod)
+        end
+        # Update the number of lines
+        line_offset += count(c->c=='\n', SubString(src, oldpos, pos-1))
+    end
+    true
+end
+
+"""
+    success = parse_source!(md::ModDict, ex::Expr, file, mod::Module)
+
+For a `file` that defines a sub-module, parse the body `ex` of the
+sub-module.  `mod` will be the module into which this sub-module is
+evaluated (i.e., included). Successfully-parsed expressions will be
+added to `md`. Returns `true` if parsing finished successfully.
+
+See also [`parse_source`](@ref).
+"""
+function parse_source!(md::ModDict, ex::Expr, file::Symbol, mod::Module)
+    @assert ex.head == :block
+    for a in ex.args
+        if isa(a, Expr)
+            parse_expr!(md, a::Expr, file, mod)
+        end
+    end
+    md
+end
+
+"""
+    parse_expr!(md::ModDict, ex::Expr, file::Symbol, mod::Module)
+
+Recursively parse the expressions in `ex`, iterating over blocks and
+sub-module definitions. Successfully parsed
+expressions are added to `md` with key `mod`, and any sub-modules will
+be stored in `md` using appropriate new keys. This accomplishes two main
+tasks:
+
+* add parsed expressions to the source-code cache (so that later we can detect changes)
+* determine the module into which each parsed expression is `eval`uated into
+"""
+function parse_expr!(md::ModDict, ex::Expr, file::Symbol, mod::Module)
+    if ex.head == :block
+        for a in ex.args
+            parse_expr!(md, a, file, mod)
+        end
+        return md
+    end
+    macroreplace!(ex, String(file))
+    if ex.head == :line
+        return md
+    elseif ex.head == :module
+        parse_module!(md, ex, file, mod)
+    elseif isdocexpr(ex) && isa(ex.args[nargs_docexpr], Expr) && ex.args[nargs_docexpr].head == :module
+        # Module with a docstring (issue #8)
+        # Split into two expressions, a module definition followed by
+        # `"docstring" newmodule`
+        newmod = parse_module!(md, ex.args[nargs_docexpr], file, mod)
+        ex.args[nargs_docexpr] = Symbol(newmod)
+        push!(md[mod], convert(RelocatableExpr, ex))
+    elseif ex.head == :call && ex.args[1] == :include
+        # skip include statements
+    else
+        # Any expression that *doesn't* define line numbers, new
+        # modules, or include new files must be "real code." Add it to
+        # the cache.
+        push!(md[mod], convert(RelocatableExpr, ex))
+    end
+    md
+end
+
+const nargs_docexpr = VERSION < v"0.7.0-DEV.328" ? 3 : 4
+isdocexpr(ex) = ex.head == :macrocall && ex.args[1] == GlobalRef(Core, Symbol("@doc")) &&
+           length(ex.args) >= nargs_docexpr
+
+
+"""
+    newmod = parse_module!(md::ModDict, ex::Expr, file, mod::Module)
+
+Parse an expression `ex` that defines a new module `newmod`. This
+module is "parented" by `mod`. Source-code expressions are added to
+`md` under the appropriate module name.
+"""
+function parse_module!(md::ModDict, ex::Expr, file::Symbol, mod::Module)
+    newname = _module_name(ex)
+    if mod != Base.__toplevel__ && !isdefined(mod, newname)
+        eval(mod, ex) # support creating new submodules
+    end
+    newmod = mod == Base.__toplevel__ ? Base.root_module(newname) : getfield(mod, Symbol(newname))
+    md[newmod] = OrderedSet{RelocatableExpr}()
+    parse_source!(md, ex.args[3], file, newmod)  # recurse into the body of the module
+    newmod
+end
+
+_module_name(ex::Expr) = ex.args[2]

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -11,10 +11,9 @@ If parsing `file` fails, `nothing` is returned.
 function parse_source(file::AbstractString, mod::Module)
     # Create a blank ModDict to store the expressions. Parsing will "fill" this.
     md = ModDict(mod=>OrderedSet{RelocatableExpr}())
-    nfile = normpath(file)
     parse_source!(md, file, mod) || return nothing
     fm = FileModules(mod, md)
-    nfile => fm
+    String(file) => fm
 end
 
 """

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -53,9 +53,9 @@ function parse_source!(md::ModDict, src::AbstractString, file::Symbol, pos::Inte
     while pos < endof(src)
         try
             oldpos = pos
-            ex, pos = parse(src, pos; greedy=true)
+            ex, pos = Meta.parse(src, pos; greedy=true)
         catch err
-            ex, posfail = parse(src, pos; greedy=true, raise=false)
+            ex, posfail = Meta.parse(src, pos; greedy=true, raise=false)
             warn(STDERR, "omitting ", file, " due to parsing error near line ",
                  line_offset + count(c->c=='\n', SubString(src, oldpos, posfail)) + 1)
             showerror(STDERR, err)

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -1,0 +1,114 @@
+# We will need to detect new function bodies, compare function bodies
+# to see if they've changed, etc.  This has to be done "blind" to the
+# line numbers at which the functions are defined.
+#
+# Now, we could just discard line numbers from expressions, but that
+# would have a very negative effect on the quality of backtraces. So
+# we keep them, but introduce machinery to compare expressions without
+# concern for line numbers.
+#
+# To reduce the performance overhead of this package, we try to
+# achieve this goal with minimal copying of data.
+
+"""
+A `RelocatableExpr` is exactly like an `Expr` except that comparisons
+between `RelocatableExpr`s ignore line numbering information.
+"""
+mutable struct RelocatableExpr
+    head::Symbol
+    args::Vector{Any}
+    typ::Any
+
+    RelocatableExpr(head::Symbol, args::Vector{Any}) = new(head, args)
+    RelocatableExpr(head::Symbol, args...) = new(head, [args...])
+end
+
+# Works in-place and hence is unsafe. Only for internal use.
+Base.convert(::Type{RelocatableExpr}, ex::Expr) = relocatable!(ex)
+
+function relocatable!(ex::Expr)
+    rex = RelocatableExpr(ex.head, relocatable!(ex.args))
+    rex.typ = ex.typ
+    rex
+end
+
+function relocatable!(args::Vector{Any})
+    for (i, a) in enumerate(args)
+        if isa(a, Expr)
+            args[i] = relocatable!(a::Expr)
+        end   # do we need to worry about QuoteNodes?
+    end
+    args
+end
+
+function Base.convert(::Type{Expr}, rex::RelocatableExpr)
+    # This makes a copy. Used for `eval`, where we don't want to
+    # mutate the cached represetation.
+    ex = Expr(rex.head)
+    ex.args = Base.copy_exprargs(rex.args)
+    ex.typ = rex.typ
+    ex
+end
+Base.copy_exprs(rex::RelocatableExpr) = convert(Expr, rex)
+
+# Implement the required comparison functions. `hash` is needed for Dicts.
+function Base.:(==)(a::RelocatableExpr, b::RelocatableExpr)
+    a.head == b.head && isequal(LineSkippingIterator(a.args), LineSkippingIterator(b.args))
+end
+
+const hashrex_seed = UInt == UInt64 ? 0x7c4568b6e99c82d9 : 0xb9c82fd8
+Base.hash(x::RelocatableExpr, h::UInt) = hash(LineSkippingIterator(x.args),
+                                              hash(x.head, h + hashrex_seed))
+
+# We could just collect all the non-line statements to a Vector, but
+# doing things in-place will be more efficient.
+
+struct LineSkippingIterator
+    args::Vector{Any}
+end
+
+Base.start(iter::LineSkippingIterator) = skip_to_nonline(iter.args, 1)
+Base.done(iter::LineSkippingIterator, i) = i > length(iter.args)
+Base.next(iter::LineSkippingIterator, i) = (iter.args[i], skip_to_nonline(iter.args, i+1))
+
+function skip_to_nonline(args, i)
+    while true
+        i > length(args) && return i
+        ex = args[i]
+        if isa(ex, RelocatableExpr) && (ex::RelocatableExpr).head == :line
+            i += 1
+        elseif isa(ex, LineNumberNode)
+            i += 1
+        else
+            return i
+        end
+    end
+end
+
+function Base.isequal(itera::LineSkippingIterator, iterb::LineSkippingIterator)
+    # We could use `zip` here except that we want to insist that the
+    # iterators also have the same length.
+    ia, ib = start(itera), start(iterb)
+    while !done(itera, ia) && !done(iterb, ib)
+        vala, ia = next(itera, ia)
+        valb, ib = next(iterb, ib)
+        if isa(vala, RelocatableExpr) && isa(valb, RelocatableExpr)
+            vala = vala::RelocatableExpr
+            valb = valb::RelocatableExpr
+            vala.head == valb.head || return false
+            isequal(LineSkippingIterator(vala.args), LineSkippingIterator(valb.args)) || return false
+        else
+            isequal(vala, valb) || return false
+        end
+    end
+    done(itera, ia) && done(iterb, ib)
+end
+
+const hashlsi_seed = UInt == UInt64 ? 0x533cb920dedccdae : 0x2667c89b
+function Base.hash(iter::LineSkippingIterator, h::UInt)
+    h += hashlsi_seed
+    for x in iter
+        h += hash(x, h)
+    end
+    h
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,0 +1,59 @@
+# Some platforms (OSX) have trouble watching too many files. So we
+# watch parent directories, and keep track of which files in them
+# should be tracked.
+mutable struct WatchList
+    timestamp::Float64         # unix time of last revision
+    trackedfiles::Set{String}
+end
+
+"""
+A `ModDict` is a `Dict{Module,Set{RelocatableExpr}}`. It is used to
+organize expressions according to their module of definition. We use a
+Set so that it is easy to find the differences between two `ModDict`s.
+
+See also [`FileModules`](@ref).
+"""
+const ModDict = Dict{Module,OrderedSet{RelocatableExpr}}
+
+"""
+    FileModules(topmod::Module, md::ModDict)
+
+Structure to hold the per-module expressions found when parsing a
+single file.  `topmod` is the current module when the file is
+parsed. `md` holds the evaluatable statements, organized by the module
+of their occurance. In particular, if the file defines one or
+more new modules, then `md` contains key/value pairs for each
+module. If the file does not define any new modules, `topmod` is
+the only key in `md`.
+
+# Example:
+
+Suppose MyPkg.jl has a file that looks like this:
+
+```julia
+__precompile__(true)
+
+module MyPkg
+
+foo(x) = x^2
+
+end
+```
+
+Then if this module is loaded from `Main`, schematically the
+corresponding `fm::FileModules` looks something like
+
+```julia
+fm.topmod = Main
+fm.md = Dict(Main=>OrderedSet([:(__precompile__(true))]),
+             Main.MyPkg=>OrderedSet[:(foo(x) = x^2)])
+```
+because the precompile statement occurs in `Main`, and the definition of
+`foo` occurs in `Main.MyPkg`.
+
+To create a `FileModules` from a source file, see [`parse_source`](@ref).
+"""
+struct FileModules
+    topmod::Module
+    md::ModDict
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -56,4 +56,6 @@ To create a `FileModules` from a source file, see [`parse_source`](@ref).
 struct FileModules
     topmod::Module
     md::ModDict
+    cachefile::String
 end
+FileModules(topmod::Module, md::ModDict) = FileModules(topmod, md, "")

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,1 @@
 Example
-Compat 0.30

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,8 +286,6 @@ end
         end
         @test li_f() == 1  # unless the include is at toplevel it is not found
 
-        @test isfile(Revise.sysimg_path)
-
         pop!(LOAD_PATH)
     end
 
@@ -569,9 +567,8 @@ revise_f(x) = 2
         cd(curdir)
 
         # Tracking Base
-        # FIXME
-        # Revise.track(Base)
-        # @test any(k->endswith(k, "number.jl"), keys(Revise.file2modules))
+        Revise.track(Base)
+        @test any(k->endswith(k, "number.jl"), keys(Revise.file2modules))
     end
 
     @testset "Cleanup" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using Revise
 using Test
 using DataStructures: OrderedSet
-using Compat
 
 to_remove = String[]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Revise
-using Base.Test
+using Test
 using DataStructures: OrderedSet
 using Compat
 
@@ -15,7 +15,7 @@ to_remove = String[]
         exs
     end
 
-    @static if is_apple()
+    @static if Sys.isapple()
         yry() = (sleep(1.1); revise(); sleep(1.1))
     else
         yry() = (sleep(0.1); revise(); sleep(0.1))
@@ -46,7 +46,7 @@ g(x) = 2
 h{x) = 3  # error
 k(x) = 4
 """,
-                                            :test, 1, Main, tempdir())
+                                            :test, 1, Main)
                 @test convert(Revise.RelocatableExpr, :(g(x) = 2)) ∈ md[Main]
             end
         end
@@ -62,8 +62,8 @@ k(x) = 4
         # test the "mistakes"
         @test ReviseTest.cube(2) == 16
         @test ReviseTest.Internal.mult3(2) == 8
-        oldmd = Revise.parse_source(fl1, Main, dirname(fl1))
-        newmd = Revise.parse_source(fl2, Main, nothing)
+        oldmd = Revise.parse_source(fl1, Main).second
+        newmd = Revise.parse_source(fl2, Main).second
         revmd = Revise.revised_statements(newmd, oldmd)
         @test length(revmd) == 2
         @test haskey(revmd, ReviseTest) && haskey(revmd, ReviseTest.Internal)
@@ -84,7 +84,7 @@ k(x) = 4
         @test ReviseTest.Internal.mult3(2) == 6
 
         # Backtraces
-        newmd = Revise.parse_source(fl3, Main, nothing)
+        newmd = Revise.parse_source(fl3, Main).second
         revmd = Revise.revised_statements(newmd, oldmd)
         Revise.eval_revised(revmd)
         try
@@ -569,8 +569,9 @@ revise_f(x) = 2
         cd(curdir)
 
         # Tracking Base
-        Revise.track(Base)
-        @test any(k->endswith(k, "number.jl"), keys(Revise.file2modules))
+        # FIXME
+        # Revise.track(Base)
+        # @test any(k->endswith(k, "number.jl"), keys(Revise.file2modules))
     end
 
     @testset "Cleanup" begin
@@ -586,7 +587,7 @@ revise_f(x) = 2
                 yry()
             end
         end
-        if !is_apple()
+        if !Sys.isapple()
             @test contains(read(warnfile, String), "is not an existing directory")
         end
         rm(warnfile)


### PR DESCRIPTION
This is based on ~~the not-yet-merged~~ https://github.com/JuliaLang/julia/pull/23898. Locally it passes all tests ~~until it gets to the `Revise.track` tests, because there I haven't expunged the dependence on parsing. I'm posting this now because there seems to be room to discuss how this should work:~~

- ~~`Revise.track(Base)`: perhaps the best approach here would be for `base/sysimg.jl` to keep track of the files it includes, and Revise could just look that information up.~~
- ~~More interesting is `Revise.track(filename)`, which I'm thinking of in the context of "scripts" for test or analysis code. Currently we recursively track any file `included` by that file, based on parsing. If we wanted to replicate that, note that the new `Revise.included_files` list includes the entire set, once `filename` has been included once. The trouble is that if the user has included several files, there doesn't seem to be a great way to know which files got recursively included by which operation. One approach would be to temporarily empty the list and re-include `filename`, but that has some obvious downsides. Overall, here I favor restricting it to be literal, and require users to list each file they want to track.~~

Once merged this will fix #40.