### PR TITLE
Fix `invokelatest` bottleneck by using scheduling

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -544,6 +544,13 @@ function watch_files_via_dir(dirname)
 end
 
 function watch_package(modsym::Symbol)
+    # Because the callbacks are made with `invokelatest`, for reasons of performance
+    # we need to make sure this function is fast to compile. By hiding the real
+    # work behind a @schedule, we truncate the chain of dependency.
+    @schedule _watch_package(modsym)
+end
+
+function _watch_package(modsym::Symbol)
     if modsym ∈ dont_watch_pkgs
         if modsym ∉ silence_pkgs
             warn("$modsym is excluded from watching by Revise. Use Revise.silence(\"$modsym\") to quiet this warning.")


### PR DESCRIPTION
One of the biggest negatives of Revise is that it slows package loading. It turns out that the majority of the bottleneck comes from having the callbacks be made with `invokelatest`: if you change [this line](https://github.com/JuliaLang/julia/blob/6dfaea5c22b24b07254903d1c2c71742d4a04843/base/loading.jl#L333) to `callback(mod)` it dramatically cuts the load time. Unfortunately, with that change, I find that I can't `push!` a callback to `Base.package_callbacks` from within the module's `__init__` method due to world age problems.

Fortunately, the simple trick in this PR basically fixes the problem.

Demo, starting with `julia --startup-file=no` so I avoid loading Revise by default (using Julia 0.6, it's *much* worse on 0.7, 4s vs 13s):

### Revise master

```julia
julia> using Revise

julia> using Example  # to make sure loading and Revise code is JITted

julia> tstart = time(); using ImageCore, ImageFiltering; yield(); time()-tstart
4.3374011516571045
```

### Without using Revise

```julia
julia> using Example

julia> tstart = time(); using ImageCore, ImageFiltering; yield(); time()-tstart
1.8541569709777832
```

### With this branch

```julia
julia> using Revise

julia> using Example

julia> tstart = time(); using ImageCore, ImageFiltering; yield(); time()-tstart
2.0255730152130127
```

CC @vchuravy (in case this trick might help Requires.jl). @vtjnash, could we change those to plain `invoke` if the module `__init__` could use `@schedule_for_next_worldage_update push!(Base.package_callbacks, mycallback)`?