### PR TITLE
Now `using Dates`

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -5,7 +5,7 @@ module Revise
 VERSION >= v"0.7.0-DEV.2359" && using FileWatching
 
 using DataStructures: OrderedSet
-using FileWatching
+using FileWatching, Dates
 
 export revise
 


### PR DESCRIPTION
Otherwise I got an error in pre-compilation on 0.7:
```
WARNING: Base.Dates is deprecated, run `using Dates` instead.
  likely near no file:0                                
WARNING: importing deprecated binding Base.now into Revise.
WARNING: Base.Dates is deprecated, run `using Dates` instead.       
  likely near no file:0          
WARNING: Base.Dates is deprecated, run `using Dates` instead.                          
  likely near no file:0                                                                         
in Type at /home/mauro/.julia/v0.7/Revise/src/Revise.jl                                                                   
                                                                         
ERROR (unhandled task failure): type Void has no field datetime2unix                                 
Stacktrace:                            
 [1] Revise.WatchList() at /home/mauro/.julia/v0.7/Revise/src/Revise.jl:488
 [2] process_parsed_files(::Array{String,1}) at /home/mauro/.julia/v0.7/Revise/src/Revise.jl:231
 [3] _watch_package(::Symbol) at /home/mauro/.julia/v0.7/Revise/src/Revise.jl:224
 [4] (::getfield(Revise, Symbol("##5#6")){Symbol})() at ./event.jl:95                            
```

Is this also a bug in the deprecation of `Dates`?  Also, presumably with `Dates` being in the std-lib, it does not require an entry in REQUIRE.
