### PR TITLE
Fix some deprecations

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -6,6 +6,7 @@ VERSION >= v"0.7.0-DEV.2359" && using FileWatching
 VERSION >= v"0.7.0-DEV.2575" && using Dates
 using Compat
 using Compat.REPL
+using Compat: @warn
 
 if VERSION < v"0.7.0-DEV.3483"
     register_root_module(m::Module) = Base.register_root_module(Base.module_name(m), m)
@@ -113,7 +114,7 @@ function eval_revised(revmd::ModDict)
                     eval(mod, ex)
                 end
             catch err
-                warn("failure to evaluate changes in ", mod)
+                @warn "failure to evaluate changes in $mod"
                 println(STDERR, ex)
             end
         end
@@ -147,7 +148,7 @@ function revise_dir_queued(dirname)
     if !isdir(dirname)
         sleep(0.1)   # in case git has done a delete/replace cycle
         if !isfile(dirname)
-            warn(dirname, " is not an existing directory, Revise is not watching")
+            @warn "$dirname is not an existing directory, Revise is not watching"
             return nothing
         end
     end
@@ -169,7 +170,7 @@ function revise_file_now(file)
         src = read_from_cache(oldmd, file)
         push!(oldmd.md, oldmd.topmod=>OrderedSet{RelocatableExpr}())
         if !parse_source!(oldmd.md, src, Symbol(file), 1, oldmd.topmod)
-            warn("failed to parse cache file source text for ", file)
+            @warn "failed to parse cache file source text for $file"
         end
     end
     pr = parse_source(file, oldmd.topmod)
@@ -180,7 +181,7 @@ function revise_file_now(file)
             eval_revised(revmd)
             file2modules[file] = newmd
         catch err
-            warn("evaluation error during revision: ", err)
+            @warn "evaluation error during revision: $err"
             Base.show_backtrace(STDERR, catch_backtrace())
         end
     end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -27,7 +27,7 @@ See also [`parse_source`](@ref).
 """
 function parse_source!(md::ModDict, file::AbstractString, mod::Module)
     if !isfile(file)
-        warn("omitting ", file, " from revision tracking")
+        @warn "omitting $file from revision tracking"
         return false
     end
     parse_source!(md, read(file, String), Symbol(file), 1, mod)
@@ -56,8 +56,8 @@ function parse_source!(md::ModDict, src::AbstractString, file::Symbol, pos::Inte
             ex, pos = Meta.parse(src, pos; greedy=true)
         catch err
             ex, posfail = Meta.parse(src, pos; greedy=true, raise=false)
-            warn(STDERR, "omitting ", file, " due to parsing error near line ",
-                 line_offset + count(c->c=='\n', SubString(src, oldpos, posfail)) + 1)
+            lineno = line_offset + count(c->c=='\n', SubString(src, oldpos, posfail)) + 1
+            @warn "omitting $file due to parsing error near line $lineno"
             showerror(STDERR, err)
             println(STDERR)
             return false

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -114,7 +114,7 @@ function _watch_package(id::PkgId)
     modsym = Symbol(id.name)
     if modsym ∈ dont_watch_pkgs
         if modsym ∉ silence_pkgs
-            warn("$modsym is excluded from watching by Revise. Use Revise.silence(\"$modsym\") to quiet this warning.")
+            @warn "$modsym is excluded from watching by Revise. Use Revise.silence(\"$modsym\") to quiet this warning."
         end
         remove_from_included_files(modsym)
         return nothing

--- a/src/pkgs_deprecated.jl
+++ b/src/pkgs_deprecated.jl
@@ -115,7 +115,7 @@ end
 function _watch_package(modsym::Symbol)
     if modsym ∈ dont_watch_pkgs
         if modsym ∉ silence_pkgs
-            warn("$modsym is excluded from watching by Revise. Use Revise.silence(\"$modsym\") to quiet this warning.")
+            @warn "$modsym is excluded from watching by Revise. Use Revise.silence(\"$modsym\") to quiet this warning."
         end
         remove_from_included_files(modsym)
         return nothing


### PR DESCRIPTION
I'll add more commits, but just tackling the `warn` deprecation is giving me some trouble. @c42f, any tips? It's the final testset that's causing trouble, somehow the message are appearing in the console instead of being captured to the file. Note that higher up in `runtests` the same strategy seems to work, so it's weird...