### PR TITLE
Support distributed revision (fixes #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you're using polling, you may have to wait several seconds before changes tak
 
 Revise can handle many kinds of changes to Julia code, but a few may require special treatment:
 
-### Method deletion
+#### Method deletion
 
 Sometimes you might wish to change a method's type signature or number of arguments,
 or remove a method specialized for specific types.
@@ -117,12 +117,17 @@ end
 will not disappear from the method lists until you restart, or manually call
 `Base.delete_method(m::Method)`. You can use `m = @which ...` to obtain a method.
 
-### Macros and generated functions
+#### Macros and generated functions
 
 For changes to macros or to functions that affect the expansion of a `@generated` function,
 you may explicitly call `revise(module)` to force reevaluating every definition in `module`.
 
-### Changes that Revise cannot handle
+#### Distributed computing (multiple workers)
+
+Revise supports changes to code in worker processes. The code must
+be loaded in the main process in which Revise is running, and you must use `@everywhere using Revise`.
+
+#### Changes that Revise cannot handle
 
 Finally, there are some kinds of changes that Revise cannot incorporate into a running Julia session:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Revise
-using Test, Unicode
+using Test, Unicode, Distributed
 using DataStructures: OrderedSet
 
 include("common.jl")
@@ -653,6 +653,56 @@ revise_f(x) = 2
         # Tracking Base
         Revise.track(Base)
         @test any(k->endswith(k, "number.jl"), keys(Revise.file2modules))
+    end
+
+    @testset "Distributed" begin
+        allworkers = [myid(); addprocs(2)]
+        @everywhere using Revise
+        dirname = randtmp()
+        mkdir(dirname)
+        @everywhere push_LOAD_PATH!(dirname) = push!(LOAD_PATH, dirname)
+        for p in allworkers
+            remotecall_wait(push_LOAD_PATH!, p, dirname)
+        end
+        push!(to_remove, dirname)
+        modname = "ReviseDistributed"
+        dn = joinpath(dirname, modname, "src")
+        mkpath(dn)
+        open(joinpath(dn, modname*".jl"), "w") do io
+            println(io, """
+module ReviseDistributed
+
+f() = π
+g(::Int) = 0
+
+end
+""")
+        end
+        sleep(2.1)   # so the defining files are old enough not to trigger mtime criterion
+        using ReviseDistributed
+        @everywhere using ReviseDistributed
+        for p in allworkers
+            @test remotecall_fetch(ReviseDistributed.f, p)    == π
+            @test remotecall_fetch(ReviseDistributed.g, p, 1) == 0
+        end
+        sleep(0.1)
+        open(joinpath(dn, modname*".jl"), "w") do io
+            println(io, """
+module ReviseDistributed
+
+f() = 3.0
+
+end
+""")
+        end
+        yry()
+        sleep(1.0)
+        @test_throws MethodError ReviseDistributed.g(1)
+        for p in allworkers
+            @test remotecall_fetch(ReviseDistributed.f, p)    == 3.0
+            p == myid() && continue
+            @test_throws RemoteException remotecall_fetch(ReviseDistributed.g, p, 1)
+        end
     end
 
     @testset "Cleanup" begin


### PR DESCRIPTION
This is an alternative to #84. This version is both simpler and supports method deletion.