### PR TITLE
Fix Juno integration

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -792,7 +792,8 @@ function __init__()
             @schedule steal_repl_backend()
         elseif isdefined(Main, :IJulia)
             Main.IJulia.push_preexecute_hook(revise)
-        elseif isdefined(Main, :Atom)
+        end
+        if isdefined(Main, :Atom)
             for x in ["eval", "evalall", "evalrepl"]
                 old = Main.Atom.handlers[x]
                 Main.Atom.handle(x) do data


### PR DESCRIPTION
Newer Juno versions use a standard REPL, so `elseif` isn't appropriate here.