### PR TITLE
Tracking Core.Compiler via git reference

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -257,7 +257,9 @@ function read_from_git(path::AbstractString)
         # check if we are at the repo root
         git_dir = joinpath(repo_dir, ".git")
         if ispath(git_dir)
-            return readstring(`git -C $repo_dir show $(Base.GIT_VERSION_INFO.commit):$repo_file`)
+            repo = LibGit2.GitRepo(repo_dir)
+            tree = LibGit2.GitTree(repo, "$(Base.GIT_VERSION_INFO.commit)^{tree}")
+            return LibGit2.content(tree[repo_file])
         end
 
         # traverse to parent folder

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -315,9 +315,12 @@ function track(mod::Module, file::AbstractString; reference::Symbol=:current)
         parse_source(file, mod)
     elseif reference == :git
         src = read_from_git(file)
+        if src != readstring(file)
+            push!(revision_queue, file)
+        end
         md = ModDict(mod=>ExprsSigs())
         if !parse_source!(md, src, Symbol(file), 1, mod)
-            warn("failed to parse cache file source text for ", file)
+            warn("failed to parse Git source text for ", file)
         end
         fm = FileModules(mod, md)
         String(file) => fm

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -250,6 +250,28 @@ function read_from_cache(fm::FileModules, file::AbstractString)
     Base.read_dependency_src(fm.cachefile, file)
 end
 
+function read_from_git(path::AbstractString)
+    repo_file = basename(path)
+    repo_dir = dirname(path)
+    while true
+        # check if we are at the repo root
+        git_dir = joinpath(repo_dir, ".git")
+        if isdir(git_dir)
+            return readstring(`git -C $repo_dir show $(Base.GIT_VERSION_INFO.commit):$repo_file`)
+        end
+
+        # traverse to parent folder
+        previous = repo_dir
+        subdir = basename(repo_dir)
+        repo_dir = dirname(repo_dir)
+        repo_file = joinpath(subdir, repo_file)
+
+        if previous == repo_dir
+            return nothing
+        end
+    end
+end
+
 """
     revise()
 
@@ -284,10 +306,22 @@ Watch `file` for updates and [`revise`](@ref) loaded code with any
 changes. `mod` is the module into which `file` is evaluated; if omitted,
 it defaults to `Main`.
 """
-function track(mod::Module, file::AbstractString)
+function track(mod::Module, file::AbstractString; reference::Symbol=:current)
     isfile(file) || error(file, " is not a file")
     file = normpath(abspath(file))
-    pr = parse_source(file, mod)
+    pr = if reference == :current
+        parse_source(file, mod)
+    elseif reference == :git
+        src = read_from_git(file)
+        md = ModDict(mod=>ExprsSigs())
+        if !parse_source!(md, src, Symbol(file), 1, mod)
+            warn("failed to parse cache file source text for ", file)
+        end
+        fm = FileModules(mod, md)
+        String(file) => fm
+    else
+        error("Invalid tracking reference $reference")
+    end
     if isa(pr, Pair)
         push!(file2modules, pr)
     end

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -256,7 +256,7 @@ function read_from_git(path::AbstractString)
     while true
         # check if we are at the repo root
         git_dir = joinpath(repo_dir, ".git")
-        if isdir(git_dir)
+        if ispath(git_dir)
             return readstring(`git -C $repo_dir show $(Base.GIT_VERSION_INFO.commit):$repo_file`)
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -666,6 +666,10 @@ revise_f(x) = 2
         # Tracking Base
         Revise.track(Base)
         @test any(k->endswith(k, "number.jl"), keys(Revise.file2modules))
+
+        # Tracking Core.Compiler
+        Revise.track(Core.Compiler)
+        @test any(k->endswith(k, "compiler.jl"), keys(Revise.file2modules))
     end
 
     @testset "Distributed" begin


### PR DESCRIPTION
This PR makes it possible to track files based on their git reference contents, by fetching source code with libgit2 using the commit hash baked in the system image. This is an alternative to the Base cache, and should be identical as long as the user is working with a clone from Git (I'm not sure how frequently users are working with Revise without a git clone).

Based on that feature, I've added a recipe for tracking Core.Compiler, which isn't part of the Base source cache.