### PR TITLE
Fix `eval(m, x)` deprecation

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -160,9 +160,9 @@ function eval_revised(revmd::ModDict, delete_methods::Bool=true)
             ex = convert(Expr, rex)
             try
                 if isdocexpr(ex) && mod == Base.__toplevel__
-                    eval(Main, ex)
+                    Core.eval(Main, ex)
                 else
-                    eval(mod, ex)
+                    Core.eval(mod, ex)
                 end
             catch err
                 succeeded = false

--- a/src/delete_method.jl
+++ b/src/delete_method.jl
@@ -40,7 +40,7 @@ end
 
 function split_sig(mod::Module, ex::Expr)
     t = split_sig_expr(mod, ex)
-    return eval(mod, t) # fex), eval(mod, argex)
+    return Core.eval(mod, t) # fex), Core.eval(mod, argex)
 end
 
 function split_sig_expr(mod::Module, ex::Expr, wheres...)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -157,7 +157,7 @@ module is "parented" by `mod`. Source-code expressions are added to
 function parse_module!(md::ModDict, ex::Expr, file::Symbol, mod::Module)
     newname = _module_name(ex)
     if mod != Base.__toplevel__ && !isdefined(mod, newname)
-        eval(mod, ex) # support creating new submodules
+        Core.eval(mod, ex) # support creating new submodules
     end
     newmod = mod == Base.__toplevel__ ? Base.root_module(mod, newname) : getfield(mod, newname)
     md[newmod] = ExprsSigs()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -534,7 +534,7 @@ end
     end
 
     @testset "Method deletion" begin
-        eval(Base, :(revisefoo(x::Float64) = 1)) # to test cross-module method scoping
+        Core.eval(Base, :(revisefoo(x::Float64) = 1)) # to test cross-module method scoping
         testdir = randtmp()
         mkdir(testdir)
         push!(to_remove, testdir)


### PR DESCRIPTION
Fixes 0.7 warning by replacing `eval(m, x)` with `Core.eval(m, x)`.