### PR TITLE
Redesign Revise for bidirectional `expr`<-->`method` capabilities

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7.0-beta2.199
+julia 0.7.0-beta2.202
 OrderedCollections

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -25,7 +25,7 @@ Revise.basesrccache
 Revise.watched_files
 Revise.revision_queue
 Revise.included_files
-Revise.file2modules
+Revise.fileinfos
 Revise.module2files
 ```
 
@@ -33,9 +33,11 @@ Revise.module2files
 
 ```@docs
 Revise.RelocatableExpr
-Revise.ExprsSigs
-Revise.ModDict
+Revise.DefMap
+Revise.SigtMap
+Revise.FMMaps
 Revise.FileModules
+Revise.FileInfo
 Revise.WatchList
 ```
 
@@ -75,7 +77,6 @@ Revise.revise_file_queued
 ```@docs
 Revise.revise_file_now
 Revise.eval_revised
-Revise.revised_statements
 Revise.get_method
 ```
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,7 +1,8 @@
 # How Revise works
 
 Revise is based on the fact that you can change functions even when
-they are defined in other modules. Here's an example showing how you do that manually (without using Revise):
+they are defined in other modules.
+Here's an example showing how you do that manually (without using Revise):
 
 ```julia
 julia> convert(Float64, π)
@@ -49,5 +50,196 @@ To accomplish this, Revise uses the following overall strategy:
   created. `eval` the diff in the appropriate module(s).
 - replace the cached version of each source file with the new version, so that
   further changes are `diff`ed against the most recent update.
+
+## The structure of Revise's internal representation
+
+Revise bridges between text files (your source code) and compiled code.
+Revise consequently maintains data structures that parallel Julia's own internal
+processing of code.
+When dealing with a source-code file, you start with strings, parse them to obtain Julia
+expressions, evaluate them to obtain Julia objects, and (where appropriate,
+e.g., for methods) compile them to machine code.
+This will be called the *forward workflow*.
+Revise sets up a few key structures that allow it to progress from files to modules
+to Julia expressions and types.
+
+Revise also sets up a *backward workflow*, proceeding from compiled code to Julia
+types back to Julia expressions.
+This workflow is useful, for example, when dealing with errors: the stack traces
+displayed by Julia link from the compiled code back to the source files.
+To make this possible, Julia builds "breadcrumbs" into compiled code that store the
+filename and line number at which each expression was found.
+However, these links are static, meaning they are set up once (when the code is compiled)
+and are not updated when the source file changes.
+Because trivial manipulations to source files (e.g., the insertion of blank lines
+and/or comments) can change the line number of an expression without necessitating
+its recompilation, Revise implements a way of correcting these line numbers before
+they are displayed to the user.
+This capability requires that Revise proceed backward from the compiled objects to
+something resembling the original text file.
+
+### Terminology
+
+A few convenience terms are used throughout: *definition*,
+*signature-expression*, and *signature-type*.
+These terms are illustrated using the following example:
+
+```@raw html
+<p><pre><code class="language-julia">function <mark>print_item(io::IO, item, ntimes::Integer=1, pre::String="")</mark>
+    print(io, pre)
+    for i = 1:ntimes
+        print(io, item)
+    end
+end</code></pre></p>
+```
+
+This represents the *definition* of a method.
+Definitions are stored as expressions, using a [`Revise.RelocatableExpr`](@ref).
+The highlighted portion is the *signature-expression*, specifying the name, argument names
+and their types, and (if applicable) type-parameters of the method.
+
+From the signature-expression we can generate one or more *signature-types*.
+Since this function has two default arguments, this signature-expression generates
+three signature-types, each corresponding to a different valid way of calling
+this method:
+
+```julia
+Tuple{typeof(print_item),IO,Any}                    # print_item(io, item)
+Tuple{typeof(print_item),IO,Any,Integer}            # print_item(io, item, 2)
+Tuple{typeof(print_item),IO,Any,Integer,String}     # print_item(io, item, 2, "  ")
+```
+
+In Revise's internal code, a definition is often represented with a variable `def`,
+a signature-expression with `sigex`, and a signature-type with `sigt`.
+
+### Core data structures and representations
+
+Two "maps" are central to Revise's inner workings: the `DefMap` links
+definition=>signature-types (the forward workflow), while the `SigtMap` links from
+signature-type=>definition (the backward workflow).
+Concretely, `SigtMap` is just a `Dict` mapping `sigt=>def`.
+Of note, a stack frame typically contains a link to a method, which stores the equivalent
+of `sigt`; consequently, this information allows one to look up the corresponding `def`.
+
+The `DefMap` is a bit more complex and has important constraints:
+
+- For expressions that do not define a method, it is just `def=>nothing`
+- For expressions that do define a method, it is `def=>([sigt1, ...], lineoffset)`.
+  `[sigt1, ...]` is the list of signature-types generated from `def` (often just one,
+  but more in the case of methods with default arguments).
+  `lineoffset` is the correction to be added to the currently-compiled code's internal
+  line numbers needed to make them match the current state of the source file.
+- `DefMap` is represented as an `OrderedDict` so as to preserve the sequence in which expressions
+  occur in the file.
+  This can be important particularly for updating macro definitions, which affect the
+  expansion of later code.
+  The order is maintained so as to match the current ordering of the source-file,
+  which is not necessarily the same as the ordering when these expressions were last
+  `eval`ed.
+- Each key in the `DefMap` (the definition `RelocatableExpr`) is the most recently
+  `eval`ed version of the expression.
+  This has an important consequence: the line numbers in the `def` (which are still present,
+  even though not used for equality comparisons) correspond to the ones in compiled code.
+  If the file is parsed again, comparing the line numbers embedded in two "equal" `def`
+  exprs (the original and the new one) allows us to accurately determine the current value
+  of `lineoffset`.
+
+Importantly, modules can be "reconstructed" from the keys of `DefMap` (or collection of
+`DefMaps`, if the module involves multiple files or has sub-modules), since they hold
+the complete ordered set of expressions that would be `eval`ed to define the module.
+
+The `DefMap` and `SigtMap` are grouped in a [`Revise.FMMaps`](@ref), which are then
+organized by the file in which they occur and their module
+of evaluation.
+
+### An example
+
+Consider a module, `Items`, defined by the following two source files:
+
+`Items.jl`:
+
+```julia
+__precompile__(false)
+
+module Items
+
+include("indents.jl")
+
+function print_item(io::IO, item, ntimes::Integer=1, pre::String=indent(item))
+    print(io, pre)
+    for i = 1:ntimes
+        print(io, item)
+    end
+end
+
+end
+```
+
+`indents.jl`:
+
+```julia
+indent(::UInt16) = 2
+indent(::UInt8)  = 4
+```
+
+`indents.jl` is particularly simple: Revise represents it as `"indents.jl"=>Dict(Items=>fmm1)`,
+specifying the filename, module(s) into which its code is `eval`ed, and corresponding `FMMaps`.
+Because `indents.jl` only contains code from a single module (`Items`), the `Dict` has just
+one entry.
+`fmm1` looks like this:
+
+```julia
+fmm1 = FMMaps(DefMap(:(indent(::UInt16) = 2) => ([Tuple{typeof(indent),UInt16}], 0),
+                     :(indent(::UInt8) = 4)  => ([Tuple{typeof(indent),UInt8}], 0)
+                     ),
+              SigtMap(Tuple{typeof(indent),UInt16} => :(indent(::UInt16) = 2),
+                      Tuple{typeof(indent),UInt8}  => :(indent(::UInt8) = 4)
+                      ))
+```
+The `lineoffset`s are initially set to 0 when the code is first compiled, but these
+may be updated if the source file is changed.
+
+`Items.jl` is represented with a bit more complexity,
+`"Items.jl"=>Dict(Main=>fmm2, Main.Items=>fmm3)`.
+This is because `Items.jl` contains one expression (the `__precompile__` statement)
+that is `eval`ed in `Main`,
+and other expressions that are `eval`ed in `Items`.
+Concretely,
+
+```julia
+fmm2 = FMMaps(DefMap(:(__precompile__(false)) => nothing),
+              SigtMap())
+fmm3 = FMMaps(DefMap(:(include("indents.jl")) => nothing,
+                     def => ([Tuple{typeof(print_item),IO,Any},
+                              Tuple{typeof(print_item),IO,Any,Integer},
+                              Tuple{typeof(print_item),IO,Any,Integer,String}], 0)),
+              SigtMap(Tuple{typeof(print_item),IO,Any} => def,
+                      Tuple{typeof(print_item),IO,Any,Integer} => def,
+                      Tuple{typeof(print_item),IO,Any,Integer,String} => def))
+```
+
+where here `def` is the expression defining `print_item`.
+
+### Revisions and computing diffs
+
+When the file system notifies Revise that a file has been modified, Revise re-parses
+the file and assigns the expressions to the appropriate modules, creating a
+[`Revise.FileModules`](@ref) `fmnew`.
+It then compares `fmnew` against `fmref`, the reference object that is synchronized to
+code as it was `eval`ed.
+The following actions are taken:
+
+- if a `def` entry in `fmref` is equal to one `fmnew`, the expression is "unchanged"
+  except possibly for line number. The `lineoffset` in `fmref` is updated as needed.
+- if a `def` entry in `fmref` is not present in `fmnew`, that entry is deleted and
+  any corresponding methods are also deleted.
+- if a `def` entry in `fmnew` is not present in `fmref`, it is `eval`ed and then added to
+  `fmref`.
+
+Technically, a new `fmref` is generated every time to ensure that the expressions are
+ordered as in `fmnew`; however, conceptually this is better thought of as an updating of
+`fmref`, after which `fmnew` is discarded.
+
+### Internal API
 
 You can find more detail about Revise's inner workings in the [Developer reference](@ref).

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -26,8 +26,8 @@ doing it manually.
 Importantly, changes are detected in a manner that is independent of the specific
 line numbers in your code, so that you don't have to re-evaluate just
 because code moves around within the same file.
-(However, one unfortunate side effect is that
-[line numbers may become inaccurate in backtraces](https://github.com/timholy/Revise.jl/issues/51).)
+(One unfortunate side effect is that line numbers may become inaccurate in backtraces,
+but Revise takes pains to correct these, see below.)
 
 To accomplish this, Revise uses the following overall strategy:
 

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -3,7 +3,7 @@ module Revise
 using FileWatching, REPL, Base.CoreLogging, Distributed
 import LibGit2
 
-using OrderedCollections: OrderedSet
+using OrderedCollections: OrderedDict
 
 export revise
 
@@ -73,19 +73,19 @@ This list gets populated by callbacks that watch directories for updates.
 const revision_queue = Set{String}()
 
 """
-    Revise.file2modules
+    Revise.fileinfos
 
-Global variable, `file2modules` is the core information that allows re-evaluation of code in
-the proper module scope.
+`fileinfos` is the core information that tracks the relationship between source code
+and julia objects, and allows re-evaluation of code in the proper module scope.
 It is a dictionary indexed by absolute paths of files;
-`file2modules[filename]` returns a value of type [`Revise.FileModules`](@ref).
+`fileinfos[filename]` returns a value of type [`Revise.FileInfo`](@ref).
 """
-const file2modules = Dict{String,FileModules}()
+const fileinfos = Dict{String,FileInfo}()
 
 """
     Revise.module2files
 
-Global variable, `module2files` holds the list of filenames used to define a particular
+`module2files` holds the list of filenames used to define a particular
 module. This is only used by `revise(MyModule)` to "refresh" all the definitions in a module.
 """
 const module2files = Dict{Symbol,Vector{String}}()
@@ -132,108 +132,115 @@ const silence_pkgs = Set{Symbol}()
 const depsdir = joinpath(dirname(@__DIR__), "deps")
 const silencefile = Ref(joinpath(depsdir, "silence.txt"))  # Ref so that tests don't clobber
 
-"""
-    revmod = revised_statements(new_defs, old_defs)
-
-Return a `Dict(Module=>changeset)`, `revmod`, listing the changes that
-should be [`eval_revised`](@ref) for each module to update definitions from `old_defs` to
-`new_defs`.  See [`parse_source`](@ref) to obtain the `defs` structures.
-"""
-function revised_statements(newfm::FileModules, oldfm::FileModules)
-    @assert newfm.topmod == oldfm.topmod
-    revised_statements(newfm.md, oldfm.md)
-end
-
-function revised_statements(newmd::ModDict, oldmd::ModDict)
-    revmd = ModDict()
-    for (mod, newdefs) in newmd
-        if haskey(oldmd, mod) # in case of new submodules, see #43
-            revised_statements!(revmd, mod, newdefs, oldmd[mod])
-        end
-    end
-    revmd
-end
-
-revised_statements(mod::Module, newdefs::ExprsSigs, olddefs::ExprsSigs) =
-    revised_statements!(ModDict(), mod, newdefs, olddefs)
-
-function revised_statements!(revmd::ModDict, mod::Module,
-                             newdefs::ExprsSigs, olddefs::ExprsSigs)
-    # Detect new or revised expressions
-    for stmt in newdefs.exprs
-        if isa(stmt, RelocatableExpr)
-            stmt = stmt::RelocatableExpr
-            @assert stmt.head != :module
-            if stmt ∉ olddefs.exprs
-                if !haskey(revmd, mod)
-                    revmd[mod] = ExprsSigs()
-                end
-                push!(revmd[mod].exprs, stmt)
-            end
-        end
-    end
-    # Detect method deletions
-    for sig in olddefs.sigs
-        if sig ∉ newdefs.sigs
-            if !haskey(revmd, mod)
-                revmd[mod] = ExprsSigs()
-            end
-            push!(revmd[mod].sigs, sig)
-        end
-    end
-    revmd
-end
-
-"""
-    succeeded = eval_revised(revmd::ModDict, delete_methods=true)
-
-Evaluate the changes listed in `revmd`, which consists of deleting all
-the listed signatures in each `.sigs` field(s) (unless `delete_methods=false`)
-and evaluating expressions in the `.exprs` field(s).
-
-Returns `true` if all revisions in `revmd` were successfully implemented.
-"""
-function eval_revised(revmd::ModDict, delete_methods::Bool=true)
-    succeeded = true
-    for (mod, exprssigs) in revmd
-        # mod = mod == Base.__toplevel__ ? Main : mod
-        if delete_methods
-            for sig in exprssigs.sigs
-                try
-                    sigexs = sig_type_exprs(sig)
-                    for sig1 in sigexs  # default-arg functions generate multiple methods
-                        m = get_method(mod, sig1)
-                        isa(m, Method) && Base.delete_method(m)
-                    end
-                catch err
-                    succeeded = false
-                    @error "failure to delete signature $sig in module $mod"
-                    showerror(stderr, err)
-                end
-            end
-        end
-        for rex in exprssigs.exprs
-            ex = convert(Expr, rex)
-            try
-                if isdocexpr(ex) && mod == Base.__toplevel__
-                    Core.eval(Main, ex)
-                else
-                    Core.eval(mod, ex)
-                end
-            catch err
-                succeeded = false
-                @error "failure to evaluate changes in $mod"
-                showerror(stderr, err)
-                println(stderr, "\n", ex)
-            end
-        end
-    end
-    succeeded
-end
-
 function use_compiled_modules()
     return Base.JLOptions().use_compiled_modules != 0
 end
+
+
+
+"""
+    fmrep = eval_revised(fmnew::FileModules, fmref::FileModules)
+
+Implement the changes from `fmref` to `fmnew`, returning a replacement [`FileModules`](@ref)
+`fmrep`.
+"""
+function eval_revised(fmnew::FileModules, fmref::FileModules)
+    fmrep = FileModules(first(keys(fmref)))  # replacement for fmref
+    for (mod, fmmnew) in fmnew
+        fmrep[mod] = fmm = FMMaps()
+        if haskey(fmref, mod)
+            eval_revised!(fmm, mod, fmmnew, fmref[mod])
+            for p in workers()
+                p == myid() && continue
+                remotecall(eval_revised_dummy!, p, mod, fmmnew, fmref[mod])
+            end
+        else  # a new submodule (see #43)
+            eval_and_insert_all!(fmm, mod, fmmnew.defmap)
+            for p in workers()
+                p == myid() && continue
+                remotecall(eval_and_insert_all_dummy!, p, mod, fmmnew.defmap)
+            end
+        end
+    end
+    fmrep
+end
+
+function eval_revised!(fmmrep::FMMaps, mod::Module,
+                       fmmnew::FMMaps, fmmref::FMMaps)
+    # Update to the state of fmmnew, preventing any unnecessary evaluation
+    for (def,val) in fmmnew.defmap
+        @assert def != nothing
+        defref = getkey(fmmref.defmap, def, nothing)
+        if defref != nothing
+            # The same expression is found in both, only update the lineoffset
+            if val !== nothing
+                sigtref = fmmref.defmap[defref][1]
+                lnref = firstlineno(defref)
+                lnnew = firstlineno(def)
+                lineoffset = (isa(lnref, Integer) && isa(lnnew, Integer)) ? lnnew-lnref : 0
+                fmmrep.defmap[defref] = (sigtref, lineoffset)
+                for sigt in sigtref
+                    fmmrep.sigtmap[sigt] = defref
+                end
+            else
+                fmmrep.defmap[defref] = nothing
+            end
+        else
+            eval_and_insert!(fmmrep, mod, def=>val)
+        end
+    end
+    # Delete any methods missing in fmmnew
+    for (sigt,_) in fmmref.sigtmap
+        if !haskey(fmmrep.sigtmap, sigt)
+            m = get_method(mod, sigt)
+            if isa(m, Method)
+                Base.delete_method(m)
+            else
+                @warn "no method found for signature $sigt"
+            end
+        end
+    end
+    return fmmrep
+end
+
+eval_revised_dummy!(mod::Module, fmmnew::FMMaps, fmmref::FMMaps) =
+    eval_revised!(FMMaps(), mod, fmmnew, fmmref)
+
+function eval_and_insert!(fmm::FMMaps, mod::Module, pr::Pair)
+    def, val = pr.first, pr.second
+    ex = convert(Expr, def)
+    try
+        if isdocexpr(ex) && mod == Base.__toplevel__
+            Core.eval(Main, ex)
+        else
+            Core.eval(mod, ex)
+        end
+        if val isa RelocatableExpr
+            instantiate_sigs!(fmm, def, val, mod)
+        else
+            fmm.defmap[def] = val
+            if val !== nothing
+                for sigt in val[1]
+                    fmm.sigtmap[sigt] = def
+                end
+            end
+        end
+    catch err
+        @error "failure to evaluate changes in $mod"
+        showerror(stderr, err)
+        println_maxlines(stderr, "\n", ex; maxlines=20)
+    end
+    return fmm
+end
+
+function eval_and_insert_all!(fmm::FMMaps, mod::Module, defmap::DefMap)
+    for pr in defmap
+        eval_and_insert!(fmm, mod, pr)
+    end
+end
+
+eval_and_insert_all_dummy!(mod::Module, defmap::DefMap) =
+    eval_and_insert_all!(FMMaps(), mod, defmap)
 
 """
     Revise.init_watching(files)
@@ -317,47 +324,66 @@ Process revisions to `file`. This parses `file` and computes an expression-level
 between the current state of the file and its most recently evaluated state.
 It then deletes any removed methods and re-evaluates any changed expressions.
 
-`file` must be a key in [`Revise.file2modules`](@ref)
+`file` must be a key in [`Revise.fileinfos`](@ref)
 """
 function revise_file_now(file)
-    if !haskey(file2modules, file)
-        println("Revise is currently tracking the following files: ", keys(file2modules))
+    if !haskey(fileinfos, file)
+        println("Revise is currently tracking the following files: ", keys(fileinfos))
         error(file, " is not currently being tracked.")
     end
-    fm = file2modules[file]
-    if isempty(fm)
+    fi = fileinfos[file]
+    topmod = first(keys(fi.fm))
+    if isempty(fi.fm)
         # Source was never parsed, get it from the precompile cache
-        src = read_from_cache(fm, file)
-        if parse_source!(fm.md, src, Symbol(file), 1, fm.topmod) === nothing
+        src = read_from_cache(fi, file)
+        if parse_source!(fi.fm, src, Symbol(file), 1, topmod) === nothing
             @error "failed to parse cache file source text for $file"
         end
+        instantiate_sigs!(fi.fm)
     end
-    newmd = parse_source(file, fm.topmod)
-    if newmd != nothing
-        revmd = revised_statements(newmd, fm.md)   # FIXME update only those being re-evaled
-        if eval_revised(revmd)
-            file2modules[file] = FileModules(fm, newmd)
-            for p in workers()
-                p == myid() && continue
-                try
-                    remotecall(Revise.eval_revised, p, revmd)
-                catch err
-                    @error "error revising worker $p"
-                    showerror(stderr, err)
-                end
-            end
-        end
+    fmref = fi.fm
+    fmnew = parse_source(file, topmod)
+    if fmnew != nothing
+        fmrep = eval_revised(fmnew, fmref)
+        fileinfos[file] = FileInfo(fmrep, fi)
     end
     nothing
 end
 
-function read_from_cache(fm::FileModules, file::AbstractString)
+function read_from_cache(fm::FileInfo, file::AbstractString)
     if fm.cachefile == basesrccache
         return open(basesrccache) do io
             Base._read_dependency_src(io, file)
         end
     end
     Base.read_dependency_src(fm.cachefile, file)
+end
+
+function instantiate_sigs!(fm::FileModules)
+    for (mod, fmm) in fm
+        instantiate_sigs!(fmm, mod)
+    end
+    return fm
+end
+
+function instantiate_sigs!(fmm::FMMaps, mod::Module)
+    for (def, sig) in fmm.defmap
+        if sig isa RelocatableExpr
+            instantiate_sigs!(fmm, def, sig, mod)
+        end
+    end
+    return fmm
+end
+
+function instantiate_sigs!(fmm::FMMaps, def::RelocatableExpr, sig::RelocatableExpr, mod::Module)
+    # Generate the signature-types
+    sigtexs = sig_type_exprs(sig)
+    sigts = Any[Core.eval(mod, s) for s in sigtexs]
+    # Insert into the maps
+    fmm.defmap[def] = (sigts, 0)
+    for sigt in sigts
+        fmm.sigtmap[sigt] = def
+    end
 end
 
 """
@@ -395,11 +421,16 @@ end
 
 Reevaluate every definition in `mod`, whether it was changed or not. This is useful
 to propagate an updated macro definition, or to force recompiling generated functions.
-
-Returns `true` if all revisions in `mod` were successfully implemented.
 """
 function revise(mod::Module)
-    all(map(file -> eval_revised(file2modules[file].md, false), module2files[Symbol(mod)]))
+    for file in module2files[Symbol(mod)]
+        for (mod,fmm) in fileinfos[file].fm
+            for def in keys(fmm.defmap)
+                Core.eval(mod, convert(Expr, def))
+            end
+        end
+    end
+    return true  # fixme try/catch?
 end
 
 """
@@ -413,9 +444,10 @@ it defaults to `Main`.
 function track(mod::Module, file::AbstractString)
     isfile(file) || error(file, " is not a file")
     file = normpath(abspath(file))
-    md = parse_source(file, mod)
-    if md != nothing
-        file2modules[file] = FileModules(mod, md)
+    fm = parse_source(file, mod)
+    if fm != nothing
+        instantiate_sigs!(fm)
+        fileinfos[file] = FileInfo(fm)
     end
     init_watching((file,))
 end
@@ -442,6 +474,31 @@ end
 silence(pkg::AbstractString) = silence(Symbol(pkg))
 
 ## Utilities
+
+function println_maxlines(io::IO, args...; maxlines::Integer=20)
+    # This is dumb but certain to work
+    iotmp = IOBuffer()
+    for a in args
+        print(iotmp, a)
+    end
+    print(iotmp, '\n')
+    seek(iotmp, 0)
+    lines = readlines(iotmp)
+    if length(lines) <= maxlines
+        for line in lines
+            println(io, line)
+        end
+        return
+    end
+    half = (maxlines+1) ÷ 2
+    for i = 1:half
+        println(io, lines[i])
+    end
+    println(io, ⋮)
+    for i = length(lines) - (maxlines-half) + 1:length(lines)
+        println(io, lines[i])
+    end
+end
 
 function fix_line_statements!(ex::Expr, file::Symbol, line_offset::Int=0)
     if ex.head == :line

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -657,8 +657,8 @@ function __init__()
     if rev_include == "1"
         tracking_Main_includes[] = true
     end
-    # # Correct line numbers for code moving around
-    # Base.update_stackframes_callback[] = update_stacktrace_lineno!
+    # Correct line numbers for code moving around
+    Base.update_stackframes_callback[] = update_stacktrace_lineno!
 end
 
 ## WatchList utilities

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -25,7 +25,7 @@ function parse_pkg_files(id::PkgId)
                         mod = modid.uuid === nothing && modid.name == "" ? Main : Base.root_module(modid)
                         # For precompiled packages, we can read the source later (whenever we need it)
                         # from the *.ji cachefile. So push an empty ModDict.
-                        push!(file2modules, fname=>FileModules(mod, ModDict(), path))
+                        file2modules[fname] = FileModules(mod, path)
                         push!(files, fname)
                         module2files[modsym] = files
                     end
@@ -58,9 +58,9 @@ function queue_includes!(files, modstring)
         mod, fname = included_files[i]
         modname = String(Symbol(mod))
         if startswith(modname, modstring) || endswith(fname, modstring*".jl")
-            pr = parse_source(fname, mod)
-            if isa(pr, Pair)
-                push!(file2modules, pr)
+            md = parse_source(fname, mod)
+            if md != nothing
+                file2modules[fname] = FileModules(mod, md)
             end
             push!(files, fname)
             push!(delids, i)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -15,7 +15,7 @@ function track(mod::Module)
         files = String[]
         for (submod, filename) in Base._included_files
             submod == Main || startswith(String(nameof(submod)), "Base") || continue
-            push!(file2modules, filename=>FileModules(submod, ModDict(), basesrccache))
+            push!(file2modules, filename=>FileModules(submod, basesrccache))
             push!(files, filename)
             if mtime(filename) > mtcache
                 push!(revision_queue, filename)
@@ -55,11 +55,10 @@ function track_subdir_from_git(mod::Module, subdir::AbstractString)
             push!(revision_queue, fullpath)
         end
         fmod = get(juliaf2m, fullpath, Core.Compiler)  # Core.Compiler is not cached
-        md = ModDict(fmod=>ExprsSigs())
-        if !parse_source!(md, src, Symbol(file), 1, fmod)
+        fm = FileModules(fmod)
+        if parse_source!(fm.md, src, Symbol(file), 1, fmod) === nothing
             warn("failed to parse Git source text for ", file)
         end
-        fm = FileModules(fmod, md)
         push!(file2modules, fullpath=>fm)
         push!(wfiles, fullpath)
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -15,7 +15,7 @@ function track(mod::Module)
         files = String[]
         for (submod, filename) in Base._included_files
             submod == Main || startswith(String(nameof(submod)), "Base") || continue
-            push!(file2modules, filename=>FileModules(submod, basesrccache))
+            push!(fileinfos, filename=>FileInfo(submod, basesrccache))
             push!(files, filename)
             if mtime(filename) > mtcache
                 push!(revision_queue, filename)
@@ -55,11 +55,11 @@ function track_subdir_from_git(mod::Module, subdir::AbstractString)
             push!(revision_queue, fullpath)
         end
         fmod = get(juliaf2m, fullpath, Core.Compiler)  # Core.Compiler is not cached
-        fm = FileModules(fmod)
-        if parse_source!(fm.md, src, Symbol(file), 1, fmod) === nothing
+        fi = FileInfo(fmod)
+        if parse_source!(fi.fm, src, Symbol(file), 1, fmod) === nothing
             warn("failed to parse Git source text for ", file)
         end
-        push!(file2modules, fullpath=>fm)
+        fileinfos[fullpath] = fi
         push!(wfiles, fullpath)
     end
     init_watching(wfiles)

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -13,6 +13,8 @@
 """
 A `RelocatableExpr` is exactly like an `Expr` except that comparisons
 between `RelocatableExpr`s ignore line numbering information.
+This allows one to detect that two expressions are the same no matter
+where they appear in a file.
 
 You can use `convert(Expr, rex::RelocatableExpr)` to convert to an `Expr`
 and `convert(RelocatableExpr, ex::Expr)` for the converse. Beware that

--- a/src/types.jl
+++ b/src/types.jl
@@ -15,118 +15,112 @@ mutable struct WatchList
     trackedfiles::Set{String}
 end
 
+const DefMapValue = Union{RelocatableExpr,Tuple{Vector{Any},Int}}  # ([sigt1,...], lineoffset)
+
 """
-    Revise.ExprsSigs
+    DefMap
 
-struct holding parsed source code.
+Maps `def`=>nothing or `def=>([sigt1,...], lineoffset)`, where:
 
-Fields:
-- `exprs`: all [`RelocatableExpr`](@ref) in the module or file
-- `sigs`: all detected function signatures (used in method deletion)
+- `def` is an expression
+- the value is `nothing` if `def` does not define a method
+- if it does define a method, `sigt1...` are the signature-types and `lineoffset` is the
+  difference between the line number when the method was compiled and the current state
+  of the source file.
 
-These fields are stored as sets so that one can efficiently find the differences between two
-versions of the same module or file.
+See the documentation page [How Revise works](@ref) for more information.
 """
-struct ExprsSigs
-    exprs::OrderedSet{RelocatableExpr}
-    sigs::OrderedSet{RelocatableExpr}
+const DefMap = OrderedDict{RelocatableExpr,Union{DefMapValue,Nothing}}
+
+"""
+    SigtMap
+
+Maps `sigt=>def`, where `sigt` is the signature-type of a method and `def` the expression
+defining the method.
+
+See the documentation page [How Revise works](@ref) for more information.
+"""
+const SigtMap = Dict{Any,RelocatableExpr}   # sigt=>def
+
+"""
+    FMMaps
+
+`source=>sigtypes` and `sigtypes=>source` mappings for a particular file/module combination.
+See the documentation page [How Revise works](@ref) for more information.
+"""
+struct FMMaps
+    defmap::DefMap
+    sigtmap::SigtMap
 end
-ExprsSigs() = ExprsSigs(OrderedSet{RelocatableExpr}(), OrderedSet{RelocatableExpr}())
+FMMaps() = FMMaps(DefMap(), SigtMap())
 
-Base.isempty(es::ExprsSigs) = isempty(es.exprs) && isempty(es.sigs)
+Base.isempty(fmm::FMMaps) = isempty(fmm.defmap)
 
-function Base.show(io::IO, exprsig::ExprsSigs)
-    println(io, "ExprsSigs with $(length(exprsig.exprs)) exprs and $(length(exprsig.sigs)) method signatures")
-    println(io, "Exprs:")
-    for ex in exprsig.exprs
-        show(io, ex)
-        println(io)
+function Base.show(io::IO, fmm::FMMaps)
+    limit = get(io, :limit, true)
+    if limit
+        print(io, "FMMaps(<$(length(fmm.defmap)) expressions>, <$(length(fmm.sigtmap)) signatures>)")
+    else
+        println(io, "FMMaps with the following expressions:")
+        for def in keys(fmm.defmap)
+            print(io, "  ")
+            Base.show_unquoted(io, def, 2)
+            print(io, '\n')
+        end
     end
-    println(io, "Method signatures:")
-    for sig in exprsig.sigs
-        show(io, sig)
-    end
 end
 
 """
-A `ModDict` is an alias for `Dict{Module,ExprsSigs}`. It is used to
-organize expressions according to their module of definition.
+    FileModules
 
-See also [`FileModules`](@ref).
-"""
-const ModDict = Dict{Module,ExprsSigs}
+For a particular source file, the corresponding `FileModules` is an
+`OrderedDict(mod1=>fmm1, mod2=>fmm2)`,
+mapping the collection of modules "active" in the file (the parent module and any
+submodules it defines) to their corresponding [`FMMaps`](@ref).
 
-"""
-    FileModules(topmod::Module, md::ModDict, [cachefile::String])
-
-Structure to hold the per-module expressions found when parsing a
-single file.
-`topmod` is the current module when the file is parsed (i.e., the module this file
-was `include`d into); this is used every time the file is modified to re-parse the file.
- `md` holds the evaluatable statements, organized by the module
-of their occurrence. In particular, if the file defines one or
-more new modules, then `md` contains key/value pairs for each
-module. If the file does not define any new modules, `topmod` is
-the only key in `md`.
-
-# Example:
-
-Suppose MyPkg.jl has a file that looks like this:
-
-```julia
-__precompile__(true)
-
-module MyPkg
-
-foo(x) = x^2
-
-end
-```
-
-Then if this module is loaded from `Main`, schematically the
-corresponding `fm::FileModules` looks something like
-
-```julia
-fm.topmod = Main
-fm.md = Dict(Main=>ExprsSigs(OrderedSet([:(__precompile__(true))]), OrderedSet()),
-             Main.MyPkg=>ExprsSigs(OrderedSet([:(foo(x) = x^2)]), OrderedSet([:(foo(x))]))
-```
-because the precompile statement occurs in `Main`, and the definition of
-`foo` occurs in `Main.MyPkg`.
-
-!!! note "Source cache files"
-
-    Optionally, a `FileModule` can also record the path to a cache file holding the original source code.
-    This is applicable only for precompiled modules and `Base`.
-    (This cache file is distinct from the original source file that might be edited by the
-    developer, and it will always hold the state
-    of the code when the package was precompiled or Julia's `Base` was built.)
-    For such modules, the `ExprsSigs` will be empty for any file that has not yet been edited:
-    the original source code gets parsed only when a revision needs to be made.
-
-    Source cache files greatly reduce the overhead of using Revise.
+The first key is guaranteed to be the module into which this file was `include`d.
 
 To create a `FileModules` from a source file, see [`parse_source`](@ref).
 """
-struct FileModules
-    topmod::Module
-    md::ModDict
+const FileModules = OrderedDict{Module,FMMaps}
+
+"""
+    fm = FileModules(mod::Module)
+
+Initialize an empty `FileModules` for a file that is `include`d into `mod`.
+"""
+FileModules(mod::Module) = FileModules(mod=>FMMaps())
+
+Base.isempty(fm::FileModules) = length(fm) == 1 && isempty(first(values(fm)))
+
+"""
+    FileInfo(fm::FileModules, cachefile="")
+
+Structure to hold the per-module expressions found when parsing a
+single file.
+`fm` holds the [`FileModules`](@ref) for the file.
+
+Optionally, a `FileInfo` can also record the path to a cache file holding the original source code.
+This is applicable only for precompiled modules and `Base`.
+(This cache file is distinct from the original source file that might be edited by the
+developer, and it will always hold the state
+of the code when the package was precompiled or Julia's `Base` was built.)
+When a cache is available, `fm` will be empty until the file gets edited:
+the original source code gets parsed only when a revision needs to be made.
+
+Source cache files greatly reduce the overhead of using Revise.
+"""
+struct FileInfo
+    fm::FileModules
     cachefile::String
 end
-FileModules(topmod::Module, md::ModDict) = FileModules(topmod, md, "")
-FileModules(topmod::Module, cachefile::AbstractString="") =
-    FileModules(topmod, Dict(topmod=>ExprsSigs()), cachefile)
+FileInfo(fm::FileModules) = FileInfo(fm, "")
 
-# "Replace" md
-FileModules(fm::FileModules, md::ModDict) = FileModules(fm.topmod, md, fm.cachefile)
+"""
+    FileInfo(mod::Module, cachefile="")
 
-Base.isempty(fm::FileModules) = length(fm.md) == 1 && isempty(first(values(fm.md)))
+Initialze an empty FileInfo for a file that is `include`d into `mod`.
+"""
+FileInfo(mod::Module, cachefile::AbstractString="") = FileInfo(FileModules(mod), cachefile)
 
-function Base.show(io::IO, fm::FileModules)
-    print(io, "FileModules(", fm.topmod, ", ")
-    showdict = Dict{Module,String}()
-    for (mod, exprsig) in fm.md
-        showdict[mod] = "ExprsSigs with $(length(exprsig.exprs)) exprs and $(length(exprsig.sigs)) method signatures"
-    end
-    print(io, showdict, ", ", isempty(fm.cachefile) ? "<no cachefile>" : fm.cachefile, ")")
-end
+FileInfo(fm::FileModules, fi::FileInfo) = FileInfo(fm, fi.cachefile)

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,9 +1,8 @@
 using Random
 
-const setseed = @static Random.seed!
 const rseed = Ref(Random.GLOBAL_RNG)  # to get new random directories (see #24445)
 function randtmp()
-    setseed(rseed[])
+    Random.seed!(rseed[])
     dirname = joinpath(tempdir(), randstring(10))
     rseed[] = Random.GLOBAL_RNG
     dirname

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 
 @test isempty(detect_ambiguities(Revise, Base, Core))
 
-using Pkg, Unicode, Distributed
+using Pkg, Unicode, Distributed, InteractiveUtils
 using OrderedCollections: OrderedSet
 
 include("common.jl")
@@ -258,7 +258,7 @@ k(x) = 4
         push!(LOAD_PATH, testdir)
         for (pcflag, fbase) in ((true, "pc"), (false, "npc"))  # precompiled & not
             modname = uppercase(fbase)
-            pcexpr = pcflag ? nothing : :(__precompile__(false))
+            pcexpr = pcflag ? :() : :(__precompile__(false))
             # Create a package with the following structure:
             #   src/PkgName.jl   # PC.jl = precompiled, NPC.jl = nonprecompiled
             #   src/file2.jl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,7 +91,7 @@ end"""
         open(warnfile, "w") do io
             redirect_stderr(io) do
                 md = Revise.ModDict(Main=>Revise.ExprsSigs())
-                @test !Revise.parse_source!(md, """
+                @test Revise.parse_source!(md, """
 begin # this block should parse correctly, cf. issue #109
 
 end
@@ -100,7 +100,7 @@ g(x) = 2
 h{x) = 3  # error
 k(x) = 4
 """,
-                                            :test, 1, Main)
+                                            :test, 1, Main) == nothing
                 @test convert(Revise.RelocatableExpr, :(g(x) = 2)) ∈ md[Main].exprs
             end
         end
@@ -170,8 +170,8 @@ k(x) = 4
         # test the "mistakes"
         @test ReviseTest.cube(2) == 16
         @test ReviseTest.Internal.mult3(2) == 8
-        oldmd = Revise.parse_source(fl1, Main).second
-        newmd = Revise.parse_source(fl2, Main).second
+        oldmd = Revise.parse_source(fl1, Main)
+        newmd = Revise.parse_source(fl2, Main)
         revmd = Revise.revised_statements(newmd, oldmd)
         @test length(revmd) == 2
         @test haskey(revmd, ReviseTest) && haskey(revmd, ReviseTest.Internal)
@@ -192,7 +192,7 @@ k(x) = 4
         @test ReviseTest.Internal.mult3(2) == 6
 
         # Backtraces
-        newmd = Revise.parse_source(fl3, Main).second
+        newmd = Revise.parse_source(fl3, Main)
         revmd = Revise.revised_statements(newmd, oldmd)
         Revise.eval_revised(revmd)
         try


### PR DESCRIPTION
This is a major redesign of Revise's internals. It is now organized around two "maps" (Dicts), one which connects expressions to Julia types and the other which goes in the opposite direction. Together the two can be leveraged for an accurate and efficient connection between methods and the source-expressions that define them.

One nice consequence of this change is that we can finally fix #51. It depends on some cooperation from Base, however: https://github.com/JuliaLang/julia/pull/28328.