### PR TITLE
Fix a couple of bugs related to REPL-stealing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ git:
 
 ## uncomment the following lines to override the default test script
 script:
-  - julia -e 'using Pkg; Pkg.add(pwd()); Pkg.build("Revise"); Pkg.test("Revise"; coverage=true)'
+  - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("Revise"); Pkg.test("Revise"; coverage=true)'
   - JULIA_REVISE_POLL=1 julia --code-coverage -e 'using Pkg; include(Pkg.dir("Revise", "test", "polling.jl"))'
 
 after_script:  # TODO: change to after_success once https://github.com/JuliaLang/julia/issues/28306 is fixed

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,7 +21,7 @@ or with `using Pkg; Pkg.add("Revise")`.
 ## Usage example
 
 ```julia
-(v0.7) pkg> add Example
+(v0.7) pkg> dev Example
   Updating registry at `/tmp/pkgs/registries/Uncurated`
   Updating git-repo `https://github.com/JuliaRegistries/Uncurated.git`
  Resolving package versions...

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -522,18 +522,21 @@ This is necessary because code registered with `atreplinit` runs before the REPL
 initialized, and there is no corresponding way to register code to run after it is complete.
 """
 function async_steal_repl_backend()
-    atreplinit() do repl
-        @async begin
-            iter = 0
-            # wait for active_repl_backend to exist
-            while !isdefined(Base, :active_repl_backend) && iter < 20
-                sleep(0.05)
-                iter += 1
-            end
-            if isdefined(Base, :active_repl_backend)
-                steal_repl_backend(Base.active_repl_backend)
-            else
-                @warn "REPL initialization failed, Revise is not watching files."
+    mode = get(ENV, "JULIA_REVISE", "auto")
+    if mode == "auto"
+        atreplinit() do repl
+            @async begin
+                iter = 0
+                # wait for active_repl_backend to exist
+                while !isdefined(Base, :active_repl_backend) && iter < 20
+                    sleep(0.05)
+                    iter += 1
+                end
+                if isdefined(Base, :active_repl_backend)
+                    steal_repl_backend(Base.active_repl_backend)
+                else
+                    @warn "REPL initialization failed, Revise is not in automatic mode. Call `revise()` manually."
+                end
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -940,6 +940,6 @@ end
         end
         rm(warnfile)
     end
-
-    GC.gc()   # work-around for https://github.com/JuliaLang/julia/issues/28306
 end
+
+GC.gc(); GC.gc(); GC.gc()   # work-around for https://github.com/JuliaLang/julia/issues/28306


### PR DESCRIPTION
We were not supporting the full range of startup options. Most seriously, one combination ended up blocking the REPL (fixed by putting in an `@async` block).
