### PR TITLE
Remove __precompile__, as it is now the default.

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -1,5 +1,3 @@
-__precompile__(true)
-
 module Revise
 
 using FileWatching, Base.CoreLogging


### PR DESCRIPTION
Elimitates the warning message after https://github.com/JuliaLang/julia/pull/26991