### PR TITLE
fixed document instructions on starting Revise by default

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -9,7 +9,7 @@ adding the following to your `.julia/config/startup.jl` file:
 try
     @eval using Revise
     # Turn on Revise's automatic-evaluation behavior
-    Revise.async_steal_repl_backend()
+    @async Revise.steal_repl_backend()
 catch err
     @warn "Could not load Revise."
 end


### PR DESCRIPTION
Currently there is no function as `Revise.async_steal_repl_backend()`, it seems that what was intended was `@async Revise.steal_repl_backend()`.  Was there an intention of adding a function istead?