### PR TITLE
Add includet to simplify script-tracking

### DIFF
--- a/docs/src/user_reference.md
+++ b/docs/src/user_reference.md
@@ -1,12 +1,13 @@
 # User reference
 
-There are really only two functions that a user would be expected to call manually:
-`revise` and `Revise.track`.
+There are really only three functions that a user would be expected to call manually:
+`revise`, `includet`, and `Revise.track`.
 Other user-level constructs might apply if you want to exclude Revise from watching specific packages.
 
 ```@docs
 revise
 Revise.track
+includet
 Revise.dont_watch_pkgs
 Revise.silence
 ```

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -5,7 +5,7 @@ import LibGit2
 
 using OrderedCollections: OrderedDict
 
-export revise
+export revise, includet
 
 """
     Revise.watching_files[]
@@ -448,6 +448,13 @@ function track(mod::Module, file::AbstractString)
 end
 
 track(file::AbstractString) = track(Main, file)
+
+"""
+    includet(filename)
+
+Include and track `filename`.
+"""
+includet(file::AbstractString) = (Base.include(Main, file); track(Main, file))
 
 """
     Revise.silence(pkg)

--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -159,7 +159,7 @@ sig_type_exprs(sigex::RelocatableExpr) = sig_type_exprs(convert(Expr, sigex))
 function _sig_type_exprs(ex, @nospecialize(wheres))
     fex = ex.args[1]
     if isa(fex, Expr) && fex.head == :(::)
-        fexTex = fex.args[2]
+        fexTex = fex.args[end]
     else
         fexTex = :(Core.Typeof($fex))
     end

--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -29,7 +29,7 @@ function funcdef_expr(ex)
     if ex.head == :macrocall
         if ex.args[1] isa GlobalRef && ex.args[1].name == Symbol("@doc")
             return funcdef_expr(ex.args[end])
-        elseif ex.args[1] ∈ (Symbol("@inline"), Symbol("@noinline"))
+        elseif ex.args[1] ∈ (Symbol("@inline"), Symbol("@noinline"), Symbol("@propagate_inbounds"))
             return funcdef_expr(ex.args[3])
         else
             io = IOBuffer()

--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -31,6 +31,8 @@ function funcdef_expr(ex)
             return funcdef_expr(ex.args[end])
         elseif ex.args[1] ∈ (Symbol("@inline"), Symbol("@noinline"), Symbol("@propagate_inbounds"))
             return funcdef_expr(ex.args[3])
+        elseif ex.args[1] == Symbol("@eval")
+            return funcdef_expr(ex.args[end])
         else
             io = IOBuffer()
             dump(io, ex)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -14,7 +14,6 @@ function track(mod::Module)
         # note any modified since Base was built
         files = String[]
         for (submod, filename) in Base._included_files
-            submod == Main || startswith(String(nameof(submod)), "Base") || continue
             push!(fileinfos, filename=>FileInfo(submod, basesrccache))
             push!(files, filename)
             if mtime(filename) > mtcache

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -71,7 +71,7 @@ function striplines!(rex::RelocatableExpr)
         # for macros, the show method in Base assumes the line number is there,
         # so don't strip it
         args3 = [a isa RelocatableExpr ? striplines!(a) : a for a in rex.args[3:end]]
-        return RelocatableExpr(rex.head, rex.args[1:2]..., args3...)
+        return RelocatableExpr(rex.head, rex.args[1], nothing, args3...)
     end
     args = [a isa RelocatableExpr ? striplines!(a) : a for a in rex.args]
     fargs = collect(LineSkippingIterator(args))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -946,6 +946,7 @@ end
         # Tracking Base
         Revise.track(Base)
         @test any(k->endswith(k, "number.jl"), keys(Revise.fileinfos))
+        @test length(filter(k->endswith(k, "file.jl"), keys(Revise.fileinfos))) == 2
 
         # Determine whether a git repo is available. Travis & Appveyor do not have this.
         repo, path = Revise.git_repo(Revise.juliadir)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,6 +278,10 @@ k(x) = 4
     end
 
     @testset "Display" begin
+        io = IOBuffer()
+        show(io, Revise.relocatable!(:(@inbounds x[2])))
+        str = String(take!(io))
+        @test str == ":(@inbounds x[2])"
         fm = Revise.parse_source(joinpath(@__DIR__, "revisetest.jl"), Main)
         Revise.instantiate_sigs!(fm)
         @test string(fm) == "OrderedCollections.OrderedDict(Main=>FMMaps(<1 expressions>, <0 signatures>),Main.ReviseTest=>FMMaps(<2 expressions>, <2 signatures>),Main.ReviseTest.Internal=>FMMaps(<2 expressions>, <2 signatures>))"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,6 +192,12 @@ k(x) = 4
             @test Revise.relocatable!(Revise.funcdef_expr(ex)) == refex
         end
 
+        # @eval-defined methods
+        ex = :(@eval getindex(A::Array, i1::Int, i2::Int, I::Int...) = (@_inline_meta; arrayref($(Expr(:boundscheck)), A, i1, i2, I...)))
+        @test Revise.get_signature(ex) == :(getindex(A::Array, i1::Int, i2::Int, I::Int...))
+        @test Revise.relocatable!(Revise.funcdef_expr(ex)) == Revise.relocatable!(
+            :(getindex(A::Array, i1::Int, i2::Int, I::Int...) = (@_inline_meta; arrayref($(Expr(:boundscheck)), A, i1, i2, I...)))
+            )
     end
 
     @testset "Comparison and line numbering" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -794,9 +794,8 @@ end
 revise_f(x) = 1
 """)
         end
-        include(srcfile)
+        includet(srcfile)
         @test revise_f(10) == 1
-        Revise.track(srcfile)
         sleep(0.1)
         open(srcfile, "w") do io
             print(io, """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,6 +176,12 @@ k(x) = 4
         i = ReviseTestPrivate.Inner(3)
         m = @which i("hello")
         @test Core.eval(ReviseTestPrivate, sigexs[1]) == m.sig
+        def = :((::Type{Inner})(::Dict) = 17)
+        sig = Revise.get_signature(def)
+        sigexs = Revise.sig_type_exprs(sig)
+        Core.eval(ReviseTestPrivate, def)
+        m = @which ReviseTestPrivate.Inner(Dict("a"=>1))
+        @test Core.eval(ReviseTestPrivate, sigexs[1]) == m.sig
 
         # Annotations
         refex =  Revise.relocatable!(:(function foo(x) x^2 end))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,6 +176,16 @@ k(x) = 4
         i = ReviseTestPrivate.Inner(3)
         m = @which i("hello")
         @test Core.eval(ReviseTestPrivate, sigexs[1]) == m.sig
+
+        # Annotations
+        refex =  Revise.relocatable!(:(function foo(x) x^2 end))
+        for ex in (:(@inline function foo(x) x^2 end),
+                   :(@noinline function foo(x) x^2 end),
+                   :(@propagate_inbounds function foo(x) x^2 end))
+            @test Revise.get_signature(ex) == :(foo(x))
+            @test Revise.relocatable!(Revise.funcdef_expr(ex)) == refex
+        end
+
     end
 
     @testset "Comparison and line numbering" begin


### PR DESCRIPTION
Plus another pile of fixes. The new signature parsing places many more demands on accuracy, it seems, so the v0.6 rewrite has led to several problems. However, in several respects it's already better than ever, so I am pretty confident this is moving in the right direction.