### PR TITLE
Greatly improve performance with IdDict

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -371,7 +371,7 @@ function instantiate_sigs!(fmm::FMMaps, def::RelocatableExpr, sig::RelocatableEx
     try
         sigts = Any[Core.eval(mod, s) for s in sigtexs]
     catch err
-        @warn "error processing module $mod signature expressions $sigtexs from $def"
+        sigwarn(mod, sigtexs, def)
         rethrow(err)
     end
     # Insert into the maps
@@ -379,7 +379,9 @@ function instantiate_sigs!(fmm::FMMaps, def::RelocatableExpr, sig::RelocatableEx
     for sigt in sigts
         fmm.sigtmap[sigt] = def
     end
+    return def
 end
+@noinline sigwarn(mod, sigtexs, def) = @warn "error processing module $mod signature expressions $sigtexs from $def"
 
 """
     revise()

--- a/src/types.jl
+++ b/src/types.jl
@@ -40,7 +40,7 @@ defining the method.
 
 See the documentation page [How Revise works](@ref) for more information.
 """
-const SigtMap = Dict{Any,RelocatableExpr}   # sigt=>def
+const SigtMap = IdDict{Any,RelocatableExpr}   # sigt=>def
 
 """
     FMMaps


### PR DESCRIPTION
Motivated by the slowness of `track(LinearAlgebra)`, I profiled and found a surprising result: almost all the time was spent on type-inference for inserting `sigtmap[sigt] = def`. Given that each key has a different type, perhaps this shouldn't have been surprising. By switching to an IdDict it got faster.

Before:
```julia
julia> using LinearAlgebra

julia> @time Revise.track(LinearAlgebra)
 89.868081 seconds (233.75 M allocations: 11.436 GiB, 3.34% gc time)
```
After:
```julia
julia> @time Revise.track(LinearAlgebra)
  3.469887 seconds (5.75 M allocations: 214.248 MiB, 4.76% gc time)
```

CC @andreasnoack