### PR TITLE
Parse return-type declarations with wheres clauses

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -366,7 +366,13 @@ end
 
 function instantiate_sigs!(fmm::FMMaps, def::RelocatableExpr, sig::RelocatableExpr, mod::Module)
     # Generate the signature-types
-    sigtexs = sig_type_exprs(sig)
+    local sigtexs
+    try
+        sigtexs = sig_type_exprs(sig)
+    catch err
+        sigwarn(mod, sig, def)
+        rethrow(err)
+    end
     local sigts
     try
         sigts = Any[Core.eval(mod, s) for s in sigtexs]

--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -139,7 +139,7 @@ julia> Revise.sig_type_exprs(:(foo(x::AbstractVector{T}, y) where T))
 ```
 """
 function sig_type_exprs(sigex::Expr, wheres...)
-    if isempty(wheres) && sigex.head == :(::)
+    if sigex.head == :(::)
         # return type annotation
         sigex = sigex.args[1]
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,6 +167,13 @@ k(x) = 4
         # Return type annotations
         @test Revise.sig_type_exprs(:(typeinfo_eltype(typeinfo::Type)::Union{Type,Nothing})) ==
               Revise.sig_type_exprs(:(typeinfo_eltype(typeinfo::Type)))
+        def = quote
+            function +(x::Bool, y::T)::promote_type(Bool,T) where T<:AbstractFloat
+                return ifelse(x, oneunit(y) + y, y)
+            end
+        end
+        sig = Revise.get_signature(def)
+        @test Revise.sig_type_exprs(sig) == [:(Tuple{Core.Typeof(+), Bool, T} where T<:AbstractFloat)]
 
         # Overloading call
         def = :((i::Inner)(::String) = i.x)


### PR DESCRIPTION
I was unnecessarily conservative in my previous implementation of this syntax; the fix is simply to drop what I thought was a "sanity check."