### PR TITLE
Update build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,5 @@
 if Sys.islinux()
-    max_watches = parse(Int, chomp(read(`sysctl -n fs.inotify.max_user_watches`, String)))
+    max_watches=parse(Int, chomp(read(`cat /proc/sys/fs/inotify/max_user_watches`, String)))
     if max_watches <= 8192 && !isfile(joinpath(@__DIR__, "user_watches"))
         default_watches = 65536
         msg = """


### PR DESCRIPTION
For non super users (like myself) you get:
```
 sysctl
Absolute path to 'sysctl' is '/usr/sbin/sysctl', so running it may require superuser privileges (eg. root).
```
And thus the build fails, this achieves the same end result, and circumvents the error... I hope :)