### PR TITLE
More robustly find `base` (and the stdlibs)

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -17,6 +17,7 @@ Revise.tracking_Main_includes
 ```@docs
 Revise.juliadir
 Revise.basesrccache
+Revise.basebuilddir
 ```
 
 ### Internal state management


### PR DESCRIPTION
This is designed to support Revise.track(Base) on a wider array of machines. This is becoming important because of [Rebugger](https://github.com/timholy/Rebugger.jl). This may fix https://github.com/timholy/Rebugger.jl/issues/1 ~and the longstanding Travis failures on OSX.~ (EDIT: those were fixed in #136)