### PR TITLE
Fix test failures on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
 
 after_script:  # TODO: change to after_success once https://github.com/JuliaLang/julia/issues/28306 is fixed
   # push coverage results to Codecov
-  - julia -e 'using Pkg; cd(Pkg.dir("Revise")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg, Revise; cd(joinpath(dirname(pathof(Revise)), "..")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
   # Update the documentation
   - julia -e 'using Pkg; Pkg.add("Documenter")'
-  - julia -e 'ENV["DOCUMENTER_DEBUG"] = "true"; using Pkg, Revise; include(joinpath(dirname(pathof(Revise)), "..", "..", "docs", "make.jl"))'
+  - julia -e 'ENV["DOCUMENTER_DEBUG"] = "true"; using Pkg, Revise; include(joinpath(dirname(pathof(Revise)), "..", "docs", "make.jl"))'

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -531,6 +531,7 @@ If it is in Base, this will execute `track(Base)` if necessary.
 """
 function get_def(method::Method)
     filename = String(method.file)
+    yield()   # magic bug fix for the OSX test failures. TODO: figure out why this works (prob. Julia bug)
     startswith(filename, "REPL") && error("methods defined at the REPL are not yet supported")
     if !haskey(fileinfos, filename)
         # See whether it's in Base


### PR DESCRIPTION
This makes no sense, but it reproducibly fixes the test failures. Thanks to @andreasnoack and @vtjnash.

Andreas also mentioned that on OSX there are times where methods don't update until you insert a `print` statement (which yields) into the method body. This suggests that we may need to insert more `yield`s in more places. But it makes sense to go stepwise, so let's start here.