### PR TITLE
Use original path for indexing basesrccache

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -145,6 +145,7 @@ const juliadir = begin
     end
     jldir
 end
+const cache_file_key = Dict{String,String}() # corrected=>uncorrected filenames
 
 """
     Revise.dont_watch_pkgs

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -95,8 +95,10 @@ end
 
 function read_from_cache(fi::FileInfo, file::AbstractString)
     if fi.cachefile == basesrccache
+        # Get the original path
+        filec = get(cache_file_key, file, file)
         return open(basesrccache) do io
-            Base._read_dependency_src(io, file)
+            Base._read_dependency_src(io, filec)
         end
     end
     Base.read_dependency_src(fi.cachefile, file)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -18,8 +18,8 @@ function track(mod::Module)
         # note any modified since Base was built
         files = String[]
         for (submod, filename) in Base._included_files
-            push!(fileinfos, filename=>FileInfo(submod, basesrccache))
             filename = fixpath(filename)
+            push!(fileinfos, filename=>FileInfo(submod, basesrccache))
             push!(files, filename)
             if mtime(filename) > mtcache
                 push!(revision_queue, filename)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -43,6 +43,7 @@ end
 # Fix paths to files that define Julia (base and stdlibs)
 function fixpath(filename; badpath=basebuilddir, goodpath=juliadir)
     isfile(filename) && return filename
+    filec = filename
     startswith(filename, badpath) || error(filename, " does not start with ", badpath)
     relfilename = relpath(filename, badpath)
     for strippath in (joinpath("usr", "share", "julia"),)
@@ -50,7 +51,9 @@ function fixpath(filename; badpath=basebuilddir, goodpath=juliadir)
             relfilename = relpath(relfilename, strippath)
         end
     end
-    return normpath(joinpath(goodpath, relfilename))
+    filename = normpath(joinpath(goodpath, relfilename))
+    cache_file_key[filename] = filec
+    return filename
 end
 
 # For tracking subdirectories of Julia itself (base/compiler, stdlibs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1040,10 +1040,9 @@ end
         Revise.track(Base)
         @test any(k->endswith(k, "number.jl"), keys(Revise.fileinfos))
         @test length(filter(k->endswith(k, "file.jl"), keys(Revise.fileinfos))) == 2
-
         m = @which show([1,2,3])
-        get_def(m)
-        
+        @test Revise.get_def(m) isa Revise.RelocatableExpr
+
         # Determine whether a git repo is available. Travis & Appveyor do not have this.
         repo, path = Revise.git_repo(Revise.juliadir)
         if repo != nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1041,6 +1041,9 @@ end
         @test any(k->endswith(k, "number.jl"), keys(Revise.fileinfos))
         @test length(filter(k->endswith(k, "file.jl"), keys(Revise.fileinfos))) == 2
 
+        m = @which show([1,2,3])
+        get_def(m)
+        
         # Determine whether a git repo is available. Travis & Appveyor do not have this.
         repo, path = Revise.git_repo(Revise.juliadir)
         if repo != nothing


### PR DESCRIPTION
Now we update the paths to Base and stdlib files on the user's system. Unfortunately, the `basesrccache` is "indexed" by the paths as they were at build time. Consequently we need to hold on to both.