### PR TITLE
Document the steps needed to fix path problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
   - osx
 julia:
   - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -24,24 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "using InteractiveUtils, Pkg; versioninfo();
-      Pkg.clone(pwd(), \"Revise\"); Pkg.build(\"Revise\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "using Pkg; Pkg.test(\"Revise\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,7 +23,7 @@ makedocs(
 deploydocs(
     repo = "github.com/timholy/Revise.jl.git",
     target = "build",
-    julia = "nightly",
+    julia = "1.0",
     deps = nothing,
     make = nothing,
 )

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -99,3 +99,66 @@ a `using` or `import` statement; files loaded by `include` are not
 tracked, unless you explicitly use `Revise.track(filename)`. However, you can turn on
 automatic tracking by setting the environment variable `JULIA_REVISE_INCLUDE` to the
 string `"1"` (e.g., `JULIA_REVISE_INCLUDE=1` in a bash script).
+
+## Fixing a broken or partially-working installation
+
+During certain types of usage you might receive messages like
+
+```julia
+Warning: /some/system/path/stdlib/v1.0/SHA/src is not an existing directory, Revise is not watching
+```
+
+and this indicates that some of Revise's functionality is broken.
+
+Revise's test suite covers a broad swath of functionality, and so if something
+is broken a good first start towards resolving the problem is to run `pkg> test Revise`.
+Note that some test failures may not really matter to you personally: if, for example, you don't
+plan on hacking on Julia's compiler then you may not be concerned about failures
+related to `Revise.track(Core.Compiler)`.
+However, because Revise is used by [Rebugger](https://github.com/timholy/Rebugger.jl)
+and it is common to step into `Base` methods while debugging,
+there may be more cases than you might otherwise expect in which you might wish for Revise's
+more "advanced" functionality.
+
+In the majority of cases, failures come down to Revise having trouble locating source
+code on your drive.
+This problem should be fixable, because Revise includes functionality
+to update its links to source files, as long as it knows what to do.
+
+Here are some possible test warnings and errors, and steps you might take to fix them:
+
+- `Error: Package Example not found in current path`:
+  This (tiny) package is only used for testing purposes, and gets installed automatically
+  if you do `pkg> test Revise`, but not if you `include("runtests.jl")` from inside
+  Revise's `test/` directory.
+  You can prevent the error with `pkg> add Example`.
+- `Base & stdlib file paths: Test Failed at /some/path...  Expression: isfile(Revise.basesrccache)`
+  This failure is quite serious, and indicates that you will be unable to access code in `Base`.
+  To fix this, look for a file called `"base.cache"` somewhere in your Julia install
+  or build directory (for the author, it is at `/home/tim/src/julia-1.0/usr/share/julia/base.cache`).
+  Now compare this with the value of `Revise.basesrccache`.
+  (If you're getting this failure, presumably they are different.)
+  An important "top level" directory is `Sys.BINDIR`; if they differ already at this level,
+  consider adding a symbolic link from the location pointed at by `Sys.BINDIR` to the
+  corresponding top-level directory in your actual Julia installation.
+  You'll know you've succeeded in specifying it correctly when, after restarting
+  Julia, `Revise.basesrccache` points to the correct file and `Revise.juliadir`
+  points to the directory that contains `base/`.
+  If this workaround is not possible or does not succeed, please
+  [file an issue](https://github.com/timholy/Revise.jl/issues) with a description of
+  why you can't use it and/or
+  + details from `versioninfo` and information about how you obtained your Julia installation;
+  + the values of `Revise.basesrccache` and `Revise.juliadir`, and the actual paths to `base.cache`
+    and the directory containing the running Julia's `base/`;
+  + what you attempted when trying to fix the problem;
+  + if possible, your best understanding of why this failed to fix it.
+- `skipping Core.Compiler and stdlibs tests due to lack of git repo`: this likely indicates
+  that you downloaded a Julia binary rather than building Julia from source.
+  While Revise should be able to access the code in `Base`,
+  at the current time it is not possible for Revise to access julia's stdlibs unless
+  you clone Julia's repository and build it from source.
+- `skipping git tests because Revise is not under development`: this warning should be
+  harmless. Revise has built-in functionality for extracting source code using `git`,
+  and it uses itself (i.e., its own git repository) for testing purposes.
+  These tests run only if you have checked out Revise for development (`pkg> dev Revise`)
+  or on the continuous integration servers (Travis and Appveyor).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,6 +53,18 @@ for the stdlibs, any changes since the last git commit will be incorporated.
 See [Using Revise by default](@ref) if you want Revise to be available every time you
 start julia.
 
+## What Revise can track
+
+Revise is fairly ambitious: if all is working you should be able to track changes to
+
+- any package that you load with `import` or `using`
+- any script you load with [`includet`](@ref)
+- any file defining `Base` julia itself (with `Revise.track(Base)`)
+- any file defining `Core.Compiler` (with `Revise.track(Core.Compiler)`)
+- any of Julia's standard libraries (with, e.g., `using Unicode; Revise.track(Unicode)`)
+
+The last two require that you clone Julia and build it yourself from source.
+
 ## If Revise doesn't work as expected
 
 If Revise isn't working for you, here are some steps to try:
@@ -61,7 +73,9 @@ If Revise isn't working for you, here are some steps to try:
   In particular, some file systems (like NFS) might require special options.
 - Revise can't handle all kinds of code changes; for more information,
   see the section on [Limitations](@ref).
-- Try running `test Revise` from the Pkg REPL-mode. If tests pass, check the documentation
-  to make sure you understand how Revise should work.
+- Try running `test Revise` from the Pkg REPL-mode.
+  If tests pass, check the documentation to make sure you understand how Revise should work.
+  If they fail (especially if it mirrors functionality that you need and isn't working), see
+  [Fixing a broken or partially-working installation](@ref) for some suggestions.
 
 If you still encounter problems, please [file an issue](https://github.com/timholy/Revise.jl/issues).

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -489,7 +489,16 @@ track(file::AbstractString) = track(Main, file)
 """
     includet(filename)
 
-Include and track `filename`.
+Load `filename` and track any future changes to it.
+`includet` is deliberately non-recursive, so if `filename` loads any other files,
+they will not be automatically tracked.
+(See [`Revise.track`](@ref) to set it up manually.)
+
+`includet` is intended for "user scripts," e.g., a file you use locally for a specific
+purpose such as loading a specific data set or performing some kind of analysis.
+Do not use `includet` for packages, as those should be handled by `using` or `import`.
+If `using` and `import` aren't working, you may have packages in a non-standard location;
+try fixing it with something like `push!(LOAD_PATH, "/path/to/my/private/repos")`.
 """
 includet(file::AbstractString) = (Base.include(Main, file); track(Main, file))
 


### PR DESCRIPTION
As Revise gets more ambitious about tracking more and more of Julia, it seems likely that path-related problems will be the number one source of trouble for users. Rather than just respond to issues as they come up, let's have some documentation that walks through the process of diagnosing and fixing path problems.