### PR TITLE
Use our own version of parse_cache_header

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7.0-beta2.202
+julia 0.7
 OrderedCollections

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -1,7 +1,8 @@
 module Revise
 
-using FileWatching, REPL, Base.CoreLogging, Distributed
+using FileWatching, REPL, Base.CoreLogging, Distributed, UUIDs
 import LibGit2
+using Base: PkgId
 
 using OrderedCollections: OrderedDict
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -454,6 +454,42 @@ end
         # Remove the precompiled file
         rm_precompile("PC")
 
+        # Submodules (issue #142)
+        srcdir = joinpath(testdir, "Mysupermodule", "src")
+        subdir = joinpath(srcdir, "Mymodule")
+        mkpath(subdir)
+        open(joinpath(srcdir, "Mysupermodule.jl"), "w") do io
+            print(io, """
+                module Mysupermodule
+                include("Mymodule/Mymodule.jl")
+                end
+                """)
+        end
+        open(joinpath(subdir, "Mymodule.jl"), "w") do io
+            print(io, """
+                module Mymodule
+                include("filesub.jl")
+                end
+                """)
+        end
+        open(joinpath(subdir, "filesub.jl"), "w") do io
+            print(io, """
+                func() = 1
+                """)
+        end
+        sleep(2.1)
+        @eval using Mysupermodule
+        @test Mysupermodule.Mymodule.func() == 1
+        sleep(1.1)
+        yry()
+        open(joinpath(subdir, "filesub.jl"), "w") do io
+            print(io, """
+                func() = 2
+                """)
+        end
+        yry()
+        @test Mysupermodule.Mymodule.func() == 2
+
         # Test files paths that can't be statically parsed
         dn = joinpath(testdir, "LoopInclude", "src")
         mkpath(dn)


### PR DESCRIPTION
Base's version recently discarded the submodule names, so it's time to maintain our own version here.

Fixes #142. CC @pawbz.

