### PR TITLE
Parse properly when macros redefine methods

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 Example
+RecipesBase


### PR DESCRIPTION
Boy, this was really dumb. I was implicitly assuming that macros don't modify the method signature. :disappointed_relieved: 

Fixes #148 . CC @mkborregaard, @daschw.
