### PR TITLE
Don't do spurious revisions

### DIFF
--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -91,21 +91,38 @@ julia> ReviseTest.cube(3)
 27
 
 julia> rlogger.logs
-5-element Array{Test.LogRecord,1}:
- Test.LogRecord(Debug, "Eval", Revise, "Action", :Revise_443cc0b6, "/home/tim/.julia/dev/Revise/src/Revise.jl", 266, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{Module,Revise.RelocatableExpr}}}}(:time=>1.5347e9,:deltainfo=>(Main.ReviseTest, :(cube(x) = begin
+8-element Array{Test.LogRecord,1}:
+ Test.LogRecord(Debug, "Diff", Revise, "Parsing", :Revise_1dfe9141, "/home/tim/.julia/dev/Revise/src/Revise.jl", 212, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol,Symbol},NamedTuple{(:activemodule, :newexprs, :oldexprs),Tuple{Tuple{Symbol},Set{Revise.RelocatableExpr},Set{Revise.RelocatableExpr}}}}(:activemodule=>(:Main,),:newexprs=>Set(Revise.RelocatableExpr[]),:oldexprs=>Set(Revise.RelocatableExpr[])))
+ Test.LogRecord(Debug, "Diff", Revise, "Parsing", :Revise_1dfe9142, "/home/tim/.julia/dev/Revise/src/Revise.jl", 212, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol,Symbol},NamedTuple{(:activemodule, :newexprs, :oldexprs),Tuple{Tuple{Symbol,Symbol},Set{Revise.RelocatableExpr},Set{Revise.RelocatableExpr}}}}(:activemodule=>(:Main, :ReviseTest),:newexprs=>Set(Revise.RelocatableExpr[:(fourth(x) = begin
+          x ^ 4
+      end), :(cube(x) = begin
+          x ^ 3
+      end)]),:oldexprs=>Set(Revise.RelocatableExpr[:(cube(x) = begin
+          x ^ 4
+      end)])))
+ Test.LogRecord(Debug, "Eval", Revise, "Action", :Revise_443cc0b6, "/home/tim/.julia/dev/Revise/src/Revise.jl", 267, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{Module,Revise.RelocatableExpr}}}}(:time=>1.53487e9,:deltainfo=>(Main.ReviseTest, :(cube(x) = begin
           x ^ 3
       end))))
- Test.LogRecord(Debug, "Eval", Revise, "Action", :Revise_443cc0b7, "/home/tim/.julia/dev/Revise/src/Revise.jl", 266, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{Module,Revise.RelocatableExpr}}}}(:time=>1.5347e9,:deltainfo=>(Main.ReviseTest, :(fourth(x) = begin
+ Test.LogRecord(Debug, "Eval", Revise, "Action", :Revise_443cc0b7, "/home/tim/.julia/dev/Revise/src/Revise.jl", 267, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{Module,Revise.RelocatableExpr}}}}(:time=>1.53487e9,:deltainfo=>(Main.ReviseTest, :(fourth(x) = begin
           x ^ 4
       end))))
- Test.LogRecord(Debug, "LineOffset", Revise, "Action", :Revise_3e9f6659, "/home/tim/.julia/dev/Revise/src/Revise.jl", 226, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{Array{Any,1},Int64,Pair{Int64,Int64}}}}}(:time=>1.5347e9,:deltainfo=>(Any[Tuple{typeof(mult2),Any}], 13, 0=>2)))
- Test.LogRecord(Debug, "Eval", Revise, "Action", :Revise_443cc0b8, "/home/tim/.julia/dev/Revise/src/Revise.jl", 266, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{Module,Revise.RelocatableExpr}}}}(:time=>1.5347e9,:deltainfo=>(Main.ReviseTest.Internal, :(mult3(x) = begin
+ Test.LogRecord(Debug, "Diff", Revise, "Parsing", :Revise_1dfe9143, "/home/tim/.julia/dev/Revise/src/Revise.jl", 212, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol,Symbol},NamedTuple{(:activemodule, :newexprs, :oldexprs),Tuple{Tuple{Symbol,Symbol,Symbol},Set{Revise.RelocatableExpr},Set{Revise.RelocatableExpr}}}}(:activemodule=>(:Main, :ReviseTest, :Internal),:newexprs=>Set(Revise.RelocatableExpr[:(mult3(x) = begin
+          3x
+      end)]),:oldexprs=>Set(Revise.RelocatableExpr[:(mult4(x) = begin
+          -x
+      end), :(mult3(x) = begin
+          4x
+      end)])))
+ Test.LogRecord(Debug, "LineOffset", Revise, "Action", :Revise_3e9f6659, "/home/tim/.julia/dev/Revise/src/Revise.jl", 227, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{Array{Any,1},Int64,Pair{Int64,Int64}}}}}(:time=>1.53487e9,:deltainfo=>(Any[Tuple{typeof(mult2),Any}], 13, 0=>2)))
+ Test.LogRecord(Debug, "Eval", Revise, "Action", :Revise_443cc0b8, "/home/tim/.julia/dev/Revise/src/Revise.jl", 267, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{Module,Revise.RelocatableExpr}}}}(:time=>1.53487e9,:deltainfo=>(Main.ReviseTest.Internal, :(mult3(x) = begin
           3x
       end))))
- Test.LogRecord(Debug, "DeleteMethod", Revise, "Action", :Revise_04f4de6f, "/home/tim/.julia/dev/Revise/src/Revise.jl", 248, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{DataType,MethodSummary}}}}(:time=>1.5347e9,:deltainfo=>(Tuple{typeof(mult4),Any}, MethodSummary(:mult4, :Internal, Symbol("/tmp/revisetest.jl"), 13, Tuple{typeof(mult4),Any}))))
+ Test.LogRecord(Debug, "DeleteMethod", Revise, "Action", :Revise_04f4de6f, "/home/tim/.julia/dev/Revise/src/Revise.jl", 249, Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:time, :deltainfo),Tuple{Float64,Tuple{DataType,MethodSummary}}}}(:time=>1.53487e9,:deltainfo=>(Tuple{typeof(mult4),Any}, MethodSummary(:mult4, :Internal, Symbol("/tmp/revisetest.jl"), 13, Tuple{typeof(mult4),Any}))))
 ```
+In addition to the "Action" items, you can see other entries that record the "Diff"s encountered
+by Revise during revision.
 
-Note that in some cases it can also be helpful to independently record the sequence of edits to the file.
+In rare cases it might be helpful to independently record the sequence of edits to the file.
 You can make copies `cp editedfile.jl > /tmp/version1.jl`, edit code, `cp editedfile.jl > /tmp/version2.jl`,
 etc.
 `diff version1.jl version2.jl` can be used to capture a compact summary of the changes

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -14,18 +14,15 @@ messages are also provided below.
 
 Currently, the best way to turn on logging is within a running Julia session:
 
-```jldoctest
-julia> using Test, Logging
-
-julia> using Base.CoreLogging: Debug
-
-julia> rlogger = Test.TestLogger(min_level=Debug);
-
-julia> stdlogger = global_logger(rlogger);
+```jldoctest; setup=(using Revise)
+julia> rlogger = Revise.debug_logger()
+Test.TestLogger(Test.LogRecord[], Debug, false, nothing)
 ```
-(The next-to-last line creates a logging object to capture `@debug` statements, and the last
-sets it as the active logger, saving the previous setting to a variable `stdlogger` in
-case you want to restore it later.)
+Hold on to `rlogger`; you're going to use it at the end to retrieve the logs.
+
+!!! note
+
+    This replaces the global logger; in rare circumstances this may have consequences for other code.
 
 Now carry out the series of julia commands and code edits that reproduces the problem.
 
@@ -47,7 +44,7 @@ See also [A complete debugging demo](@ref) below.
 ## The structure of the logs
 
 For those who want to do a little investigating on their own, it may be helpful to
-know that Revise's decisions are captured in the group called "Action," and they come in three
+know that Revise's core decisions are captured in the group called "Action," and they come in three
 flavors:
 
 - log entries with message `"Eval"` signify a call to `eval`; for these events,
@@ -72,18 +69,14 @@ determining which revisions occur in conjunction with which user actions.
 If you want to make use of this, it can be handy to capture the start time with `tstart = time()`
 before commencing on a session.
 
+See [`Revise.debug_logger`](@ref) for information on groups besides "Action."
+
 ## A complete debugging demo
 
 From within Revise's `test/` directory, try the following:
 
 ```julia
-julia> using Test, Logging
-
-julia> using Base.CoreLogging: Debug
-
-julia> rlogger = Test.TestLogger(min_level=Debug);
-
-julia> stdlogger = global_logger(rlogger);
+julia> rlogger = Revise.debug_logger();
 
 shell> cp revisetest.jl /tmp/
 

--- a/docs/src/user_reference.md
+++ b/docs/src/user_reference.md
@@ -2,12 +2,14 @@
 
 There are really only three functions that a user would be expected to call manually:
 `revise`, `includet`, and `Revise.track`.
-Other user-level constructs might apply if you want to exclude Revise from watching specific packages.
+Other user-level constructs might apply if you want to debug Revise or
+prevent it from watching specific packages.
 
 ```@docs
 revise
 Revise.track
 includet
+Revise.debug_logger
 Revise.dont_watch_pkgs
 Revise.silence
 ```

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -209,6 +209,7 @@ end
 function eval_revised!(fmmrep::FMMaps, mod::Module,
                        fmmnew::FMMaps, fmmref::FMMaps)
     # Update to the state of fmmnew, preventing any unnecessary evaluation
+    @debug "Diff" _group="Parsing" activemodule=mod newexprs=setdiff(keys(fmmnew.defmap), keys(fmmref.defmap)) oldexprs=setdiff(keys(fmmref.defmap), keys(fmmnew.defmap))
     for (def,val) in fmmnew.defmap
         @assert def != nothing
         defref = getkey(fmmref.defmap, def, nothing)

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -798,6 +798,41 @@ function async_steal_repl_backend()
     return nothing
 end
 
+"""
+    logger = Revise.debug_logger()
+
+Turn on [debug logging](https://docs.julialang.org/en/stable/stdlib/Logging/) and return the logger object.
+`logger.logs` contains a list of the logged events. The items in this list are of type `Test.LogRecord`,
+with the following relevant fields:
+
+- `group`: the event category. Revise currently uses the following groups:
+  + "Action": a change was implemented, of type described in the `message` field.
+  + "Parsing": a "significant" event in parsing. For these, examine the `message` field
+    for more information.
+  + "Watching": an indication that Revise determined that a particular file needed to be
+    examined for possible code changes. This is typically done on the basis of `mtime`,
+    the modification time of the file, and does not necessarily indicate that there were
+    any changes.
+- `message`: a string containing more information. Some examples:
+  + For entries in the "Action" group, `message` can be `"Eval"` when modifying
+    old methods or defining new ones, "DeleteMethod" when deleting a method,
+    and "LineOffset" to indicate that the line offset for a method
+    was updated (the last only affects the printing of stacktraces upon error,
+    it does not change how code runs)
+  + Items with group "Parsing" and message "Diff" contain sets `:newexprs` and `:oldexprs`
+    that contain the expression unique to post- or pre-revision, respectively.
+- `kwargs`: a pairs list of any other data. This is usually specific to particular `group`/`message`
+  combinations.
+
+Note that the logs may also contain information from sources other than Revise.
+"""
+function debug_logger()
+    @eval using Test
+    rlogger = Test.TestLogger(min_level=CoreLogging.Debug)
+    CoreLogging.global_logger(rlogger)
+    return rlogger
+end
+
 function __init__()
     # Base.register_root_module(Base.__toplevel__)
     if isfile(silencefile[])

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -209,7 +209,7 @@ end
 function eval_revised!(fmmrep::FMMaps, mod::Module,
                        fmmnew::FMMaps, fmmref::FMMaps)
     # Update to the state of fmmnew, preventing any unnecessary evaluation
-    @debug "Diff" _group="Parsing" activemodule=mod newexprs=setdiff(keys(fmmnew.defmap), keys(fmmref.defmap)) oldexprs=setdiff(keys(fmmref.defmap), keys(fmmnew.defmap))
+    @debug "Diff" _group="Parsing" activemodule=fullname(mod) newexprs=setdiff(keys(fmmnew.defmap), keys(fmmref.defmap)) oldexprs=setdiff(keys(fmmref.defmap), keys(fmmnew.defmap))
     for (def,val) in fmmnew.defmap
         @assert def != nothing
         defref = getkey(fmmref.defmap, def, nothing)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -166,7 +166,7 @@ module is "parented" by `mod`. Source-code expressions are added to
 function parse_module!(fm::FileModules, ex::Expr, file::Symbol, mod::Module)
     newname = _module_name(ex)
     if mod != Base.__toplevel__ && !isdefined(mod, newname)
-        @debug "parse_module" _group="Parsing" activemodule=mod newmodule=newname
+        @debug "parse_module" _group="Parsing" activemodule=fullname(mod) newmodule=fullname(newname)
         try
             Core.eval(mod, ex) # support creating new submodules
         catch

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -166,6 +166,7 @@ module is "parented" by `mod`. Source-code expressions are added to
 function parse_module!(fm::FileModules, ex::Expr, file::Symbol, mod::Module)
     newname = _module_name(ex)
     if mod != Base.__toplevel__ && !isdefined(mod, newname)
+        @debug "parse_module" _group="Parsing" activemodule=mod newmodule=newname
         try
             Core.eval(mod, ex) # support creating new submodules
         catch

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -22,6 +22,7 @@ function track(mod::Module)
             push!(fileinfos, filename=>FileInfo(submod, basesrccache))
             push!(files, filename)
             if mtime(filename) > mtcache
+                @debug "Recipe for Base" _group="Watching" filename=filename mtime=mtime(filename) mtimeref=mtcache
                 push!(revision_queue, filename)
             end
         end

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -68,7 +68,7 @@ Base.hash(x::RelocatableExpr, h::UInt) = hash(LineSkippingIterator(x.args),
                                               hash(x.head, h + hashrex_seed))
 
 function Base.show(io::IO, rex::RelocatableExpr)
-    rexf = striplines!(deepcopy(rex))
+    rexf = striplines!(copy(rex))
     show(io, convert(Expr, rexf))
 end
 

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -139,16 +139,13 @@ function Base.isequal(itera::LineSkippingIterator, iterb::LineSkippingIterator)
 end
 
 const hashlsi_seed = UInt == UInt64 ? 0x533cb920dedccdae : 0x2667c89b
-const gensymmed_rex = r"(^##([^#]+)#|^#\d+#([^#]+))"
 function Base.hash(iter::LineSkippingIterator, h::UInt)
     h += hashlsi_seed
     for x in iter
         if x isa Symbol
-            # For gensymmed symbols, hash on the "base" name
             xs = String(x)
-            if startswith(xs, '#')
-                c = match(gensymmed_rex, xs).captures
-                h += hash(c[3] == nothing ? c[2] : c[3], h)
+            if startswith(xs, '#')  # all gensymmed symbols are treated as identical
+                h += hash("gensym", h)
                 continue
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -341,8 +341,9 @@ k(x) = 4
         @test isequal(rex1, rex2)
         @test hash(rex1) == hash(rex2)
         sym3 = gensym(:world)
-        @test !isequal(rex1, rex3)
-        @test hash(rex1) != hash(rex3)
+        rex3 = Revise.relocatable!(:(x = $sym3))
+        @test isequal(rex1, rex3)
+        @test hash(rex1) == hash(rex3)
     end
 
     @testset "Macros" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,6 +326,23 @@ k(x) = 4
         cmpdiff(logs[1], "Eval"; deltainfo=(ReviseTest, Revise.relocatable!(:(cube(x) = error("cube")))))
         cmpdiff(logs[2], "Eval"; deltainfo=(ReviseTest.Internal, Revise.relocatable!(:(mult2(x) = error("mult2")))))
         global_logger(stdlogger)
+
+        # Gensymmed symbols
+        rex1 = Revise.relocatable!(macroexpand(Main, :(t = @elapsed(foo(x)))))
+        rex2 = Revise.relocatable!(macroexpand(Main, :(t = @elapsed(foo(x)))))
+        @test isequal(rex1, rex2)
+        @test hash(rex1) == hash(rex2)
+        rex3 = Revise.relocatable!(macroexpand(Main, :(t = @elapsed(bar(x)))))
+        @test !isequal(rex1, rex3)
+        @test hash(rex1) != hash(rex3)
+        sym1, sym2 = gensym(:hello), gensym(:hello)
+        rex1 = Revise.relocatable!(:(x = $sym1))
+        rex2 = Revise.relocatable!(:(x = $sym2))
+        @test isequal(rex1, rex2)
+        @test hash(rex1) == hash(rex2)
+        sym3 = gensym(:world)
+        @test !isequal(rex1, rex3)
+        @test hash(rex1) != hash(rex3)
     end
 
     @testset "Macros" begin


### PR DESCRIPTION
This may fix #161. The log suggests that most or all of the revised expressions used gensymmed symbols. This PR should make them compare (and hash) as equal.

This also adds a little more debug info.