### PR TITLE
Create our own custom logger

### DIFF
--- a/docs/src/user_reference.md
+++ b/docs/src/user_reference.md
@@ -9,7 +9,19 @@ prevent it from watching specific packages.
 revise
 Revise.track
 includet
+```
+
+### Revise logs (debugging Revise)
+
+```@docs
 Revise.debug_logger
+Revise.actions
+Revise.diffs
+```
+
+### Prevent Revise from watching specific packages
+
+```@docs
 Revise.dont_watch_pkgs
 Revise.silence
 ```

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,0 +1,122 @@
+using Base.CoreLogging
+using Base.CoreLogging: Info, Debug
+
+struct LogRecord
+    level
+    message
+    group
+    id
+    file
+    line
+    kwargs
+end
+LogRecord(args...; kwargs...) = LogRecord(args..., kwargs)
+
+mutable struct ReviseLogger <: AbstractLogger
+    logs::Vector{LogRecord}
+    min_level::LogLevel
+end
+
+ReviseLogger(; min_level=Info) = ReviseLogger(LogRecord[], min_level)
+
+CoreLogging.min_enabled_level(logger::ReviseLogger) = logger.min_level
+
+CoreLogging.shouldlog(logger::ReviseLogger, level, _module, group, id) = _module == Revise
+
+function CoreLogging.handle_message(logger::ReviseLogger, level, msg, _module,
+                                    group, id, file, line; kwargs...)
+    push!(logger.logs, LogRecord(level, msg, group, id, file, line, kwargs))
+end
+
+CoreLogging.catch_exceptions(::ReviseLogger) = false
+
+function Base.show(io::IO, l::LogRecord)
+    print(io, LogRecord)
+    print(io, '(', l.level, ", ", l.message, ", ", l.group, ", ", l.id, ", \"", l.file, "\", ", l.line)
+    if !isempty(l.kwargs)
+        print(io, ", (")
+        prefix = ""
+        for (kw, val) in l.kwargs
+            print(io, prefix, kw, "=", val)
+            prefix = ", "
+        end
+        print(io, ')')
+    end
+    print(io, ')')
+end
+
+const _debug_logger = ReviseLogger()
+
+"""
+    logger = Revise.debug_logger(; min_level=Debug)
+
+Turn on [debug logging](https://docs.julialang.org/en/stable/stdlib/Logging/)
+(if `min_level` is set to `Debug` or better) and return the logger object.
+`logger.logs` contains a list of the logged events. The items in this list are of type `Revise.LogRecord`,
+with the following relevant fields:
+
+- `group`: the event category. Revise currently uses the following groups:
+  + "Action": a change was implemented, of type described in the `message` field.
+  + "Parsing": a "significant" event in parsing. For these, examine the `message` field
+    for more information.
+  + "Watching": an indication that Revise determined that a particular file needed to be
+    examined for possible code changes. This is typically done on the basis of `mtime`,
+    the modification time of the file, and does not necessarily indicate that there were
+    any changes.
+- `message`: a string containing more information. Some examples:
+  + For entries in the "Action" group, `message` can be `"Eval"` when modifying
+    old methods or defining new ones, "DeleteMethod" when deleting a method,
+    and "LineOffset" to indicate that the line offset for a method
+    was updated (the last only affects the printing of stacktraces upon error,
+    it does not change how code runs)
+  + Items with group "Parsing" and message "Diff" contain sets `:newexprs` and `:oldexprs`
+    that contain the expression unique to post- or pre-revision, respectively.
+- `kwargs`: a pairs list of any other data. This is usually specific to particular `group`/`message`
+  combinations.
+
+See also [`Revise.actions`](@ref) and [`Revise.diffs`](@ref).
+"""
+function debug_logger(; min_level=Debug)
+    _debug_logger.min_level = min_level
+    return _debug_logger
+end
+
+"""
+    actions(logger; line=false)
+
+Return a vector of all log events in the "Action" group. "LineOffset" events are returned
+only if `line=true`; by default the returned items are the events that modified
+methods in your session.
+"""
+function actions(logger::ReviseLogger; line=false)
+    filter(logger.logs) do r
+        r.group=="Action" && (line || r.message!="LineOffset")
+    end
+end
+
+"""
+    diffs(logger)
+
+Return a vector of all log events that encode a (non-empty) diff between two versions of a file.
+"""
+function diffs(logger::ReviseLogger)
+    filter(logger.logs) do r
+        r.message=="Diff" && r.group=="Parsing" && (!isempty(r.kwargs[:newexprs]) || !isempty(r.kwargs[:oldexprs]))
+    end
+end
+
+## Make the logs portable
+
+"""
+    MethodSummary(method)
+
+Create a portable summary of a method. In particular, a MethodSummary can be saved to a JLD2 file.
+"""
+struct MethodSummary
+    name::Symbol
+    modulename::Symbol
+    file::Symbol
+    line::Int32
+    sig::Type
+end
+MethodSummary(m::Method) = MethodSummary(m.name, nameof(m.module), m.file, m.line, m.sig)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -166,7 +166,9 @@ module is "parented" by `mod`. Source-code expressions are added to
 function parse_module!(fm::FileModules, ex::Expr, file::Symbol, mod::Module)
     newname = _module_name(ex)
     if mod != Base.__toplevel__ && !isdefined(mod, newname)
-        @debug "parse_module" _group="Parsing" activemodule=fullname(mod) newmodule=fullname(newname)
+        with_logger(_debug_logger) do
+            @debug "parse_module" _group="Parsing" activemodule=fullname(mod) newmodule
+        end
         try
             Core.eval(mod, ex) # support creating new submodules
         catch

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -22,7 +22,9 @@ function track(mod::Module)
             push!(fileinfos, filename=>FileInfo(submod, basesrccache))
             push!(files, filename)
             if mtime(filename) > mtcache
-                @debug "Recipe for Base" _group="Watching" filename=filename mtime=mtime(filename) mtimeref=mtcache
+                with_logger(_debug_logger) do
+                    @debug "Recipe for Base" _group="Watching" filename=filename mtime=mtime(filename) mtimeref=mtcache
+                end
                 push!(revision_queue, filename)
             end
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -132,17 +132,3 @@ end
 function Base.showerror(io::IO, ex::GitRepoException)
     print(io, "no repository at ", ex.filename, " to track stdlibs you must build Julia from source")
 end
-
-"""
-    MethodSummary(method)
-
-Create a portable summary of a method. In particular, a MethodSummary can be saved to a JLD2 file.
-"""
-struct MethodSummary
-    name::Symbol
-    modulename::Symbol
-    file::Symbol
-    line::Int32
-    sig::Type
-end
-MethodSummary(m::Method) = MethodSummary(m.name, nameof(m.module), m.file, m.line, m.sig)


### PR DESCRIPTION
It turns out that using TestLogger interacted with `@testset`. Consequently, it's better to use something completely independent. The overall design of the logger mimics that of TestLogger.

This also adds some convenience utilities and nicer printing. Overall it makes it considerably nicer to collect and inspect logs.
