### PR TITLE
Prevent spurious re-evaluation of more docstrings

### DIFF
--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -107,6 +107,8 @@ function skip_to_nonline(args, i)
             i += 1
         elseif isa(ex, LineNumberNode)
             i += 1
+        elseif isa(ex, Pair) && (ex::Pair).first == :linenumber     # used in the doc system
+            i += 1
         else
             return i
         end

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -109,6 +109,8 @@ function skip_to_nonline(args, i)
             i += 1
         elseif isa(ex, Pair) && (ex::Pair).first == :linenumber     # used in the doc system
             i += 1
+        elseif isa(ex, Base.RefValue) && !isdefined(ex, :x)         # also in the doc system
+            i += 1
         else
             return i
         end

--- a/test/revisetest.jl
+++ b/test/revisetest.jl
@@ -12,6 +12,11 @@ mult2(x) = 2*x
 mult3(x) = 4*x  # oops
 mult4(x) = -x
 
+"""
+This has a docstring
+"""
+unchanged(x) = x
+
 end  # Internal
 
 end  # ReviseTest

--- a/test/revisetest_errors.jl
+++ b/test/revisetest_errors.jl
@@ -13,6 +13,11 @@ module Internal
 mult2(x) = error("mult2")
 mult3(x) = 3*x
 
+"""
+This has a docstring
+"""
+unchanged(x) = x
+
 end  # Internal
 
 end

--- a/test/revisetest_revised.jl
+++ b/test/revisetest_revised.jl
@@ -13,6 +13,11 @@ module Internal
 mult2(x) = 2*x
 mult3(x) = 3*x
 
+"""
+This has a docstring
+"""
+unchanged(x) = x
+
 end  # Internal
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -747,6 +747,17 @@ end
         pop!(LOAD_PATH)
     end
 
+    @testset "Undef in docstrings" begin
+        fn = Base.find_source_file("abstractset.jl")   # has lots of examples of """str""" func1, func2
+        oldmd = Revise.parse_source(fn, Base)
+        newmd = Revise.parse_source(fn, Base)
+        odict = oldmd[Base].defmap
+        ndict = newmd[Base].defmap
+        for (k, v) in odict
+            @test haskey(ndict, k)
+        end
+    end
+
     @testset "Line numbers" begin
         # issue #27
         testdir = randtmp()


### PR DESCRIPTION
I am guessing this *should* fix #161 (CC @pfitzseb). In any event I can verify that it is an improvement even on my own machine, so even if this doesn't fix #161 I am confident we want this.