### PR TITLE
Detect changes in performance annotations (fixes #165)

### DIFF
--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -3,7 +3,6 @@
 using Core: MethodInstance
 using Base: MethodList
 
-const ExLike = Union{Expr,RelocatableExpr}
 const poppable_macro = (Symbol("@inline"), Symbol("@noinline"), Symbol("@propagate_inbounds"), Symbol("@eval"))
 
 """

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -28,6 +28,8 @@ mutable struct RelocatableExpr
     RelocatableExpr(head::Symbol, args...) = new(head, [args...])
 end
 
+const ExLike = Union{Expr,RelocatableExpr}
+
 # Works in-place and hence is unsafe. Only for internal use.
 Base.convert(::Type{RelocatableExpr}, ex::Expr) = relocatable!(ex)
 


### PR DESCRIPTION
I'm not quite sure if and when this changed (it clearly wasn't being tested), but a prime suspect is the switch to computing signature types. At any rate, this fixes the problem and adds good tests so this won't regress.

CC @quinnj.