### PR TITLE
Optionally return the list of modified files from Revise.track(Base)

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -592,7 +592,7 @@ Return the RelocatableExpr defining `method`.
 The source-file defining `method` must be tracked.
 If it is in Base, this will execute `track(Base)` if necessary.
 """
-function get_def(method::Method)
+function get_def(method::Method; modified_files=revision_queue)
     filename = String(method.file)
     yield()   # magic bug fix for the OSX test failures. TODO: figure out why this works (prob. Julia bug)
     startswith(filename, "REPL") && error("methods defined at the REPL are not yet supported")
@@ -623,7 +623,7 @@ function get_def(method::Method)
     filename isa AbstractString || return nothing
     if !haskey(fileinfos, filename)
         @info "tracking $recipemod"
-        track(recipemod)
+        track(recipemod; modified_files=modified_files)
     end
     fi = fileinfos[filename]
     maybe_parse_from_cache!(fi, filename)

--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -75,7 +75,7 @@ julia> Revise.get_signature(quote
 """
 function get_signature(ex::E) where E <: ExLike
     if ex.head == :macrocall
-        error("macros must be handled externally")
+        error("macros must be handled externally, got $ex")
     end
     if is_trivial_block_wrapper(ex)
         return get_signature(ex.args[end])


### PR DESCRIPTION
This should fix #168 by ~~basically having Revise ignore changes to Base files unless the user has a source-build of Julia. Since we'd like to have them commit their improvements back to Base anyway, this is just incentive for good behavior :smile:.~~
allowing the caller to choose whether to process the files that trigger the `mtime` criterion.

@pfitzseb, does this fix #168 for you?