### PR TITLE
Add a few precompiles for faster startup

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -197,7 +197,7 @@ function watch_package(id::PkgId)
     @async _watch_package(id)
 end
 
-function _watch_package(id::PkgId)
+@noinline function _watch_package(id::PkgId)
     modsym = Symbol(id.name)
     if modsym ∈ dont_watch_pkgs
         if modsym ∉ silence_pkgs
@@ -208,4 +208,5 @@ function _watch_package(id::PkgId)
     end
     files = parse_pkg_files(id)
     init_watching(files)
+    nothing
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,15 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+
+    precompile(Tuple{typeof(setindex!), typeof(fileinfos), FileInfo, String})
+    precompile(Tuple{typeof(setindex!), typeof(module2files), Vector{String}, Symbol})
+    precompile(Tuple{typeof(setindex!), typeof(watched_files), WatchList, String})
+    precompile(Tuple{typeof(haskey), typeof(watched_files), String})
+
+    precompile(Tuple{typeof(_watch_package), Base.PkgId})
+    precompile(Tuple{typeof(revise_dir_queued), String})
+    precompile(Tuple{typeof(run_backend), REPL.REPLBackend})
+    precompile(Tuple{typeof(steal_repl_backend), REPL.REPLBackend})
+
+    return nothing
+end


### PR DESCRIPTION
This also reorganizes some functions to make them more precompile-friendly.

On my machine this drops the time for `@time (using Revise; revise())` from 3.1 seconds to 1.5 seconds. I'd like to get it even lower, but this is a worthy step forward.