### PR TITLE
 Fix module scoping in call to sig_type_exprs (fixes #183) 

### DIFF
--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -98,7 +98,7 @@ function sigex2sigts(mod::Module, sig::ExLike, def=nothing)
     # Generate the signature-types
     local sigtexs
     try
-        sigtexs = sig_type_exprs(sig)
+        sigtexs = sig_type_exprs(mod, sig)
     catch err
         sigwarn(mod, sig, def)
         rethrow(err)

--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -183,7 +183,6 @@ function sig_type_exprs(mod::Module, sigex::Expr, wheres...)
     return reverse!(typexs)  # method table is organized in increasing # of args
 end
 sig_type_exprs(mod::Module, sigex::RelocatableExpr) = sig_type_exprs(mod, convert(Expr, sigex))
-sig_type_exprs(ex::ExLike) = sig_type_exprs(Main, ex)
 
 function _sig_type_exprs(mod::Module, ex, @nospecialize(wheres))
     fex = ex.args[1]

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,4 @@
 Example
 RecipesBase
 Plots
+EponymTuples

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -600,6 +600,8 @@ end
         end
         yry()
         @test Mysupermodule.Mymodule.func() == 2
+        rm_precompile("Mymodule")
+        rm_precompile("Mysupermodule")
 
         # Test files paths that can't be statically parsed
         dn = joinpath(testdir, "LoopInclude", "src")
@@ -636,6 +638,7 @@ end
         yry()
         @test li_f() == -1
 
+        rm_precompile("LoopInclude")
         pop!(LOAD_PATH)
     end
 
@@ -692,6 +695,7 @@ end
         yry()
         @test ModFILE.mf() == (joinpath(dn, "ModFILE.jl"), 2)
         rm_precompile("ModFILE")
+        pop!(LOAD_PATH)
     end
 
     # issue #8
@@ -758,7 +762,7 @@ end
         @test ModDocstring.f() == 3
         ds = @doc(ModDocstring)
         @test get_docstring(ds) == "Hello! "
-
+        rm_precompile("ModDocstring")
         pop!(LOAD_PATH)
     end
 
@@ -860,6 +864,7 @@ end
         @test ex0 == Revise.relocatable!(:(@propagate_inbounds @inline foo(x) = 1))
         @test ex1 == Revise.relocatable!(:(foo(x) = 1))
         @test Revise.get_signature(ex1) == Revise.relocatable!(:(foo(x)))
+        pop!(LOAD_PATH)
     end
 
     @testset "Revising macros" begin
@@ -918,6 +923,8 @@ end
         @test MacroRevision.foo("hello") == 2
         revise(MacroRevision)
         @test MacroRevision.foo("hello") == 3
+        rm_precompile("MacroRevision")
+        pop!(LOAD_PATH)
     end
 
     @testset "Line numbers" begin
@@ -993,6 +1000,8 @@ foo(y::Int) = y-51
             @test endswith(string(m.file), "incl.jl")
             @test m.line ∈ lines
         end
+        rm_precompile("LineNumberMod")
+        pop!(LOAD_PATH)
     end
 
     # Issue #43
@@ -1027,6 +1036,8 @@ end
         yry()
         @test Submodules.f() == 1
         @test Submodules.Sub.g() == 2
+        rm_precompile("Submodules")
+        pop!(LOAD_PATH)
     end
 
     @testset "Method deletion" begin
@@ -1175,6 +1186,7 @@ end
         finally
             Revise.silencefile[] = sfile
         end
+        pop!(LOAD_PATH)
     end
 
     @testset "Manual track" begin
@@ -1308,6 +1320,8 @@ end
             @test_throws RemoteException remotecall_fetch(ReviseDistributed.g, p, 1)
         end
         rmprocs(allworkers[2:3]...; waitfor=10)
+        rm_precompile("ReviseDistributed")
+        pop!(LOAD_PATH)
     end
 
     @testset "Git" begin
@@ -1371,6 +1385,8 @@ end
             end
             @test haskey(Revise.fileinfos, mainjl)
             @test startswith(logs[1].message, "skipping src/extra.jl")
+            rm_precompile("ModuleWithNewFile")
+            pop!(LOAD_PATH)
         end
     end
 


### PR DESCRIPTION
The important change here is [a single line](https://github.com/timholy/Revise.jl/compare/teh/fix_183?expand=1#diff-e017b612ac9926c6c378bf32adf520b3R101), but I took the occasion to throw in a few more improvements. In particular, EponymTuples is now a test-dependency of Revise, which may make it easier to ensure we continue to support it.

I was not able to replicate the exact error in #183, can you test @tpapp?