### PR TITLE
Compare signatures using RelocatableExpr

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -218,6 +218,7 @@ function eval_revised!(fmmrep::FMMaps, mod::Module,
         oldsigs, newsigs = filter_signatures(mod, keys(fmmref.defmap)), filter_signatures(mod, keys(fmmnew.defmap))
         for sig in oldsigs
             sig ∈ newsigs && continue
+            @debug "DiffSig" _group="Parsing" activemodule=fullname(mod) missingsig=sig newsigs=newsigs
             for sigt in sigex2sigts(mod, sig)
                 m = get_method(sigt)
                 if isa(m, Method)
@@ -261,7 +262,7 @@ function eval_revised!(fmmrep::FMMaps, mod::Module,
 end
 
 function filter_signatures(mod::Module, defs)
-    sigs = Set{Expr}()
+    sigs = Set{RelocatableExpr}()
     for def in defs
         while is_trivial_block_wrapper(def)
             def = def.args[end]
@@ -274,7 +275,7 @@ function filter_signatures(mod::Module, defs)
         def.head == :function || def.head == :(=) || continue
         sig = get_signature(def)
         sig isa ExLike || continue
-        push!(sigs, convert(Expr, sig))
+        push!(sigs, relocatable!(sig))
     end
     return sigs
 end

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -36,6 +36,7 @@ Base.convert(::Type{RelocatableExpr}, ex::Expr) = relocatable!(ex)
 function relocatable!(ex::Expr)
     return RelocatableExpr(ex.head, relocatable!(ex.args))
 end
+relocatable!(ex::RelocatableExpr) = ex
 
 function relocatable!(args::Vector{Any})
     for (i, a) in enumerate(args)

--- a/test/revisetest.jl
+++ b/test/revisetest.jl
@@ -17,6 +17,8 @@ This has a docstring
 """
 unchanged(x) = x
 
+unchanged2(@nospecialize(x)) = x
+
 end  # Internal
 
 end  # ReviseTest

--- a/test/revisetest_errors.jl
+++ b/test/revisetest_errors.jl
@@ -18,6 +18,8 @@ This has a docstring
 """
 unchanged(x) = x
 
+unchanged2(@nospecialize(x)) = x
+
 end  # Internal
 
 end

--- a/test/revisetest_revised.jl
+++ b/test/revisetest_revised.jl
@@ -18,6 +18,8 @@ This has a docstring
 """
 unchanged(x) = x
 
+unchanged2(@nospecialize(x)) = x
+
 end  # Internal
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -293,7 +293,7 @@ k(x) = 4
         @test revmd[ReviseTest].sigtmap[Tuple{typeof(ReviseTest.fourth),Any}] == def
 
         dvs = collect(revmd[ReviseTest.Internal].defmap)
-        @test length(dvs) == 4
+        @test length(dvs) == 5
         (def, val) = dvs[1]
         @test isequal(def,  Revise.relocatable!(:(mult2(x) = 2*x)))
         @test val == (DataType[Tuple{typeof(ReviseTest.Internal.mult2),Any}], 2)  # 2 because it shifted down 2 lines and was not evaled
@@ -318,15 +318,16 @@ k(x) = 4
             return nothing
         end
         logs = filter(r->r.level==Debug && r.group=="Action", rlogger.logs)
-        @test length(logs) == 6
+        @test length(logs) == 7
         cmpdiff(logs[1], "Eval"; deltainfo=(ReviseTest, Revise.relocatable!(:(cube(x) = x^3))))
         cmpdiff(logs[2], "Eval"; deltainfo=(ReviseTest, Revise.relocatable!(:(fourth(x) = x^4))))
         cmpdiff(logs[3], "DeleteMethod"; deltainfo=(Tuple{typeof(ReviseTest.Internal.mult4),Any}, MethodSummary(delmeth)))
         cmpdiff(logs[4], "LineOffset"; deltainfo=(Any[Tuple{typeof(ReviseTest.Internal.mult2),Any}], 13, 0 => 2))
         cmpdiff(logs[5], "Eval"; deltainfo=(ReviseTest.Internal, Revise.relocatable!(:(mult3(x) = 3*x))))
         cmpdiff(logs[6], "LineOffset"; deltainfo=(Any[Tuple{typeof(ReviseTest.Internal.unchanged),Any}], 19, 0 => 1))
+        cmpdiff(logs[7], "LineOffset"; deltainfo=(Any[Tuple{typeof(ReviseTest.Internal.unchanged2),Any}], 21, 0 => 1))
         @test length(Revise.actions(rlogger)) == 4  # by default LineOffset is skipped
-        @test length(Revise.actions(rlogger; line=true)) == 6
+        @test length(Revise.actions(rlogger; line=true)) == 7
         @test length(Revise.diffs(rlogger)) == 2
         empty!(rlogger.logs)
 
@@ -399,7 +400,7 @@ k(x) = 4
         @test str == ":(@inbounds x[2])"
         fm = Revise.parse_source(joinpath(@__DIR__, "revisetest.jl"), Main)
         Revise.instantiate_sigs!(fm)
-        @test string(fm) == "OrderedCollections.OrderedDict(Main=>FMMaps(<1 expressions>, <0 signatures>),Main.ReviseTest=>FMMaps(<2 expressions>, <2 signatures>),Main.ReviseTest.Internal=>FMMaps(<5 expressions>, <4 signatures>))"
+        @test string(fm) == "OrderedCollections.OrderedDict(Main=>FMMaps(<1 expressions>, <0 signatures>),Main.ReviseTest=>FMMaps(<2 expressions>, <2 signatures>),Main.ReviseTest.Internal=>FMMaps(<6 expressions>, <5 signatures>))"
         fmmr = fm[ReviseTest]
         @test string(fmmr) == "FMMaps(<2 expressions>, <2 signatures>)"
         io = IOBuffer()


### PR DESCRIPTION
This fixes a rare bug in which a method got deleted without replacing it. It arose from the asymmetry of comparing defs and sigs.

This also logs the signature diff in case something like this happens again.
