### PR TITLE
Use type intersection to match signatures to those of methods

### DIFF
--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -113,6 +113,18 @@ function sigex2sigts(mod::Module, sig::ExLike, def=nothing)
     return sigts
 end
 
+"""
+    methsig = sigt2methsig(sig)
+
+For a signature `sig`, try to return the signature `methsig` of a currently-defined method.
+"""
+function sigt2methsig(sig)
+    ret = Base._methods_by_ftype(sig, -1, typemax(UInt))
+    isempty(ret) && return sig
+    methsig = ret[end][3].sig  # the last method returned is the least-specific that matches, and thus most likely to be type-equal
+    @assert sig <: methsig && methsig <: sig
+    return methsig
+end
 
 """
     callex = get_callexpr(sigex::ExLike)


### PR DESCRIPTION
This allows `get_def` to succeed with many more methods (with respect to Base, about 700 more methods). In particular, it finally supports methods with signatures like `f(a::AbstractVector{<:Integer})`, which has formerly been a real limitation for Rebugger.

The downside is it may slow Revise down a bit (for the cost of running type-intersection), but in playing with this locally I haven't noticed any real problems.