### PR TITLE
Follow switches between `free` and `dev`

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -23,11 +23,10 @@ Revise.basebuilddir
 ### Internal state management
 
 ```@docs
+Revise.pkgdatas
 Revise.watched_files
 Revise.revision_queue
 Revise.included_files
-Revise.fileinfos
-Revise.module2files
 ```
 
 ## Types
@@ -39,6 +38,7 @@ Revise.SigtMap
 Revise.FMMaps
 Revise.FileModules
 Revise.FileInfo
+Revise.PkgData
 Revise.WatchList
 MethodSummary
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,6 +41,15 @@ julia> Example.f()
 π = 3.1415926535897...
 ```
 
+Revise updates its internal paths when you change versions of a package. For example:
+
+```julia
+(v1.0) pkg> free Example   # switch to the released version of Example
+
+julia> Example.f()
+ERROR: UndefVarError: f not defined
+```
+
 Revise is not tied to any particular editor.
 (The [EDITOR or JULIA_EDITOR](https://docs.julialang.org/en/latest/stdlib/InteractiveUtils/#InteractiveUtils.edit-Tuple{AbstractString,Integer}) environment variables can be used to specify your preference.)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,7 @@ This can save you the overhead of restarting, loading packages, and waiting for 
 You can obtain Revise using Julia's Pkg REPL-mode (hitting `]` as the first character of the command prompt):
 
 ```julia
-(v0.7) pkg> add Revise
+(v1.0) pkg> add Revise
 ```
 
 or with `using Pkg; Pkg.add("Revise")`.
@@ -20,7 +20,7 @@ or with `using Pkg; Pkg.add("Revise")`.
 ## Usage example
 
 ```julia
-(v0.7) pkg> dev Example
+(v1.0) pkg> dev Example
 [...output related to installation...]
 
 julia> using Revise        # importantly, this must come before `using Example`

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,13 +1,13 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
 
-    precompile(Tuple{typeof(setindex!), typeof(fileinfos), FileInfo, String})
-    precompile(Tuple{typeof(setindex!), typeof(module2files), Vector{String}, Symbol})
+    precompile(Tuple{typeof(setindex!), typeof(pkgdatas), PkgData, PkgId})
+    precompile(Tuple{typeof(setindex!), Dict{String,FileInfo}, FileInfo, String})
     precompile(Tuple{typeof(setindex!), typeof(watched_files), WatchList, String})
     precompile(Tuple{typeof(haskey), typeof(watched_files), String})
 
     precompile(Tuple{typeof(_watch_package), Base.PkgId})
-    precompile(Tuple{typeof(revise_dir_queued), String})
+    precompile(Tuple{typeof(revise_dir_queued), PkgData, String})
     precompile(Tuple{typeof(run_backend), REPL.REPLBackend})
     precompile(Tuple{typeof(steal_repl_backend), REPL.REPLBackend})
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -81,6 +81,9 @@ end
 
 # For tracking subdirectories of Julia itself (base/compiler, stdlibs)
 function track_subdir_from_git(id::PkgId, subdir::AbstractString; commit=Base.GIT_VERSION_INFO.commit, modified_files=revision_queue)
+    if !haskey(pkgdatas, id)
+        pkgdatas[id] = PkgData(id)
+    end
     pkgdata = pkgdatas[id]
     # diff against files at the same commit used to build Julia
     repo, repo_path = git_repo(subdir)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -7,9 +7,11 @@ Track updates to the code in Julia's `base` directory, `base/compiler`, or one o
 standard libraries.
 """
 function track(mod::Module; modified_files=revision_queue)
+    id = PkgId(mod)
     if mod == Base
         # Test whether we know where to find the files
-        if !isdir(joinpath(juliadir, "base"))
+        basedir = fixpath(joinpath(juliadir, "base"))
+        if !isdir(basedir)
             @error "unable to find path containing Julia's base/ folder, tracking is not possible"
         end
         # Determine when the basesrccache was built
@@ -17,50 +19,69 @@ function track(mod::Module; modified_files=revision_queue)
         # Initialize expression-tracking for files, and
         # note any modified since Base was built
         files = String[]
+        if !haskey(pkgdatas, id)
+            pkgdatas[id] = PkgData(id, basedir)
+        end
+        pkgdata = pkgdatas[id]
         for (submod, filename) in Base._included_files
-            filename = fixpath(filename)
-            push!(fileinfos, filename=>FileInfo(submod, basesrccache))
-            push!(files, filename)
+            ffilename = fixpath(filename)
+            rpath = relpath(ffilename, basedir)
+            pkgdata.fileinfos[rpath] = FileInfo(submod, basesrccache)
+            push!(files, ffilename)
             if mtime(filename) > mtcache
                 with_logger(_debug_logger) do
                     @debug "Recipe for Base" _group="Watching" filename=filename mtime=mtime(filename) mtimeref=mtcache
                 end
-                push!(modified_files, filename)
+                push!(modified_files, (pkgdata, ffilename))
             end
         end
         # Add the files to the watch list
-        init_watching(files)
+        init_watching(pkgdata, files)
     elseif mod == Core.Compiler
-        compilerdir = joinpath(juliadir, "base", "compiler")
-        track_subdir_from_git(Core.Compiler, compilerdir; modified_files=modified_files)
+        compilerdir = normpath(joinpath(juliadir, "base", "compiler"))
+        if !haskey(pkgdatas, id)
+            pkgdatas[id] = PkgData(id, compilerdir)
+        end
+        track_subdir_from_git(id, compilerdir; modified_files=modified_files)
     elseif nameof(mod) ∈ stdlib_names
         stdlibdir = joinpath(juliadir, "stdlib")
-        libdir = joinpath(stdlibdir, String(nameof(mod)), "src")
-        track_subdir_from_git(mod, normpath(libdir); modified_files=modified_files)
+        libdir = normpath(joinpath(stdlibdir, String(nameof(mod)), "src"))
+        if !haskey(pkgdatas, id)
+            pkgdatas[id] = PkgData(id, libdir)
+        end
+        track_subdir_from_git(id, libdir; modified_files=modified_files)
     else
         error("no Revise.track recipe for module ", mod)
     end
-    nothing
+    return nothing
 end
 
 # Fix paths to files that define Julia (base and stdlibs)
 function fixpath(filename; badpath=basebuilddir, goodpath=juliadir)
-    isfile(filename) && return filename
+    startswith(filename, badpath) || return normpath(filename)
     filec = filename
-    startswith(filename, badpath) || error(filename, " does not start with ", badpath)
     relfilename = relpath(filename, badpath)
-    for strippath in (joinpath("usr", "share", "julia"),)
+    relfilename0 = relfilename
+    for strippath in (#joinpath("usr", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)"),
+                      joinpath("usr", "share", "julia"),)
         if startswith(relfilename, strippath)
             relfilename = relpath(relfilename, strippath)
+            if occursin("stdlib", relfilename0) && !occursin("stdlib", relfilename)
+                relfilename = joinpath("stdlib", relfilename)
+            end
         end
     end
-    filename = normpath(joinpath(goodpath, relfilename))
-    cache_file_key[filename] = filec
-    return filename
+    ffilename = normpath(joinpath(goodpath, relfilename))
+    if (isfile(filename) & !isfile(ffilename))
+        ffilename = normpath(filename)
+    end
+    cache_file_key[ffilename] = filec
+    return ffilename
 end
 
 # For tracking subdirectories of Julia itself (base/compiler, stdlibs)
-function track_subdir_from_git(mod::Module, subdir::AbstractString; commit=Base.GIT_VERSION_INFO.commit, modified_files=revision_queue)
+function track_subdir_from_git(id::PkgId, subdir::AbstractString; commit=Base.GIT_VERSION_INFO.commit, modified_files=revision_queue)
+    pkgdata = pkgdatas[id]
     # diff against files at the same commit used to build Julia
     repo, repo_path = git_repo(subdir)
     if repo == nothing
@@ -73,6 +94,7 @@ function track_subdir_from_git(mod::Module, subdir::AbstractString; commit=Base.
     wfiles = String[]  # files to watch
     for file in files
         fullpath = joinpath(repo_path, file)
+        rpath = relpath_safe(fullpath, pkgdata.path)  # this might undo the above, except for Core.Compiler
         local src
         try
             src = git_source(file, tree)
@@ -84,7 +106,7 @@ function track_subdir_from_git(mod::Module, subdir::AbstractString; commit=Base.
             rethrow(err)
         end
         if src != read(fullpath, String)
-            push!(modified_files, fullpath)
+            push!(modified_files, (pkgdata, rpath))
         end
         fmod = get(juliaf2m, fullpath, Core.Compiler)  # Core.Compiler is not cached
         fi = FileInfo(fmod)
@@ -93,10 +115,13 @@ function track_subdir_from_git(mod::Module, subdir::AbstractString; commit=Base.
         else
             instantiate_sigs!(fi.fm)
         end
-        fileinfos[fullpath] = fi
-        push!(wfiles, fullpath)
+        pkgdata.fileinfos[rpath] = fi
+        push!(wfiles, rpath)
     end
-    init_watching(wfiles)
+    if !isempty(pkgdata.fileinfos)
+        pkgdatas[id] = pkgdata
+        init_watching(pkgdata, wfiles)
+    end
     return nothing
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -127,7 +127,7 @@ FileInfo(mod::Module, cachefile::AbstractString="") = FileInfo(FileModules(mod),
 FileInfo(fm::FileModules, fi::FileInfo) = FileInfo(fm, fi.cachefile)
 
 """
-    PkgData(id, path, fileinfos::Dict{String,FileInfo})
+    PkgData(id, path, fileinfos::Dict{String,FileInfo}, [watchtasks::Vector{Pair{String,Task}}])
 
 A structure holding the data required to handle a particular package.
 `path` is the top-level directory defining the package,
@@ -142,8 +142,10 @@ mutable struct PkgData
     id::PkgId
     path::String
     fileinfos::Dict{String,FileInfo}
+    watchtasks::Vector{Pair{String,Task}}
 end
 
+PkgData(id::PkgId, path, fileinfos) = PkgData(id, path, fileinfos, Pair{String,Task}[])
 PkgData(id::PkgId, path) = PkgData(id, path, Dict{String,FileInfo}())
 PkgData(id::PkgId, ::Nothing) = PkgData(id, "")
 PkgData(id::PkgId) = PkgData(id, normpath(basepath(id)))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,8 @@
-function basepath(id::PkgId)
-    id.name ∈ ("Main", "Base", "Core") && return ""
-    loc = Base.locate_package(id)
-    loc === nothing && return ""
-    return dirname(dirname(loc))
-end
-
 relpath_safe(path, startpath) = isempty(startpath) ? path : relpath(path, startpath)
+
+function iswritable(file::AbstractString)  # note this trashes the Base definition, but we don't need it
+    return uperm(stat(file)) & 0x02 != 0x00
+end
 
 function use_compiled_modules()
     return Base.JLOptions().use_compiled_modules != 0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,71 @@
+function basepath(id::PkgId)
+    id.name ∈ ("Main", "Base", "Core") && return ""
+    loc = Base.locate_package(id)
+    loc === nothing && return ""
+    return dirname(dirname(loc))
+end
+
+relpath_safe(path, startpath) = isempty(startpath) ? path : relpath(path, startpath)
+
+function use_compiled_modules()
+    return Base.JLOptions().use_compiled_modules != 0
+end
+
+## WatchList utilities
+function systime()
+    tv = Libc.TimeVal()
+    tv.sec + tv.usec/10^6
+end
+function updatetime!(wl::WatchList)
+    wl.timestamp = systime()
+end
+Base.push!(wl::WatchList, filename) = push!(wl.trackedfiles, filename)
+WatchList() = WatchList(systime(), Set{String}())
+Base.in(file, wl::WatchList) = in(file, wl.trackedfiles)
+
+function macroreplace!(ex::Expr, filename)
+    for i = 1:length(ex.args)
+        ex.args[i] = macroreplace!(ex.args[i], filename)
+    end
+    if ex.head == :macrocall
+        m = ex.args[1]
+        if m == Symbol("@__FILE__")
+            return String(filename)
+        elseif m == Symbol("@__DIR__")
+            return dirname(String(filename))
+        end
+    end
+    return ex
+end
+macroreplace!(s, filename) = s
+
+function printf_maxsize(f::Function, io::IO, args...; maxchars::Integer=500, maxlines::Integer=20)
+    # This is dumb but certain to work
+    iotmp = IOBuffer()
+    for a in args
+        print(iotmp, a)
+    end
+    print(iotmp, '\n')
+    seek(iotmp, 0)
+    str = read(iotmp, String)
+    if length(str) > maxchars
+        str = first(str, (maxchars+1)÷2) * "…" * last(str, maxchars - (maxchars+1)÷2)
+    end
+    lines = split(str, '\n')
+    if length(lines) <= maxlines
+        for line in lines
+            f(io, line)
+        end
+        return
+    end
+    half = (maxlines+1) ÷ 2
+    for i = 1:half
+        f(io, lines[i])
+    end
+    maxlines > 1 && f(io, ⋮)
+    for i = length(lines) - (maxlines-half) + 1:length(lines)
+        f(io, lines[i])
+    end
+end
+println_maxsize(args...; kwargs...) = println_maxsize(stdout, args...; kwargs...)
+println_maxsize(io::IO, args...; kwargs...) = printf_maxsize(println, stdout, args...; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1466,11 +1466,11 @@ end
     end
 
     @testset "Git" begin
-        if haskey(ENV, "CI")   # if we're doing CI testing (Travis, Appveyor, etc.)
-            # First do a full git checkout of a package (we'll use Revise itself)
-            @warn "checking out a development copy of Revise for testing purposes"
-            pkg = Pkg.develop("Revise")
-        end
+        # if haskey(ENV, "CI")   # if we're doing CI testing (Travis, Appveyor, etc.)
+        #     # First do a full git checkout of a package (we'll use Revise itself)
+        #     @warn "checking out a development copy of Revise for testing purposes"
+        #     pkg = Pkg.develop("Revise")
+        # end
         loc = Base.find_package("Revise")
         if occursin("dev", loc)
             repo, path = Revise.git_repo(loc)


### PR DESCRIPTION
Switching between `free` and `dev` has become my main reason to restart Revise, so it's finally time to fix #146.

This is a breaking change. When tagged this will become Revise version 1.0.0.