### PR TITLE
Small reorganization to simplify porting Rebugger

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -79,7 +79,7 @@ function parse_pkg_files(id::PkgId)
                     end
                     pkgdata = pkgdatas[id]
                     for (mod, fname, _) in mods_files_mtimes
-                        fname = relpath_safe(fname, pkgdata.path)
+                        fname = relpath(fname, pkgdata)
                         # For precompiled packages, we can read the source later (whenever we need it)
                         # from the *.ji cachefile.
                         pkgdata.fileinfos[fname] = FileInfo(mod, path)
@@ -120,7 +120,7 @@ function queue_includes!(files, id::PkgId)
         if startswith(modname, modstring) || endswith(fname, modstring*".jl")
             fm = parse_source(fname, mod)
             instantiate_sigs!(fm)
-            fname = relpath_safe(fname, pkgdata.path)
+            fname = relpath(fname, pkgdata)
             if fm != nothing
                 pkgdata.fileinfos[fname] = FileInfo(fm)
             end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -97,7 +97,7 @@ function track_subdir_from_git(id::PkgId, subdir::AbstractString; commit=Base.GI
     wfiles = String[]  # files to watch
     for file in files
         fullpath = joinpath(repo_path, file)
-        rpath = relpath_safe(fullpath, pkgdata.path)  # this might undo the above, except for Core.Compiler
+        rpath = relpath(fullpath, pkgdata)  # this might undo the above, except for Core.Compiler
         local src
         try
             src = git_source(file, tree)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,15 @@
 relpath_safe(path, startpath) = isempty(startpath) ? path : relpath(path, startpath)
 
+function Base.relpath(filename, pkgdata::PkgData)
+    if isabspath(filename) && startswith(filename, pkgdata.path)
+        filename = relpath_safe(filename, pkgdata.path)
+    elseif startswith(filename, "compiler")
+        # Core.Compiler's pkgid includes "compiler/" in the path
+        filename = relpath(filename, "compiler")
+    end
+    return filename
+end
+
 function iswritable(file::AbstractString)  # note this trashes the Base definition, but we don't need it
     return uperm(stat(file)) & 0x02 != 0x00
 end


### PR DESCRIPTION
The new internal framework breaks Rebugger, but this makes it easier to update it.