### PR TITLE
Improve startup latency

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -40,6 +40,7 @@ Revise.FileModules
 Revise.FileInfo
 Revise.PkgData
 Revise.WatchList
+Revise.Rescheduler
 MethodSummary
 ```
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,15 +1,22 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
 
-    precompile(Tuple{typeof(setindex!), typeof(pkgdatas), PkgData, PkgId})
-    precompile(Tuple{typeof(setindex!), Dict{String,FileInfo}, FileInfo, String})
-    precompile(Tuple{typeof(setindex!), typeof(watched_files), WatchList, String})
-    precompile(Tuple{typeof(haskey), typeof(watched_files), String})
-
-    precompile(Tuple{typeof(_watch_package), Base.PkgId})
-    precompile(Tuple{typeof(revise_dir_queued), PkgData, String})
+    precompile(Tuple{typeof(watch_manifest), String})
     precompile(Tuple{typeof(run_backend), REPL.REPLBackend})
-    precompile(Tuple{typeof(steal_repl_backend), REPL.REPLBackend})
+    precompile(Tuple{typeof(Revise._watch_package), Base.PkgId})
+    precompile(Tuple{typeof(Revise.watch_package), Base.PkgId})
+    precompile(Tuple{typeof(Revise.sig_type_exprs), Module, Expr})
+    precompile(Tuple{Rescheduler{typeof(revise_dir_queued),Tuple{PkgData,String}}})
+
+    # # Here are other methods that require >10ms for inference but which do
+    # # not successfully precompile
+    # for dct in (watched_files, pkgdatas)
+    #     precompile(Tuple{typeof(setindex!), typeof(dct), valtype(dct), keytype(dct)})
+    # end
+    # precompile(Tuple{typeof(setindex!), FileModules, FMMaps, Module})
+    # precompile(Tuple{typeof(setindex!), Dict{String,FileInfo}, FileInfo, String})
+    # precompile(Tuple{typeof(watch_file), String, Int})
+    # precompile(Tuple{typeof(empty!), Dict{Tuple{PkgData,String},Nothing}})
 
     return nothing
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,6 +14,15 @@ function iswritable(file::AbstractString)  # note this trashes the Base definiti
     return uperm(stat(file)) & 0x02 != 0x00
 end
 
+function unique_dirs(iter)
+    udirs = Set{String}()
+    for file in iter
+        dir, basename = splitdir(file)
+        push!(udirs, dir)
+    end
+    return udirs
+end
+
 function use_compiled_modules()
     return Base.JLOptions().use_compiled_modules != 0
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1620,7 +1620,7 @@ end
         devpath = joinpath(depot, "dev")
         mkpath(devpath)
         mfile = Revise.manifest_file()
-        @async Revise.watch_manifest(mfile)
+        schedule(Task(Revise.Rescheduler(Revise.watch_manifest, (mfile,))))
         sleep(2.1)
         pkgdevpath = make_a2d(devpath, 2, "w")
         Pkg.REPLMode.do_cmd(Pkg.REPLMode.minirepl[], "dev $pkgdevpath"; do_rethrow=true)


### PR DESCRIPTION
In my testing this shaves about 35% off the startup time of Revise. Not awesome, but not too bad either. If we could get those 4 commented-out `setindex!` methods to precompile, it would shave an additional 15% off from where this is now.