### PR TITLE
Allow Base.@​propagate_inbounds etc.

### DIFF
--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -3,7 +3,10 @@
 using Core: MethodInstance
 using Base: MethodList
 
-const poppable_macro = (Symbol("@inline"), Symbol("@noinline"), Symbol("@propagate_inbounds"), Symbol("@eval"))
+const poppable_macro = (Symbol("@inline"), Symbol("@noinline"), Symbol("@propagate_inbounds"), Symbol("@eval"), Symbol("@pure"))
+
+is_poppable_macro(ex) = ex ∈ poppable_macro ||
+    ex.head == :. && ex.args[1] == :Base && ex.args[2].value ∈ poppable_macro
 
 """
     exf = funcdef_expr(ex)
@@ -29,7 +32,7 @@ function funcdef_expr(ex)
     if ex.head == :macrocall
         if ex.args[1] isa GlobalRef && ex.args[1].name == Symbol("@doc")
             return funcdef_expr(ex.args[end])
-        elseif ex.args[1] ∈ poppable_macro
+        elseif is_poppable_macro(ex.args[1])
             return funcdef_expr(ex.args[end])
         else
             io = IOBuffer()

--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -6,7 +6,7 @@ using Base: MethodList
 const poppable_macro = (Symbol("@inline"), Symbol("@noinline"), Symbol("@propagate_inbounds"), Symbol("@eval"), Symbol("@pure"))
 
 is_poppable_macro(ex) = ex ∈ poppable_macro ||
-    ex.head == :. && ex.args[1] == :Base && ex.args[2].value ∈ poppable_macro
+    (ex isa Expr && ex.head == :. && ex.args[1] == :Base && ex.args[2].value ∈ poppable_macro)
 
 """
     exf = funcdef_expr(ex)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -193,7 +193,7 @@ end
 
 function macexpand(mod::Module, ex::Expr)
     ex0 = ex
-    if ex.args[1] ∈ poppable_macro
+    if is_poppable_macro(ex.args[1])
         ex = ex.args[end]
         if ex isa Expr && ex.head == :macrocall
             ex0.args[end], ex = macexpand(mod, ex)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,7 +229,9 @@ k(x) = 4
         refex =  Revise.relocatable!(:(function foo(x) x^2 end))
         for ex in (:(@inline function foo(x) x^2 end),
                    :(@noinline function foo(x) x^2 end),
-                   :(@propagate_inbounds function foo(x) x^2 end))
+                   :(@propagate_inbounds function foo(x) x^2 end),
+                   :(Base.@propagate_inbounds function foo(x) x^2 end),
+                   :(Base.@pure function foo(x) x^2 end))
             @test Revise.get_signature(Revise.funcdef_expr(ex)) == :(foo(x))
             @test Revise.relocatable!(Revise.funcdef_expr(ex)) == refex
         end


### PR DESCRIPTION
It would be nice if Revise.jl notices `Base.@​propagate_inbounds` etc. are the "annotation" macro.  Is this the right approach?
