### PR TITLE
Support adding new source files to a package

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "config.md",
+        "advanced.md",
         "limitations.md",
         "debugging.md",
         "internals.md",

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -1,0 +1,36 @@
+# Advanced usage
+
+## Tracking files loaded conditionally with Requires.jl
+
+[Requires.jl](https://github.com/MikeInnes/Requires.jl) allows you to declare conditional dependencies for a package.
+When those dependencies result in the inclusion of new source files, Revise will not
+automatically track them. However, you can force Revise to track them by registering the file(s).
+An example registration might look like this:
+
+```julia
+function __init__()
+    @require SomePackage="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" begin
+        include("newcode.jl")
+        # Register newcode.jl with Revise
+        @require Revise="295af30f-e4ad-537b-8983-00126c2a3abe" begin
+            import .Revise
+            Revise.add_file(TrackRequires, "src/newcode.jl")
+        end
+    end
+end
+```
+
+The inner `@require` statement makes registration conditional on Revise, allowing
+your package to be used with and without Revise.
+In the `add_file` call (which is what performs the registration),
+note that you must use the relative path from the package top-level directory
+(here, `"src/newcode.jl"` rather than just `"newcode.jl"`).
+
+!!! note
+    In principle, Revise could parse the `__init__` function and perform this
+    registration itself. However, this would lead to a performance problem:
+    for this to work, Revise would have to "defensively" parse the top-level source file
+    of every loaded package.
+    Since Revise takes pains to parse only source files that
+    have changes (see the first section of [How Revise works](@ref)),
+    we instead opt for manual registration of `@require` dependencies.

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -27,6 +27,7 @@ Revise.pkgdatas
 Revise.watched_files
 Revise.revision_queue
 Revise.included_files
+Revise.add_file!
 ```
 
 ## Types

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -124,6 +124,10 @@ all without restarting your Julia session.
 Generally, that's it!
 Revise is a tool that runs in the background, and when all is well it should be
 essentially invisible, except that you don't have to restart Julia so often.
+It's worth noting that Revise updates code when you enter a new command
+at the REPL, not when you save a file---this allows you to make
+extensive edits, saving as you go, without worrying that Revise will try to parse
+half-completed changes to a file.
 In rare circumstances there are cases where [Advanced usage](@ref) is necessary.
 
 Revise can also be used as a "library" by developers who want to add other new capabilities

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -121,9 +121,10 @@ all without restarting your Julia session.
 
 ## What else do I need to know?
 
-Except in cases of problems (see below), that's it!
+Generally, that's it!
 Revise is a tool that runs in the background, and when all is well it should be
 essentially invisible, except that you don't have to restart Julia so often.
+In rare circumstances there are cases where [Advanced usage](@ref) is necessary.
 
 Revise can also be used as a "library" by developers who want to add other new capabilities
 to Julia; the sections [How Revise works](@ref) and [Developer reference](@ref) are

--- a/docs/src/user_reference.md
+++ b/docs/src/user_reference.md
@@ -9,6 +9,7 @@ prevent it from watching specific packages.
 revise
 Revise.track
 includet
+Revise.add_file
 ```
 
 ### Revise logs (debugging Revise)

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -168,7 +168,11 @@ function read_from_cache(pkgdata::PkgData, file::AbstractString)
             Base._read_dependency_src(io, filec)
         end
     end
-    Base.read_dependency_src(fi.cachefile, filep)
+    try
+        return Base.read_dependency_src(fi.cachefile, filep)
+    catch
+        return nothing
+    end
 end
 
 function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString)

--- a/src/types.jl
+++ b/src/types.jl
@@ -52,8 +52,9 @@ See the documentation page [How Revise works](@ref) for more information.
 struct FMMaps
     defmap::DefMap
     sigtmap::SigtMap
+    includes::Vector{String}
 end
-FMMaps() = FMMaps(DefMap(), SigtMap())
+FMMaps() = FMMaps(DefMap(), SigtMap(), String[])
 
 Base.isempty(fmm::FMMaps) = isempty(fmm.defmap)
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -3,3 +3,5 @@ RecipesBase
 Plots
 EponymTuples
 JSON
+Requires
+EndpointRanges # dummy package for triggering Requires

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -855,7 +855,7 @@ end
                     include("testfile.jl")
                     @require Revise="295af30f-e4ad-537b-8983-00126c2a3abe" begin
                         import .Revise
-                        # Revise.add_file(TrackRequires, "src/testfile.jl")
+                        Revise.add_file(TrackRequires, "src/testfile.jl")
                     end
                 end
             end
@@ -869,6 +869,7 @@ end
         sleep(2.1) # so the defining files are old enough not to trigger mtime criterion
         @eval using TrackRequires
         @test_throws UndefVarError TrackRequires.testfunc()
+        sleep(0.1)
         @eval using EndpointRanges  # to trigger Requires
         sleep(0.1)
         @test TrackRequires.testfunc() == 1
@@ -876,7 +877,7 @@ end
             println(io, "testfunc() = 2")
         end
         yry()
-        @test_broken TrackRequires.testfunc() == 2
+        @test TrackRequires.testfunc() == 2
         rm_precompile("TrackRequires")
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -837,7 +837,7 @@ end
         end
         yry()
         @test NewFile.f() == 1
-        @test_broken NewFile.g() == 2
+        @test NewFile.g() == 2
         rm_precompile("NewFile")
 
         # https://discourse.julialang.org/t/revise-with-requires/19347

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -799,6 +799,87 @@ end
         pop!(LOAD_PATH)
     end
 
+    @testset "New files & Requires.jl" begin
+        # Issue #107
+        testdir = randtmp()
+        mkdir(testdir)
+        push!(to_remove, testdir)
+        push!(LOAD_PATH, testdir)
+        dn = joinpath(testdir, "NewFile", "src")
+        mkpath(dn)
+        open(joinpath(dn, "NewFile.jl"), "w") do io
+            println(io, """
+                module NewFile
+
+                f() = 1
+
+                end
+                """)
+        end
+        sleep(2.1) # so the defining files are old enough not to trigger mtime criterion
+        @eval using NewFile
+        @test NewFile.f() == 1
+        @test_throws UndefVarError NewFile.g()
+        sleep(0.1)
+        open(joinpath(dn, "g.jl"), "w") do io
+            println(io, "g() = 2")
+        end
+        open(joinpath(dn, "NewFile.jl"), "w") do io
+            println(io, """
+                module NewFile
+
+                include("g.jl")
+
+                f() = 1
+
+                end
+                """)
+        end
+        yry()
+        @test NewFile.f() == 1
+        @test_broken NewFile.g() == 2
+        rm_precompile("NewFile")
+
+        # https://discourse.julialang.org/t/revise-with-requires/19347
+        dn = joinpath(testdir, "TrackRequires", "src")
+        mkpath(dn)
+        open(joinpath(dn, "TrackRequires.jl"), "w") do io
+            println(io, """
+            module TrackRequires
+
+            using Requires
+
+            function __init__()
+                @require EndpointRanges="340492b5-2a47-5f55-813d-aca7ddf97656" begin
+                    export testfunc
+                    include("testfile.jl")
+                    @require Revise="295af30f-e4ad-537b-8983-00126c2a3abe" begin
+                        import .Revise
+                        # Revise.add_file(TrackRequires, "src/testfile.jl")
+                    end
+                end
+            end
+
+            end # module
+            """)
+        end
+        open(joinpath(dn, "testfile.jl"), "w") do io
+            println(io, "testfunc() = 1")
+        end
+        sleep(2.1) # so the defining files are old enough not to trigger mtime criterion
+        @eval using TrackRequires
+        @test_throws UndefVarError TrackRequires.testfunc()
+        @eval using EndpointRanges  # to trigger Requires
+        sleep(0.1)
+        @test TrackRequires.testfunc() == 1
+        open(joinpath(dn, "testfile.jl"), "w") do io
+            println(io, "testfunc() = 2")
+        end
+        yry()
+        @test_broken TrackRequires.testfunc() == 2
+        rm_precompile("TrackRequires")
+    end
+
     # issue #8
     @testset "Module docstring" begin
         testdir = randtmp()


### PR DESCRIPTION
This fixes both https://discourse.julialang.org/t/revise-with-requires/19347 and #107. While #107 is "transitory" and therefore not a huge problem, the case in the discourse post is a permanent state. Since I could fix both with the same infrastructure, this seemed worth prioritizing.

For usage with `Requires.jl`, the following is taken from the new documentation:

### docs

[Requires.jl](https://github.com/MikeInnes/Requires.jl) allows you to declare conditional dependencies for a package. When those dependencies result in the inclusion of new source files, Revise will not automatically track them. However, you can force Revise to track them by registering the file(s). An example registration might look like this:

```julia
function __init__()
    @require SomePackage="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" begin
        include("newcode.jl")
        # Register newcode.jl with Revise
        @require Revise="295af30f-e4ad-537b-8983-00126c2a3abe" begin
            import .Revise
            Revise.add_file(TrackRequires, "src/newcode.jl")
        end
    end
end
```

The inner `@require` statement makes registration conditional on Revise, allowing your package to be used with and without Revise. In the `add_file` call (which is what performs the registration), note that you must use the relative path from the package top-level directory (here, `"src/newcode.jl"` rather than just `"newcode.jl"`).

!!! note
    In principle, Revise could parse the `__init__` function and perform this
    registration itself. However, this would lead to a performance problem:
    for this to work, Revise would have to "defensively" parse the top-level source file
    of every loaded package.
    Since Revise takes pains to parse only source files that
    have changes,
    we instead opt for manual registration of `@require` dependencies.
