### PR TITLE
Support catch_stack API

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -495,7 +495,7 @@ function revise(backend::REPL.REPLBackend)
         try
             revise_file_now(pkgdata, file)
         catch err
-            @static if isdefined(Base, :catch_stack)
+            @static if VERSION >= v"1.2.0-DEV.253"
                 put!(backend.response_channel, (Base.catch_stack(), true))
             else
                 put!(backend.response_channel, (err, catch_backtrace()))
@@ -507,7 +507,7 @@ function revise(backend::REPL.REPLBackend)
         try
             queue_includes(Main)
         catch err
-            @static if isdefined(Base, :catch_stack)
+            @static if VERSION >= v"1.2.0-DEV.253"
                 put!(backend.response_channel, (Base.catch_stack(), true))
             else
                 put!(backend.response_channel, (err, catch_backtrace()))

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -495,7 +495,11 @@ function revise(backend::REPL.REPLBackend)
         try
             revise_file_now(pkgdata, file)
         catch err
-            put!(backend.response_channel, (err, catch_backtrace()))
+            @static if isdefined(Base, :catch_stack)
+                put!(backend.response_channel, (Base.catch_stack(), true))
+            else
+                put!(backend.response_channel, (err, catch_backtrace()))
+            end
         end
     end
     empty!(revision_queue)
@@ -503,7 +507,11 @@ function revise(backend::REPL.REPLBackend)
         try
             queue_includes(Main)
         catch err
-            put!(backend.response_channel, (err, catch_backtrace()))
+            @static if isdefined(Base, :catch_stack)
+                put!(backend.response_channel, (Base.catch_stack(), true))
+            else
+                put!(backend.response_channel, (err, catch_backtrace()))
+            end
         end
     end
     return nothing

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -350,7 +350,7 @@ function watch_manifest(mfile)
             end
         end
     catch err
-        @static if isdefined(Base, :catch_stack)
+        @static if VERSION >= v"1.2.0-DEV.253"
             put!(Base.active_repl_backend.response_channel, (Base.catch_stack(), true))
         else
             put!(Base.active_repl_backend.response_channel, (err, catch_backtrace()))

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -350,7 +350,11 @@ function watch_manifest(mfile)
             end
         end
     catch err
-        put!(Base.active_repl_backend.response_channel, (err, catch_backtrace()))
+        @static if isdefined(Base, :catch_stack)
+            put!(Base.active_repl_backend.response_channel, (Base.catch_stack(), true))
+        else
+            put!(Base.active_repl_backend.response_channel, (err, catch_backtrace()))
+        end
     end
     return true
 end


### PR DESCRIPTION
Lately, I've been seeing accidental exit from Julia REPL with error like this:

```julia
ERROR: MethodError: Cannot `convert` an object of type Array{Union{Ptr{Nothing}, Base.InterpreterIP},1} to an object of type Bool
Closest candidates are:
  convert(::Type{T<:Number}, ::T<:Number) where T<:Number at number.jl:6
  convert(::Type{T<:Number}, ::Number) where T<:Number at number.jl:7
  convert(::Type{T<:Integer}, ::Ptr) where T<:Integer at pointer.jl:23
  ...
Stacktrace:
 [1] setproperty!(::REPL.LineEditREPL, ::Symbol, ::Array{Union{Ptr{Nothing}, Base.InterpreterIP},1}) at ./Base.jl:19
 [2] print_response(::REPL.AbstractREPL, ::Any, ::Bool, ::Bool) at /home/takafumi/repos/watch/julia/usr/share/julia/stdlib/v1.2/REPL/src/REPL.jl:139
 [3] (::getfield(REPL, Symbol("#do_respond#38")){Bool,getfield(REPL, Symbol("##48#57")){REPL.LineEditREPL,REPL.REPLHistoryProvider},REPL.LineEditREPL,REPL.LineEdit.Prompt})(::Any, ::Any, ::Any) at /home/takafumi/repos/watch/julia/usr/share/julia/stdlib/v1.2/REPL/src/REPL.jl:701
 [4] #invokelatest#1 at ./essentials.jl:761 [inlined]
 [5] invokelatest at ./essentials.jl:760 [inlined]
 [6] run_interface(::REPL.Terminals.TextTerminal, ::REPL.LineEdit.ModalInterface, ::REPL.LineEdit.MIState) at /home/takafumi/repos/watch/julia/usr/share/julia/stdlib/v1.2/REPL/src/LineEdit.jl:2273
 [7] run_frontend(::REPL.LineEditREPL, ::REPL.REPLBackendRef) at /home/takafumi/repos/watch/julia/usr/share/julia/stdlib/v1.2/REPL/src/REPL.jl:1021
 [8] run_repl(::REPL.AbstractREPL, ::Any) at /home/takafumi/repos/watch/julia/usr/share/julia/stdlib/v1.2/REPL/src/REPL.jl:192
 [9] (::getfield(Base, Symbol("##729#731")){Bool,Bool,Bool,Bool})(::Module) at ./client.jl:402
 [10] #invokelatest#1 at ./essentials.jl:761 [inlined]
 [11] invokelatest at ./essentials.jl:760 [inlined]
 [12] run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at ./client.jl:386
 [13] exec_options(::Base.JLOptions) at ./client.jl:324
 [14] _start() at ./client.jl:476
```

I think this is due to the change https://github.com/JuliaLang/julia/pull/30900 in REPL.jl in particular the change in [`eval_with_backend`](https://github.com/JuliaLang/julia/blob/f9c7716f7528992d4c3ed4569c36048bcdb96df8/stdlib/REPL/src/REPL.jl#L681-L684) which now expects a `Bool` in the second slot:

```julia
function eval_with_backend(ast, backend::REPLBackendRef)
    put!(backend.repl_channel, (ast, 1))
    take!(backend.response_channel) # (val, iserr)
end
```

I _think_ this solves the issue but I haven't looked into the issue carefully enough to find a way to reproduce the issue.  However, given the changes in https://github.com/JuliaLang/julia/pull/30900 this change seems to be appropriate.
