### PR TITLE
Smaller logo and center it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-![splash](images/logo.png)
-
-# Revise
+<div align="center"> <img src="images/logo.png" alt="Revise.jl" width="420"></img></div>
 
 **NOTE: this page is for Julia 0.7.0 and higher. For Julia 0.6 [see this branch](https://github.com/timholy/Revise.jl/tree/v0.6)**
 


### PR DESCRIPTION
Currently the logo is so big it dominates the page, I've made it smaller and centered it in the readme.

Feel free to close if you prefer to current style! 