### PR TITLE
bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"


### PR DESCRIPTION
"ERROR: LoadError: LoadError: Tagged version 2.0.1 of Revise lists version 2.0.0 in its Project file."