### PR TITLE
Fix line number correction in stack traces

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -1,6 +1,6 @@
 using Random
 
-const rseed = Ref(Random.GLOBAL_RNG)  # to get new random directories (see #24445)
+const rseed = Ref(Random.GLOBAL_RNG)  # to get new random directories (see julia #24445)
 function randtmp()
     Random.seed!(rseed[])
     dirname = joinpath(tempdir(), randstring(10))


### PR DESCRIPTION
This had broken and our tests were inadequate to catch that. (Also obscured by the fact that this gets called from Base inside a `try/catch`.) This also generalizes the correction so that it can either take a `(frame, nrepetitions)` or just a `frame`.