### PR TITLE
Check for `nothing` return from `parse_source` (fixes #257)

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -152,9 +152,9 @@ function queue_includes!(pkgdata::PkgData, id::PkgId)
         modname = String(Symbol(mod))
         if startswith(modname, modstring) || endswith(fname, modstring*".jl")
             modexsigs = parse_source(fname, mod)
-            instantiate_sigs!(modexsigs)
-            fname = relpath(fname, pkgdata)
-            if modexsigs != nothing
+            if modexsigs !== nothing
+                instantiate_sigs!(modexsigs)
+                fname = relpath(fname, pkgdata)
                 push!(pkgdata, fname=>FileInfo(modexsigs))
             end
             push!(delids, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1431,6 +1431,14 @@ revise_f(x) = 2
             end
             yry()
             @test revise_g() == 2
+
+            # issue #257
+            logs, _ = Test.collect_test_logs() do  # just to prevent noisy warning
+                try include("nonexistent1.jl") catch end
+                yry()
+                try include("nonexistent2.jl") catch end
+                yry()
+            end
         finally
             Revise.tracking_Main_includes[] = false  # restore old behavior
         end


### PR DESCRIPTION
I was checking, but it was too late. Just moved it up a little earlier.