### PR TITLE
 Add `entr` to do work when files update 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-CodeTracking = "0.4, 0.5"
+CodeTracking = "~0.5.1"
 JuliaInterpreter = "0.2, 0.3, 0.4"
 LoweredCodeUtils = "0.3"
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 1.0
 OrderedCollections
-CodeTracking 0.4 0.6
+CodeTracking 0.5.1 0.6
 JuliaInterpreter 0.2 0.5
 LoweredCodeUtils 0.3 0.4

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -119,6 +119,22 @@ With Revise, you can
 
 all without restarting your Julia session.
 
+## Other Revise workflows
+
+Revise can be used to perform work when files update.
+For example, let's say you want to regenerate a set of web pages whenever your code changes.
+Suppose you've placed your Julia code in a package called `MyWebCode`,
+and the pages depend on "file1.css" and "file2.js"; then
+
+```julia
+entr(["file1.css", "file2.js"], [MyWebCode]) do
+    build_webpages(args...)
+end
+```
+
+will execute `build_webpages(args...)` whenever you save updates to the listed files
+or `MyWebCode`.
+
 ## What else do I need to know?
 
 Except in cases of problems (see below), that's it!

--- a/docs/src/user_reference.md
+++ b/docs/src/user_reference.md
@@ -1,7 +1,7 @@
 # User reference
 
-There are really only three functions that a user would be expected to call manually:
-`revise`, `includet`, and `Revise.track`.
+There are really only four functions that a user would be expected to call manually:
+`revise`, `includet`, `Revise.track`, and `entr`.
 Other user-level constructs might apply if you want to debug Revise or
 prevent it from watching specific packages.
 
@@ -9,6 +9,7 @@ prevent it from watching specific packages.
 revise
 Revise.track
 includet
+entr
 ```
 
 ### Revise logs (debugging Revise)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1661,6 +1661,8 @@ end
             push!(hp.history, fstr)
             m = first(methods(f))
             @test !isempty(signatures_at(String(m.file), m.line))
+            @test isa(definition(m), Expr)
+            @test isa(definition(String, m), Tuple{<:AbstractString,<:Integer})
             pop!(hp.history)
         end
     end


### PR DESCRIPTION
This is an oft-requested feature whose solution was pioneered in discussion in #203. I initially felt it was orthogonal to Revise, but one important thing changed: Revise's ability to follow `dev->add` and back means that a low-level implementation in terms of absolute paths would be painful from the user side. So, at the risk of growing this package, it now seems to belong here.

I also have the sense that usage of `includet` is getting out of hand. I suspect some of its users are really after `entr`.

CC @mlhetland, @essenciary, @yurivish
