### PR TITLE
Test deletion of atsign-evaled method and update docs

### DIFF
--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -2,55 +2,6 @@
 
 Revise (really, Julia itself) can handle many kinds of code changes, but a few may require special treatment:
 
-### Method deletion
-
-Sometimes you might wish to change a method's type signature or number of arguments,
-or remove a method specialized for specific types.
-To prevent "stale" methods
-from being called by dispatch, Revise automatically accommodates
-method deletion, for example:
-
-```julia
-f(x) = 1
-f(x::Int) = 2 # delete this method
-```
-
-If you save the file, the next time you call `f(5)` from the REPL you will get 1,
-and `methods(f)` will show a single method.
-Revise even handles more complex situations, such as functions with default arguments: the
-definition
-
-```julia
-defaultargs(x, y=0, z=1.0f0) = x + y + z
-```
-
-generates 3 different methods (with one, two, and three arguments respectively),
-and editing this definition to
-
-```julia
-defaultargs(x, yz=(0,1.0f0)) = x + yz[1] + yz[2]
-```
-
-requires that we delete all 3 of the original methods and replace them with two new methods.
-
-However, to find the right method(s) to delete, Revise needs to be able to parse source code
-to extract the signature of the to-be-deleted method(s).
-Unfortunately, a few valid constructs are quite difficult to parse properly.
-For example, methods generated with code:
-
-```julia
-for T in (Int, Float64, String)   # edit this line to `for T in (Int, Float64)`
-    @eval mytypeof(x::$T) = $T
-end
-```
-
-will not disappear from the method lists until you restart.
-
-!!! note
-
-    To delete a method manually, you can use `m = @which foo(args...)` to obtain a method,
-    and then call `Base.delete_method(m)`.
-
 ### Macros and generated functions
 
 If you change a macro definition or methods that get called by `@generated` functions
@@ -61,11 +12,10 @@ You may explicitly call `revise(MyModule)` to force reevaluating every definitio
 `MyModule`.
 Note that when a macro changes, you have to revise all of the modules that *use* it.
 
-### Distributed computing (multiple workers)
+### Distributed computing (multiple workers) and anonymous functions
 
 Revise supports changes to code in worker processes.
-The code must be loaded in the main process in which Revise is running, and you must use
-`@everywhere using Revise`.
+The code must be loaded in the main process in which Revise is running.
 
 Revise cannot handle changes in anonymous functions used in `remotecall`s.
 Consider the following module definition:
@@ -110,6 +60,7 @@ Finally, there are some kinds of changes that Revise cannot incorporate into a r
 
 - changes to type definitions
 - file or module renames
+- adding new source files to packages
 - conflicts between variables and functions sharing the same name
 
 These kinds of changes require that you restart your Julia session.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1156,6 +1156,10 @@ methgensym(::Vector{<:Integer}) = 1
 mapf(fs, x) = (fs[1](x), mapf(Base.tail(fs), x)...)
 mapf(::Tuple{}, x) = ()
 
+for T in (Int, Float64, String)
+    @eval mytypeof(x::\$T) = \$T
+end
+
 end
 """)
         end
@@ -1183,6 +1187,9 @@ end
         @test MethDel.methgensym([1]) == 1
         @test_throws MethodError MethDel.methgensym([1.0])
         @test MethDel.mapf((x->x+1, x->x+0.1), 3) == (4, 3.1)
+        @test MethDel.mytypeof(1) === Int
+        @test MethDel.mytypeof(1.0) === Float64
+        @test MethDel.mytypeof("hi") === String
         sleep(0.1)  # ensure watching is set up
         open(joinpath(dn, "MethDel.jl"), "w") do io
             println(io, """
@@ -1202,6 +1209,10 @@ methgensym(::Vector{<:Real}) = 1
 
 mapf(fs::F, x) where F = (fs[1](x), mapf(Base.tail(fs), x)...)
 mapf(::Tuple{}, x) = ()
+
+for T in (Int, String)
+    @eval mytypeof(x::\$T) = \$T
+end
 
 end
 """)
@@ -1234,6 +1245,9 @@ end
         @test length(methods(MethDel.methgensym)) == 1
         @test MethDel.mapf((x->x+1, x->x+0.1), 3) == (4, 3.1)
         @test length(methods(MethDel.mapf)) == 2
+        @test MethDel.mytypeof(1) === Int
+        @test_throws MethodError MethDel.mytypeof(1.0)
+        @test MethDel.mytypeof("hi") === String
 
         Base.delete_method(first(methods(Base.revisefoo)))
 


### PR DESCRIPTION
Revise 2.0 ended one of Revise's main limitations, but I had not yet eliminated it from the docs.