### PR TITLE
fix appveyor julia version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - julia_version: 1
+  - julia_version: 1.0
   - julia_version: 1.1
   - julia_version: nightly
 


### PR DESCRIPTION
`julia_version: 1` actually calls the latest stable version, i.e., `julia v1.1.0`