### PR TITLE
Re-activate Core.Compiler (fixes #270)

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -132,11 +132,11 @@ function track_subdir_from_git(id::PkgId, subdir::AbstractString; commit=Base.GI
             end
             rethrow(err)
         end
+        fmod = get(juliaf2m, fullpath, Core.Compiler)  # Core.Compiler is not cached
+        fmod === Core.Compiler && (endswith(fullpath, "compiler.jl") || endswith(fullpath, "tfuncs.jl")) && continue  # defines the module, skip
         if src != read(fullpath, String)
             push!(modified_files, (pkgdata, rpath))
         end
-        fmod = get(juliaf2m, fullpath, Core.Compiler)  # Core.Compiler is not cached
-        fmod === Core.Compiler && (@warn "Core.Compiler is disabled"; continue)
         fi = FileInfo(fmod)
         if parse_source!(fi.modexsigs, src, file, fmod) === nothing
             @warn "failed to parse Git source text for $file"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1998,20 +1998,19 @@ end
         Revise.get_tracked_id(Core)   # just test that this doesn't error
 
         # Determine whether a git repo is available. Travis & Appveyor do not have this.
-        # FIXME restore these tests
-        # repo, path = Revise.git_repo(Revise.juliadir)
-        # if repo != nothing
-        #     # Tracking Core.Compiler
-        #     Revise.track(Core.Compiler)
-        #     id = Base.PkgId(Core.Compiler)
-        #     pkgdata = Revise.pkgdatas[id]
-        #     @test any(k->endswith(k, "compiler.jl"), Revise.srcfiles(pkgdata))
-        #     m = first(methods(Core.Compiler.typeinf_code))
-        #     @test definition(m) isa Expr
-        # else
-        #     @test_throws Revise.GitRepoException Revise.track(Core.Compiler)
-        #     @warn "skipping Core.Compiler tests due to lack of git repo"
-        # end
+        repo, path = Revise.git_repo(Revise.juliadir)
+        if repo != nothing
+            # Tracking Core.Compiler
+            Revise.track(Core.Compiler)
+            id = Base.PkgId(Core.Compiler)
+            pkgdata = Revise.pkgdatas[id]
+            @test any(k->endswith(k, "optimize.jl"), Revise.srcfiles(pkgdata))
+            m = first(methods(Core.Compiler.typeinf_code))
+            @test definition(m) isa Expr
+        else
+            @test_throws Revise.GitRepoException Revise.track(Core.Compiler)
+            @warn "skipping Core.Compiler tests due to lack of git repo"
+        end
     end
 
     @testset "CodeTracking #48" begin


### PR DESCRIPTION
Does not work well enough for prime-time, but still might have useful functionality for people working on the compiler.

Current status:
```julia
julia> using Revise
[ Info: Recompiling stale cache file /home/tim/.julia/compiled/v1.1/Revise/M1Qoh.ji for Revise [295af30f-e4ad-537b-8983-00126c2a3abe]

julia> Revise.track(Core.Compiler)
file = "base/compiler/abstractinterpretation.jl"
file = "base/compiler/bootstrap.jl"
file = "base/compiler/inferenceresult.jl"
file = "base/compiler/inferencestate.jl"
file = "base/compiler/optimize.jl"
file = "base/compiler/params.jl"
file = "base/compiler/ssair/domtree.jl"
file = "base/compiler/ssair/driver.jl"
file = "base/compiler/ssair/inlining.jl"
file = "base/compiler/ssair/ir.jl"
file = "base/compiler/ssair/legacy.jl"
file = "base/compiler/ssair/passes.jl"
file = "base/compiler/ssair/queries.jl"
file = "base/compiler/ssair/show.jl"
file = "base/compiler/ssair/slot2ssa.jl"
file = "base/compiler/ssair/verify.jl"
file = "base/compiler/tfuncs.jl"
file = "base/compiler/typeinfer.jl"
file = "base/compiler/typelattice.jl"
file = "base/compiler/typelimits.jl"
file = "base/compiler/typeutils.jl"
file = "base/compiler/utilities.jl"
file = "base/compiler/validation.jl"
Internal error: encountered unexpected error in runtime:
MethodError(f=getfield(Core.Compiler, Symbol("##467#468"))(), args=(Array{Core.Compiler.Pair{Symbol, Core.Compiler.UnitRange{Int64}}, 1},), world=0x0000000000000eb9)
rec_backtrace at /home/tim/src/julia-1/src/stackwalk.c:94
record_backtrace at /home/tim/src/julia-1/src/task.c:217 [inlined]
jl_throw at /home/tim/src/julia-1/src/task.c:417
jl_method_error_bare at /home/tim/src/julia-1/src/gf.c:1649
jl_method_error at /home/tim/src/julia-1/src/gf.c:1667
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2195
jl_apply at /home/tim/src/julia-1/src/julia.h:1571 [inlined]
jl_f__apply at /home/tim/src/julia-1/src/builtins.c:556
builtin_tfunction at ./compiler/tfuncs.jl:1286
builtin_tfunction at ./compiler/tfuncs.jl:1200 [inlined]
abstract_call at ./compiler/abstractinterpretation.jl:593
abstract_eval_call at ./compiler/abstractinterpretation.jl:805
abstract_eval at ./compiler/abstractinterpretation.jl:890
typeinf_local at ./compiler/abstractinterpretation.jl:1135
typeinf_nocycle at ./compiler/abstractinterpretation.jl:1191
typeinf at ./compiler/typeinfer.jl:14
typeinf_edge at ./compiler/typeinfer.jl:497
abstract_call_method at ./compiler/abstractinterpretation.jl:345
abstract_call_gf_by_type at ./compiler/abstractinterpretation.jl:85
abstract_call at ./compiler/abstractinterpretation.jl:776
abstract_eval_call at ./compiler/abstractinterpretation.jl:805
abstract_eval at ./compiler/abstractinterpretation.jl:890
typeinf_local at ./compiler/abstractinterpretation.jl:1135
typeinf_nocycle at ./compiler/abstractinterpretation.jl:1191
typeinf at ./compiler/typeinfer.jl:14
typeinf_edge at ./compiler/typeinfer.jl:497
abstract_call_method at ./compiler/abstractinterpretation.jl:345
abstract_call_gf_by_type at ./compiler/abstractinterpretation.jl:85
abstract_call at ./compiler/abstractinterpretation.jl:776
abstract_eval_call at ./compiler/abstractinterpretation.jl:805
abstract_eval at ./compiler/abstractinterpretation.jl:890
typeinf_local at ./compiler/abstractinterpretation.jl:1135
typeinf_nocycle at ./compiler/abstractinterpretation.jl:1191
typeinf at ./compiler/typeinfer.jl:14
typeinf_edge at ./compiler/typeinfer.jl:497
abstract_call_method at ./compiler/abstractinterpretation.jl:345
abstract_call_gf_by_type at ./compiler/abstractinterpretation.jl:85
abstract_call at ./compiler/abstractinterpretation.jl:776
abstract_eval_call at ./compiler/abstractinterpretation.jl:805
abstract_eval at ./compiler/abstractinterpretation.jl:890
typeinf_local at ./compiler/abstractinterpretation.jl:1121
typeinf_nocycle at ./compiler/abstractinterpretation.jl:1191
typeinf at ./compiler/typeinfer.jl:14
typeinf_edge at ./compiler/typeinfer.jl:497
abstract_call_method at ./compiler/abstractinterpretation.jl:345
abstract_call_gf_by_type at ./compiler/abstractinterpretation.jl:85
abstract_call at ./compiler/abstractinterpretation.jl:776
abstract_eval_call at ./compiler/abstractinterpretation.jl:805
abstract_eval at ./compiler/abstractinterpretation.jl:890
typeinf_local at ./compiler/abstractinterpretation.jl:1135
typeinf_nocycle at ./compiler/abstractinterpretation.jl:1191
typeinf at ./compiler/typeinfer.jl:14
typeinf_ext at ./compiler/typeinfer.jl:576
typeinf_ext at ./compiler/typeinfer.jl:613
jfptr_typeinf_ext_1 at /home/tim/src/julia-1/usr/lib/julia/sys.so (unknown line)
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
jl_apply at /home/tim/src/julia-1/src/julia.h:1571 [inlined]
jl_type_infer at /home/tim/src/julia-1/src/gf.c:277
jl_compile_method_internal at /home/tim/src/julia-1/src/gf.c:1819 [inlined]
jl_fptr_trampoline at /home/tim/src/julia-1/src/gf.c:1863
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
collect at ./array.jl:611
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
_ntuple at ./tuple.jl:154
prepare_framedata at ./tuple.jl:136
prepare_frame at /home/tim/.julia/dev/JuliaInterpreter/src/construct.jl:308
prepare_frame_caller at /home/tim/.julia/dev/JuliaInterpreter/src/construct.jl:321 [inlined]
#evaluate_call_recurse!#35 at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:237
unknown function (ip: 0x7f478dd44e57)
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
evaluate_call_recurse! at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:206 [inlined]
eval_rhs at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:372
step_expr! at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:500
#methods_by_execution!#12 at /home/tim/.julia/dev/Revise/src/lowered.jl:154
unknown function (ip: 0x7f478dd39cf3)
#methods_by_execution! at ./none:0
unknown function (ip: 0x7f478dd36176)
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
#methods_by_execution!#9 at /home/tim/.julia/dev/Revise/src/lowered.jl:46
#methods_by_execution! at ./none:0 [inlined]
#eval_with_signatures#57 at /home/tim/.julia/dev/Revise/src/Revise.jl:344
unknown function (ip: 0x7f478dd2ce93)
#eval_with_signatures at /home/tim/.julia/dev/Revise/src/Revise.jl:0 [inlined]
#instantiate_sigs!#58 at /home/tim/.julia/dev/Revise/src/Revise.jl:352
unknown function (ip: 0x7f478dd2cc3e)
instantiate_sigs! at /home/tim/.julia/dev/Revise/src/Revise.jl:349 [inlined]
#track_subdir_from_git#37 at /home/tim/.julia/dev/Revise/src/recipes.jl:145
jl_fptr_trampoline at /home/tim/src/julia-1/src/gf.c:1864
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
#track_subdir_from_git at ./none:0 [inlined]
#_track#27 at /home/tim/.julia/dev/Revise/src/recipes.jl:75
jl_fptr_trampoline at /home/tim/src/julia-1/src/gf.c:1864
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
#_track at ./none:0 [inlined]
#track#26 at /home/tim/.julia/dev/Revise/src/recipes.jl:12 [inlined]
track at /home/tim/.julia/dev/Revise/src/recipes.jl:10
jl_fptr_trampoline at /home/tim/src/julia-1/src/gf.c:1864
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
do_call at /home/tim/src/julia-1/src/interpreter.c:323
eval_value at /home/tim/src/julia-1/src/interpreter.c:411
eval_stmt_value at /home/tim/src/julia-1/src/interpreter.c:362 [inlined]
eval_body at /home/tim/src/julia-1/src/interpreter.c:773
jl_interpret_toplevel_thunk_callback at /home/tim/src/julia-1/src/interpreter.c:885
Interpreter frame (ip: 2)
Core.CodeInfo(code=Array{Any, (4,)}[
  Expr(:call, Base.getproperty, :Revise, :(:track)),
  Expr(:call, Base.getproperty, :Core, :(:Compiler)),
  Expr(:call, SSAValue(1), SSAValue(2)),
  Expr(:return, SSAValue(3))], codelocs=Array{Int32, (4,)}[1, 1, 1, 1], method_for_inference_limit_heuristics=nothing, ssavaluetypes=4, linetable=Array{Any, (1,)}[Core.LineInfoNode(mod=Main, method=Symbol("top-level scope"), file=:none, line=0, inlined_at=0)], ssaflags=Array{UInt8, (0,)}[], slotflags=Array{UInt8, (0,)}[], slotnames=Array{Any, (0,)}[], inferred=false, inlineable=false, propagate_inbounds=false, pure=false)jl_interpret_toplevel_thunk at /home/tim/src/julia-1/src/interpreter.c:894
jl_toplevel_eval_flex at /home/tim/src/julia-1/src/toplevel.c:764
jl_toplevel_eval_in at /home/tim/src/julia-1/src/toplevel.c:793
eval at ./boot.jl:328
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
eval_user_input at /home/tim/src/julia-1/usr/share/julia/stdlib/v1.1/REPL/src/REPL.jl:85
run_backend at /home/tim/.julia/dev/Revise/src/Revise.jl:943
#72 at ./task.jl:259
jl_fptr_trampoline at /home/tim/src/julia-1/src/gf.c:1864
jl_apply_generic at /home/tim/src/julia-1/src/gf.c:2219
jl_apply at /home/tim/src/julia-1/src/julia.h:1571 [inlined]
start_task at /home/tim/src/julia-1/src/task.c:572
unknown function (ip: 0xffffffffffffffff)

julia> 
```

The "execute all code that isn't a method definition" strategy seems particularly dangerous with `Core.Compiler`. Help wanted in figuring out what to fix.