### PR TITLE
Rewrite, postpone and pause

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -692,8 +692,7 @@ function entr(f::Function, files, modules=nothing; postpone=false)
                 waitfor = isdir(file) ? watch_folder : watch_file
                 @async while active
                     ret = waitfor(file, 1)
-                    ret.renamed && break
-                    if active && ret.changed
+                    if active && (ret.changed || ret.renamed)
                         revise()
                         f()
                     end

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -662,7 +662,7 @@ Execute `f()` whenever files listed in `files`, or code in `modules`, updates.
 `entr` will process updates (and block your command line) until you press Ctrl-C.
 Unless `postpone` is `true`, `f()` will be executed also when calling `entr`,
 regardless of file changes. The `pause` is the period (in seconds) that `entr`
-will wait between it has been triggered and actually calling `f()`, to handle
+will wait between being triggered and actually calling `f()`, to handle
 clusters of modifications, such as those produced by saving files in certain
 text editors.
 

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -655,11 +655,13 @@ end
 includet(file::AbstractString) = includet(Main, file)
 
 """
-    entr(f, files)
-    entr(f, files, modules)
+    entr(f, files; postpone=false)
+    entr(f, files, modules; postpone=false)
 
 Execute `f()` whenever files listed in `files`, or code in `modules`, updates.
 `entr` will process updates (and block your command line) until you press Ctrl-C.
+Unless `postpone` is `true`, `f()` will be executed also when calling `entr`,
+regardless of file changes.
 
 # Example
 
@@ -671,7 +673,7 @@ end
 This will print "update" every time `"/tmp/watched.txt"` or any of the code defining
 `Pkg1` or `Pkg2` gets updated.
 """
-function entr(f::Function, files, modules=nothing)
+function entr(f::Function, files, modules=nothing; postpone=false)
     files = collect(files)  # because we may add to this list
     if modules !== nothing
         for mod in modules
@@ -685,6 +687,7 @@ function entr(f::Function, files, modules=nothing)
     active = true
     try
         @sync begin
+            postpone || f()
             for file in files
                 waitfor = isdir(file) ? watch_folder : watch_file
                 @async while active


### PR DESCRIPTION
This PR has three minor modifications to `entr` (cf. #298):

- By default, `entr` will now execute `f()` initially, unless the `postpone` keyword is used;
- `entr` sleeps for the amount given by `pause` between being triggered and executing `f()`, to handle clusters of modifications, such as text editor saves; and
- Rewrites *to* a given file/file name are now accepted as modifications; rewrites *from* the file name cause an error, as the file with the supplied name no longer exists.

The first and last are in line with the `entr` command line tool. The second is an added convenience, to avoid redundant execution when (e.g.) generating output based on saved files, etc.

The modifications are independent – no need to accept them all.

(Note: No new tests have been added for these features.)