### PR TITLE
Assign docstring created by a macro (fixes #309)

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -13,3 +13,25 @@ end
 else
     yry() = (sleep(0.1); revise(); sleep(0.1))
 end
+
+function collectexprs(rex::Revise.RelocatableExpr)
+    items = []
+    for item in Revise.LineSkippingIterator(rex.ex.args)
+        push!(items, isa(item, Expr) ? Revise.RelocatableExpr(item) : item)
+    end
+    items
+end
+
+function get_docstring(obj)
+    while !isa(obj, AbstractString)
+        fn = fieldnames(typeof(obj))
+        if :content ∈ fn
+            obj = obj.content[1]
+        elseif :code ∈ fn
+            obj = obj.code
+        else
+            error("unknown object ", obj)
+        end
+    end
+    return obj
+end


### PR DESCRIPTION
The simplified example due to @simonbyrne in #309 generates a frame that looks like this:
```julia
frame = Frame for ParamTest
  1  5  1 ─      const c
  2  5  │        c = 1.2
  3  5  │   %3 = (Base.Docs.Binding)(ParamTest, :c)
  4  5  │   %4 = (Core.svec)("    mydoc\n")
  5  5  │   %5 = (Dict)(:path => "/home/tim/.julia/packages/ParamTest/CpquX/src/ParamTest.jl", :linenumber => 5, :module => ParamTest)
  6  5  │   %6 = (Base.Docs.docstr)(%4, %5)
  7  5  │   %7 = (Core.apply_type)(Union)
  8  5  │   %8 = (Base.Docs.doc!)(ParamTest, %3, %6, %7)
  9* 5  └──      return %8
```
The fundamental error here is that `%8` was not formerly being assigned. I've also set this up so that, should we eventually get the ability to handle #20, macro-defined docstrings should update if modified.