### PR TITLE
add compatibility with JuliaInterpreter 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CodeTracking = "~0.5.1"
-JuliaInterpreter = "0.2, 0.3, 0.4, 0.5, 0.6"
+JuliaInterpreter = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7"
 LoweredCodeUtils = "0.3.4"
 julia = "1"
 
@@ -25,8 +25,8 @@ julia = "1"
 EponymTuples = "97e2ac4a-e175-5f49-beb1-4d6866a6cdc3"
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Example", "EponymTuples", "InteractiveUtils", "Random"]


### PR DESCRIPTION
Tested locally with JuliaInterpreter 0.7 and passes. For this to run on CI, the PR to General for 0.7 needs to be merged and LoweredCodeUtils also needs new compat + tag.