### PR TITLE
Use `bodymethod` if location info is missing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "2.1.7"
+version = "2.1.8"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -18,7 +18,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 CodeTracking = "~0.5.1"
 JuliaInterpreter = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7"
-LoweredCodeUtils = "0.3.4"
+LoweredCodeUtils = "0.3.8"
 julia = "1"
 
 [extras]

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -787,6 +787,10 @@ This is a callback function used by `CodeTracking.jl`'s `definition`.
 """
 function get_def(method::Method; modified_files=revision_queue)
     yield()   # magic bug fix for the OSX test failures. TODO: figure out why this works (prob. Julia bug)
+    if method.file == :none && String(method.name)[1] == '#'
+        # This is likely to be a kwarg method, try to find something with location info
+        method = bodymethod(method)
+    end
     filename = fixpath(String(method.file))
     if startswith(filename, "REPL[")
         isdefined(Base, :active_repl) || return false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1789,6 +1789,12 @@ end
         # end
     end
 
+    @testset "CodeTracking #48" begin
+        m = @which sum([1]; dims=1)
+        file, line = whereis(m)
+        @test endswith(file, "reducedim.jl") && line > 1
+    end
+
     @testset "Methods at REPL" begin
         if isdefined(Base, :active_repl)
             hp = Base.active_repl.interface.modes[1].hist


### PR DESCRIPTION
Fixes https://github.com/timholy/CodeTracking.jl/pull/48