### PR TITLE
Preserve revision_queue items that errored

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1499,6 +1499,26 @@ end
         @test startswith(rec.message, "Failed to revise")
         @test occursin("missing comma", rec.message)
 
+        logs, _ = Test.collect_test_logs() do
+            yry()
+        end
+        rec = logs[1]
+        @test startswith(rec.message, "Due to a previously reported error")
+        @test occursin("RevisionErrors.jl", rec.message)
+
+        open(joinpath(dn, "RevisionErrors.jl"), "w") do io
+            println(io, """
+            module RevisionErrors
+            f(x) = 2
+            end
+            """)
+        end
+        logs, _ = Test.collect_test_logs() do
+            yry()
+        end
+        @test isempty(logs)
+        @test RevisionErrors.f(0) == 2
+
         # Also test that it ends up being reported to the user (issue #281)
         open(joinpath(dn, "RevisionErrors.jl"), "w") do io
             println(io, """


### PR DESCRIPTION
This issues a continuous reminder about files that are out-of-sync. Fixes #317, fixes #321.

I may not merge this immediately, this seems like the kind of change that would be good to try out before making it the standard. @oschulz and @ianshmean, can you try out this branch and see how you like it?