### PR TITLE
Improve module hygiene when parsing code (fixes #312)

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -115,6 +115,9 @@ function parse_pkg_files(id::PkgId)
         cachefile, mods_files_mtimes = pkg_fileinfo(id)
         if cachefile !== nothing
             for (mod, fname, _) in mods_files_mtimes
+                if mod === Main && !isdefined(mod, modsym)  # issue #312
+                    mod = Base.root_module(PkgId(pkgdata))
+                end
                 fname = relpath(fname, pkgdata)
                 # For precompiled packages, we can read the source later (whenever we need it)
                 # from the *.ji cachefile.


### PR DESCRIPTION
Ensure that we parse into the correct module. This seems to fix #312. Testing this is brutally hard, so let's just take the fix and call it a day.