### PR TITLE
Don't interpret `includet` (workaround for #302)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CodeTracking = "~0.5.1"
-JuliaInterpreter = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7"
+JuliaInterpreter = "~0.7.1"
 LoweredCodeUtils = "0.3.8"
 julia = "1"
 

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -1069,6 +1069,10 @@ function __init__()
         pkgdata = pkgdatas[id]
         init_watching(pkgdata, srcfiles(pkgdata))
     end
+    # Add `includet` to the compiled_modules (fixes #302)
+    for m in methods(includet)
+        push!(JuliaInterpreter.compiled_methods, m)
+    end
     # Set up a repository for methods defined at the REPL
     id = PkgId(nothing, "@REPL")
     pkgdatas[id] = pkgdata = PkgData(id, nothing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1697,6 +1697,54 @@ end
         end
         yry()
         @test f264() == 2
+
+        # recursive `includet`s (issue #302)
+        testdir = newtestdir()
+        srcfile1 = joinpath(testdir, "Test302.jl")
+        open(srcfile1, "w") do io
+            print(io, """
+            module Test302
+            struct Parameters{T}
+                control::T
+            end
+            function Parameters(control = nothing; kw...)
+                Parameters(control)
+            end
+            function (p::Parameters)(; kw...)
+                p
+            end
+            end
+            """)
+        end
+        srcfile2 = joinpath(testdir, "test2.jl")
+        open(srcfile2, "w") do io
+            print(io, """
+            includet(joinpath(@__DIR__, "Test302.jl"))
+            using .Test302
+            """)
+        end
+        sleep(mtimedelay)
+        includet(srcfile2)
+        sleep(mtimedelay)
+        p = Test302.Parameters{Int}(3)
+        @test p() == p
+        open(srcfile1, "w") do io
+            print(io, """
+            module Test302
+            struct Parameters{T}
+                control::T
+            end
+            function Parameters(control = nothing; kw...)
+                Parameters(control)
+            end
+            function (p::Parameters)(; kw...)
+                0
+            end
+            end
+            """)
+        end
+        yry()
+        @test p() == 0
     end
 
     @testset "Auto-track user scripts" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2101,6 +2101,7 @@ end
                     include(srcfile)
                 end
             end
+            sleep(mtimedelay)
             touch(srcfile)
             sleep(mtimedelay)
             @test Main.__entr__ == 1


### PR DESCRIPTION
Fixes #302, although it also needs ~~a little something on the JuliaIntepreter side.~~ https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/331 ~~works, but it's a little weird, so I'm going to leave this here until I have a chance to dig a little more.~~