### PR TITLE
Allow Revise to be loaded in -e/E arguments

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -1045,7 +1045,9 @@ function __init__()
         elseif isdefined(Main, :IJulia)
             Main.IJulia.push_preexecute_hook(revise)
         elseif Base.isinteractive()
-            @async Revise.wait_steal_repl_backend()
+            atreplinit() do repl
+                @async Revise.wait_steal_repl_backend()
+            end
         end
         if isdefined(Main, :Atom)
             setup_atom(getfield(Main, :Atom)::Module)

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -1044,6 +1044,8 @@ function __init__()
             steal_repl_backend(Base.active_repl_backend::REPL.REPLBackend)
         elseif isdefined(Main, :IJulia)
             Main.IJulia.push_preexecute_hook(revise)
+        elseif Base.isinteractive()
+            @async Revise.wait_steal_repl_backend()
         end
         if isdefined(Main, :Atom)
             setup_atom(getfield(Main, :Atom)::Module)


### PR DESCRIPTION
@timholy Did you mean like this?

I have been running Revise with essentially this patch (sans the `Base.isinteractive` check) for quite a while now and everything has been working fine.

At some point, I did see an issue when I would get some warnings with scripts (i.e. running `julia script.jl`). I don't remember exactly, but I think it was about stealing the REPL when there isn't one when I had `using Revise` in the startup file. But I wasn't able to reproduce that anymore. And hopefully the `Base.isinteractive` check will get around that?

As far as I can tell, this definitely fixes #202, i.e. `julia -i -e 'using Revise; includet("script.jl")'` now works as expected.