### PR TITLE
 Improve error message in case of parsing problems (fixes #301) 

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -291,7 +291,7 @@ function eval_new!(exs_sigs_new::ExprsSigs, exs_sigs_old, mod::Module)
             else
                 sigs = exs_sigs_old[rexo]
                 # Update location info
-                ln, lno = firstline(rex), firstline(rexo)
+                ln, lno = firstline(unwrap(rex)), firstline(unwrap(rexo))
                 if sigs !== nothing && !isempty(sigs) && ln != lno
                     @debug "LineOffset" _group="Action" time=time() deltainfo=(sigs, lno=>ln)
                     for sig in sigs
@@ -563,12 +563,13 @@ function revise(mod::Module)
         for (mod, exsigs) in fi.modexsigs
             for def in keys(exsigs)
                 ex = def.ex
-                isexpr(ex, :call) && ex.args[1] == :include && continue
+                exuw = unwrap(ex)
+                isexpr(exuw, :call) && exuw.args[1] == :include && continue
                 try
                     Core.eval(mod, ex)
                 catch err
                     @show mod
-                    display(def)
+                    display(ex)
                     rethrow(err)
                 end
             end

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -205,7 +205,7 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, fra
                             showerror(io, err)
                         end
                         fl, ln = whereis(frame)
-                        println(stderr, "\nin expression starting at ", fl, ": ", ln)
+                        println(stderr, "\nin expression starting at ", location_string(fl, ln))
                         badstmt = lookup_callexpr(frame, stmt)
                         @warn "omitting call expression $badstmt"
                         assign_this!(frame, nothing)

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -190,7 +190,7 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, fra
                     # A :call Expr we don't want to intercept
                     try
                         pc = step_expr!(recurse, frame, stmt, true)
-                    catch
+                    catch err
                         # This can happen with functions defined in `let` blocks, e.g.,
                         #     let trynames(names) = begin
                         #         return root_path::AbstractString -> begin
@@ -201,8 +201,13 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, fra
                         #         global manifestfile_path = trynames(Base.manifest_names)
                         #     end
                         # as found in Pkg.Types.
+                        Base.with_output_color(Base.error_color(), stderr) do io
+                            showerror(io, err)
+                        end
+                        fl, ln = whereis(frame)
+                        println(stderr, "\nin expression starting at ", fl, ": ", ln)
                         badstmt = lookup_callexpr(frame, stmt)
-                        @warn "omitting call expression $badstmt in $(whereis(frame))"
+                        @warn "omitting call expression $badstmt"
                         assign_this!(frame, nothing)
                         pc = next_or_nothing!(frame)
                     end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -48,8 +48,8 @@ function parse_source!(mod_exprs_sigs::ModuleExprsSigs, src::AbstractString, fil
         if exprs_sigs === nothing
             mod_exprs_sigs[mod] = exprs_sigs = ExprsSigs()
         end
-        exprs_sigs[unwrap(ex)] = nothing
-        # exprs_sigs[ex] = nothing
+        # exprs_sigs[unwrap(ex)] = nothing
+        exprs_sigs[ex] = nothing
     end
     for (mod, docexs) in docexprs
         exprs_sigs = get(mod_exprs_sigs, mod, nothing)

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -29,7 +29,13 @@ Base.copy(rex::RelocatableExpr) = RelocatableExpr(copy(rex.ex))
 # Implement the required comparison functions. `hash` is needed for Dicts.
 function Base.:(==)(ra::RelocatableExpr, rb::RelocatableExpr)
     a, b = ra.ex, rb.ex
-    a.head == b.head && isequal(LineSkippingIterator(a.args), LineSkippingIterator(b.args))
+    if a.head == b.head
+    elseif a.head == :block
+        a = unwrap(a)
+    elseif b.head == :block
+        b = unwrap(b)
+    end
+    return a.head == b.head && isequal(LineSkippingIterator(a.args), LineSkippingIterator(b.args))
 end
 
 const hashrex_seed = UInt == UInt64 ? 0x7c4568b6e99c82d9 : 0xb9c82fd8

--- a/src/types.jl
+++ b/src/types.jl
@@ -33,7 +33,7 @@ function Base.show(io::IO, exsigs::ExprsSigs)
         print(io, "ExprsSigs with the following expressions: ")
         for def in keys(exsigs)
             print(io, "\n  ")
-            Base.show_unquoted(io, def, 2)
+            Base.show_unquoted(io, RelocatableExpr(unwrap(def)), 2)
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,6 +41,9 @@ firstline(rex::RelocatableExpr) = firstline(rex.ex)
 
 newloc(methloc::LineNumberNode, ln, lno) = fixpath(ln)
 
+location_string(file::AbstractString, line) = abspath(file)*':'*string(line)
+location_string(file::Symbol, line) = location_string(string(file), line)
+
 # Return the only non-trivial expression in ex, or ex itself
 function unwrap(ex::Expr)
     if ex.head == :block

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,7 +182,7 @@ k(x) = 4
         (def, val) = dvs[1]
         @test isequal(def, Revise.RelocatableExpr(:(square(x) = x^2)))
         @test val == [Tuple{typeof(ReviseTest.square),Any}]
-        @test Revise.firstline(def).line == 5
+        @test Revise.firstline(Revise.unwrap(def)).line == 5
         m = @which ReviseTest.square(1)
         @test m.line == 5
         @test whereis(m) == (tmpfile, 5)
@@ -207,7 +207,7 @@ k(x) = 4
         (def, val) = dvs[1]
         @test isequal(def,  Revise.RelocatableExpr(:(mult2(x) = 2*x)))
         @test val == [Tuple{typeof(ReviseTest.Internal.mult2),Any}]
-        @test Revise.firstline(def).line == 13
+        @test Revise.firstline(Revise.unwrap(def)).line == 13
         m = @which ReviseTest.Internal.mult2(1)
         @test m.line == 11
         @test whereis(m) == (tmpfile, 13)
@@ -1518,6 +1518,33 @@ end
         @test occursin("T not defined", str)
 
         rm_precompile("RevisionErrors")
+
+        testfile = joinpath(testdir, "Test301.jl")
+        open(testfile, "w") do io
+            print(io, """
+            module Test301
+            mutable struct Struct301
+                x::Int
+                err
+
+                Struct301(x::Integer) = new(x)
+            end
+            f(s) = s.err
+            const s = Struct301(1)
+            f(s)
+            end
+            """)
+        end
+        logfile = joinpath(tempdir(), randtmp()*".log")
+        Test.collect_test_logs() do
+            open(logfile, "w") do io
+                redirect_stderr(io) do
+                    includet(testfile)
+                end
+            end
+        end
+        str = read(logfile, String)
+        @test occursin("Test301.jl: 10", str)
     end
 
     @testset "get_def" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1544,7 +1544,7 @@ end
             end
         end
         str = read(logfile, String)
-        @test occursin("Test301.jl: 10", str)
+        @test occursin("Test301.jl:10", str)
     end
 
     @testset "get_def" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2115,48 +2115,50 @@ end
 end
 
 @testset "entr" begin
-    srcfile = joinpath(tempdir(), randtmp()*".jl")
-    push!(to_remove, srcfile)
-    open(srcfile, "w") do io
-        println(io, "Core.eval(Main, :(__entr__ = 1))")
-    end
-    sleep(mtimedelay)
-    try
-        @sync begin
-            @async begin
-                entr([srcfile]) do
-                    include(srcfile)
+    if !Sys.isapple()   # these tests are very flaky on OSX
+        srcfile = joinpath(tempdir(), randtmp()*".jl")
+        push!(to_remove, srcfile)
+        open(srcfile, "w") do io
+            println(io, "Core.eval(Main, :(__entr__ = 1))")
+        end
+        sleep(mtimedelay)
+        try
+            @sync begin
+                @async begin
+                    entr([srcfile]) do
+                        include(srcfile)
+                    end
+                end
+                sleep(mtimedelay)
+                touch(srcfile)
+                sleep(mtimedelay)
+                @test Main.__entr__ == 1
+                open(srcfile, "w") do io
+                    println(io, "Core.eval(Main, :(__entr__ = 2))")
+                end
+                sleep(mtimedelay)
+                @test Main.__entr__ == 2
+                open(srcfile, "w") do io
+                    println(io, "error(\"stop\")")
+                end
+                sleep(mtimedelay)
+            end
+            @test false
+        catch err
+            while err isa CompositeException
+                err = err.exceptions[1]
+                @static if VERSION >= v"1.3.0-alpha.110"
+                    if  err isa TaskFailedException
+                        err = err.task.exception
+                    end
+                end
+                if err isa CapturedException
+                    err = err.ex
                 end
             end
-            sleep(mtimedelay)
-            touch(srcfile)
-            sleep(mtimedelay)
-            @test Main.__entr__ == 1
-            open(srcfile, "w") do io
-                println(io, "Core.eval(Main, :(__entr__ = 2))")
-            end
-            sleep(mtimedelay)
-            @test Main.__entr__ == 2
-            open(srcfile, "w") do io
-                println(io, "error(\"stop\")")
-            end
-            sleep(mtimedelay)
+            @test isa(err, LoadError)
+            @test err.error.msg == "stop"
         end
-        @test false
-    catch err
-        while err isa CompositeException
-            err = err.exceptions[1]
-            @static if VERSION >= v"1.3.0-alpha.110"
-                if  err isa TaskFailedException
-                    err = err.task.exception
-                end
-            end
-            if err isa CapturedException
-                err = err.ex
-            end
-        end
-        @test isa(err, LoadError)
-        @test err.error.msg == "stop"
     end
 end
 


### PR DESCRIPTION
This should generate error messages much more similar to Base's. The biggest change here is to avoid calling `unwrap` on the stored expressions, which produced better location info in some cases but necessitated some changes elsewhere.

Also, @mlhetland and @essenciary, I have disabled the `entr` tests on OSX. They have been the cause of [many failures](https://travis-ci.org/timholy/Revise.jl/builds) (note I went through a period where I allowed failures on OSX, so some of those green checks are a bit misleading). I have tried several approaches (e.g., 77cfdcb3f1c71eeec2bacebcbfdb43a3cb5dba38, e22ec82548c103f97cccb6a5d7b024e65fda759c, f1645112a28833dd9ad20376a794dc367ae33160, 8c60017f70824a264e37367fecf1cf89eb80c578) without completely nailing the problem. Because `entr` is a bit specialized, I don't want to fail to test the core functionality of the package, so disabling those specific tests seems best. But of course things could decay, so I wanted you to know.
