### PR TITLE
Don't use "." as the basedir

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -36,6 +36,7 @@ string. `pos` is the 1-based byte offset from which to begin parsing `src`.
 See also [`Revise.parse_source`](@ref).
 """
 function parse_source!(mod_exprs_sigs::ModuleExprsSigs, src::AbstractString, filename::AbstractString, mod::Module)
+    startswith(src, "# REVISE: DO NOT PARSE") && return nothing
     ex = Base.parse_input_line(src; filename=filename)
     ex === nothing && return mod_exprs_sigs
     if isexpr(ex, :error) || isexpr(ex, :incomplete)

--- a/src/types.jl
+++ b/src/types.jl
@@ -126,7 +126,13 @@ end
 
 PkgData(id::PkgId, path) = PkgData(PkgFiles(id, path), FileInfo[])
 PkgData(id::PkgId, ::Nothing) = PkgData(id, "")
-PkgData(id::PkgId) = PkgData(id, normpath(basepath(id)))
+function PkgData(id::PkgId)
+    bp = basepath(id)
+    if !isempty(bp)
+        bp = normpath(bp)
+    end
+    PkgData(id, bp)
+end
 
 # Abstraction interface for PkgData
 Base.PkgId(pkgdata::PkgData) = PkgId(pkgdata.info)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+# REVISE: DO NOT PARSE   # For people with JULIA_REVISE_INCLUDE=1
 using Revise, CodeTracking, JuliaInterpreter
 using Test
 
@@ -1789,6 +1790,9 @@ end
         end
         sleep(mtimedelay)
         # By default user scripts are not tracked
+        # issue #358: but if the user is tracking all includes...
+        user_track_includes = Revise.tracking_Main_includes[]
+        Revise.tracking_Main_includes[] = false
         include(srcfile)
         yry()
         @test revise_g() == 1
@@ -1824,7 +1828,7 @@ end
                 yry()
             end
         finally
-            Revise.tracking_Main_includes[] = false  # restore old behavior
+            Revise.tracking_Main_includes[] = user_track_includes  # restore old behavior
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,13 @@ const pair_op_compact = let io = IOBuffer()
 end
 
 @testset "Revise" begin
+    @testset "PkgData" begin
+        # Related to #358
+        id = Base.PkgId(Main)
+        pd = Revise.PkgData(id)
+        @test isempty(Revise.basedir(pd))
+    end
+
     @testset "LineSkipping" begin
         rex = Revise.RelocatableExpr(quote
                                     f(x) = x^2


### PR DESCRIPTION
Fixes the important part of #358. The first commit is the important one, the second commit is largely cosmetic (to make the tests pass even if the user is running with `JULIA_REVISE_INCLUDE=1`).