### PR TITLE
Backport to #357 to v1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,28 @@
+name = "Revise"
+uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
+version = "1.1.1"
+
+[deps]
+CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1"
+
+[extras]
+EponymTuples = "97e2ac4a-e175-5f49-beb1-4d6866a6cdc3"
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[targets]
+test = ["Test", "Example", "EponymTuples", "InteractiveUtils", "Random", "Pkg", "Unicode", "RecipesBase"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 1.0
-OrderedCollections
-CodeTracking

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -72,7 +72,9 @@ function parse_pkg_files(id::PkgId)
         # Try to find the matching cache file
         uuid = id.uuid
         paths = Base.find_all_in_cache_path(id)
+        sourcepath = Base.locate_package(id)
         for path in paths
+            Base.stale_cachefile(sourcepath, path) === true && continue
             provides, includes_requires = parse_cache_header(path)
             mods_files_mtimes, _ = includes_requires
             for (pkgid, buildid) in provides

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,0 @@
-Example
-RecipesBase
-Plots
-EponymTuples
-JSON


### PR DESCRIPTION
Following the advice of @KristofferC (https://github.com/timholy/Revise.jl/pull/357#issuecomment-531950644).
If someone with push permission could create a `release-1.1` branch so that the PR is actually sensible.