### PR TITLE
Define `Base.typeinfo_prefix` for ModExSigs

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -54,6 +54,8 @@ To create a `ModuleExprsSigs` from a source file, see [`Revise.parse_source`](@r
 """
 const ModuleExprsSigs = OrderedDict{Module,ExprsSigs}
 
+Base.typeinfo_prefix(io::IO, mexs::ModuleExprsSigs) = string(typeof(mexs).name)
+
 """
     fm = ModuleExprsSigs(mod::Module)
 


### PR DESCRIPTION
This fixes a test failure on nightly, ref https://github.com/JuliaLang/julia/pull/33290.