### PR TITLE
update to https://github.com/JunoLab/Atom.jl/pull/177

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -1115,11 +1115,13 @@ end
 
 function setup_atom(atommod::Module)::Nothing
     handlers = getfield(atommod, :handlers)
-    for x in ["eval", "evalall", "evalrepl"]
-        old = handlers[x]
-        Main.Atom.handle(x) do data
-            revise()
-            old(data)
+    for x in ["eval", "evalall", "evalshow", "evalrepl"]
+        if haskey(handlers, x)
+            old = handlers[x]
+            Main.Atom.handle(x) do data
+                revise()
+                old(data)
+            end
         end
     end
     return nothing


### PR DESCRIPTION
update to https://github.com/JunoLab/Atom.jl/pull/177

Actually the `evalrepl` handler hasn't been used in recent Juno versions, thus I think we even don't need version compat checks for this change.