### PR TITLE
Update config to include auto install of Revise.jl

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -8,6 +8,8 @@ adding the following to your `.julia/config/startup.jl` file:
 ```julia
 atreplinit() do repl
     try
+        @eval using Pkg
+        haskey(Pkg.installed(), "Revise") || @eval Pkg.add("Revise")
         @eval using Revise
         @async Revise.wait_steal_repl_backend()
     catch


### PR DESCRIPTION
I am using [juliavm](https://github.com/pmargreff/juliavm) to manage multiple versions of `julia`.  When I switch versions the above script will auto install `Revise.jl`.  Using the auto install as above does not noticeably increase my subsequent startup times.