### PR TITLE
Ignore errors when non-Julia files cannot be handled

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -592,6 +592,7 @@ function revise()
             push!(finished, (pkgdata, file))
         catch err
             push!(revision_errors, (basedir(pkgdata), file, err))
+            endswith(file, ".jl") || continue
             push!(queue_errors, (pkgdata, file))
         end
     end
@@ -606,6 +607,7 @@ function revise()
             maybe_add_includes_to_pkgdata!(pkgdata, file, includes)
         catch err
             push!(revision_errors, (basedir(pkgdata), file, err))
+            endswith(file, ".jl") || continue
             push!(queue_errors, (pkgdata, file))
         end
     end


### PR DESCRIPTION
I use the following pattern ([example](https://github.com/tkf/InitialValues.jl/blob/54f1f0b43aff57aa35fd624132a901b88708007d/src/InitialValues.jl#L4-L7)) a lot to include README in the docstring so that I can test the examples in it:

```julia
module MyPackage

@doc let path = joinpath(dirname(@__DIR__), "README.md")
    include_dependency(path)
    replace(read(path, String), r"^```julia"m => "```jldoctest README")
end MyPackage

...
end
```

However, this gives me warnings like this

```
┌ Warning: Failed to revise /PATH/TO/README.md: ErrorException("/PATH/TO/README.md is not stored in the source-text cache")
└ @ Revise ~/.julia/dev/Revise/src/Revise.jl:615
┌ Warning: Due to a previously reported error, the running code does not match saved version for the following files:
│   /PATH/TO/README.md
└ @ Revise ~/.julia/dev/Revise/src/Revise.jl:623
```

after I edit the README.  I can workaround the second error by `empty!(Revise.queue_errors)` but it'd be nice if Revise supports this out-of-the-box.

This PR implements a simple approach (maybe too simple) to fix it by just checking the extension of the file on error.  It is somewhat conservative in that the first error is still printed.  What do you think?  Is it good enough?
