### PR TITLE
Handle file deletion and fix stdlib paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 This lists only major changes, and does not include bug fixes,
 cleanups, or minor enhancements.
 
+# Revise 2.3
+
+* Avoid running code that is not needed for method definitions when computing signatures.
+  This leads to improved safety and performance.
+* Switch to an O(N) algorithm for renaming frame methods to match their running variants
+* Support addition and deletion of source files
+* Improve handling and printing of errors
+
 # Revise 2.2
 
 * Revise now warns you when the source files are not synchronized with running code.
@@ -12,7 +20,7 @@ New features:
 
 * Add `entr` for re-running code any time a set of dependent files and/or
   packages change.
-  
+
 # Revise 2.0
 
 Revise 2.0 is a major rewrite with
@@ -25,37 +33,37 @@ Breaking changes:
 
 * The ability to revise code in Core.Compiler has regressed until technical
   issues are resolved in JuliaInterpreter.
-  
+
 * In principle, code that cannot be evaluated twice (e.g., library initialization)
   could be problematic.
-  
+
 New features:
 
 * Revise now (re)evaluates top-level code to extract method signatures. This allows
   Revise to identify methods defined by code, e.g., by an `@eval` block.
   Moreover, Revise can identify important changes external to the definition, e.g.,
   if
-  
+
   ```julia
   for T in (Float16, Float32, Float32)
       @eval foo(::Type{$T}) = 1
   end
   ```
-  
+
   gets revised to
-  
+
   ```julia
   for T in (Float32, Float32)
       @eval foo(::Type{$T}) = 1
   end
   ```
-  
+
   then Revise correctly deletes the `Float16` method of `foo`. ([#243])
 
 * Revise handles all method deletions before enacting any new definitions.
   As a consequence, moving methods from one file to another is more robust.
   ([#243])
-  
+
 * Revise was split, with a new package
   [CodeTracking](https://github.com/timholy/CodeTracking.jl)
   designed to be the "query" interface for Revise. ([#245])

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -3,7 +3,6 @@
 There are some kinds of changes that Revise (or often, Julia itself) cannot incorporate into a running Julia session:
 
 - changes to type definitions
-- adding new source files to packages, or file/module renames
 - conflicts between variables and functions sharing the same name
 
 These kinds of changes require that you restart your Julia session.

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -480,7 +480,7 @@ This is generally called via a [`Revise.Rescheduler`](@ref).
     @assert isabspath(dirname)
     if !isdir(dirname)
         sleep(0.1)   # in case git has done a delete/replace cycle
-        if !isfile(dirname)
+        if !isdir(dirname)
             with_logger(SimpleLogger(stderr)) do
                 @warn "$dirname is not an existing directory, Revise is not watching"
             end

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -512,12 +512,10 @@ function revise_file_queued(pkgdata::PkgData, file)
     if !isabspath(file)
         file = joinpath(basedir(pkgdata), file)
     end
-    if !isfile(file)
+    if !file_exists(file)
         sleep(0.1)  # in case git has done a delete/replace cycle
-        if !isfile(file)
-            with_logger(SimpleLogger(stderr)) do
-                @error "$file is not an existing file, Revise is not watching"
-            end
+        if !file_exists(file)
+            push!(revision_queue, (pkgdata, file0))  # process file deletions
             return false
         end
     end
@@ -538,7 +536,8 @@ function handle_deletions(pkgdata, file)
     mexsold = fi.modexsigs
     filep = normpath(joinpath(basedir(pkgdata), file))
     topmod = first(keys(mexsold))
-    mexsnew = parse_source(filep, topmod)
+    mexsnew = file_exists(filep) ? parse_source(filep, topmod) :
+              (@warn("$filep no longer exists, deleting all methods"); ModuleExprsSigs(topmod))
     if mexsnew !== nothing
         delete_missing!(mexsold, mexsnew)
     end

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -284,6 +284,14 @@ function watch_files_via_dir(dirname)
         wf = watched_files[dirname]
         for (file, id) in wf.trackedfiles
             fullpath = joinpath(dirname, file)
+            if !file_exists(fullpath)
+                # File may have been deleted. But be very sure.
+                sleep(0.1)
+                if !file_exists(fullpath)
+                    push!(latestfiles, file=>id)
+                    continue
+                end
+            end
             if newer(mtime(fullpath), wf.timestamp)
                 push!(latestfiles, file=>id)
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,6 +23,13 @@ function unique_dirs(iter)
     return udirs
 end
 
+function file_exists(filename)
+    isfile(filename) && return true
+    alt = get(cache_file_key, filename, nothing)
+    alt === nothing && return false
+    return isfile(alt)
+end
+
 function use_compiled_modules()
     return Base.JLOptions().use_compiled_modules != 0
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,6 +24,7 @@ function unique_dirs(iter)
 end
 
 function file_exists(filename)
+    filename = normpath(filename)
     isfile(filename) && return true
     alt = get(cache_file_key, filename, nothing)
     alt === nothing && return false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2227,7 +2227,37 @@ end
     @test NewFile.f() == 1
     @test NewFile.g() == 2
 
+    dn = joinpath(testdir, "DeletedFile", "src")
+    mkpath(dn)
+    open(joinpath(dn, "DeletedFile.jl"), "w") do io
+        println(io, """
+            module DeletedFile
+            include("g.jl")
+            f() = 1
+            end
+            """)
+    end
+    open(joinpath(dn, "g.jl"), "w") do io
+        println(io, "g() = 1")
+    end
+    sleep(mtimedelay)
+    @eval using DeletedFile
+    @test DeletedFile.f() == DeletedFile.g() == 1
+    sleep(mtimedelay)
+    open(joinpath(dn, "DeletedFile.jl"), "w") do io
+        println(io, """
+            module DeletedFile
+            f() = 1
+            end
+            """)
+    end
+    rm(joinpath(dn, "g.jl"))
+    yry()
+    @test DeletedFile.f() == 1
+    @test_throws MethodError DeletedFile.g()
+
     rm_precompile("NewFile")
+    rm_precompile("DeletedFile")
     pop!(LOAD_PATH)
 
     # # https://discourse.julialang.org/t/revise-with-requires/19347

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2407,12 +2407,13 @@ GC.gc(); GC.gc()
                     catch
                     end
                 end
-                try yry() catch end
+                for i = 1:3
+                    yry()
+                    GC.gc()
+                end
             end
         end
-        if !Sys.isapple()
-            @test occursin("is not an existing directory", read(warnfile, String))
-        end
+        @test occursin("is not an existing directory", read(warnfile, String))
         rm(warnfile)
     end
 end


### PR DESCRIPTION
This is essentially the opposite operation from #386.

This proved much more interesting than expected: it revealed a bug in which `Pkg/src/REPLcompletions.jl` was confused for the REPL stdlib. Consequently this PR also fixes that bug.