### PR TITLE
Record correct assignment line (fixes #399)

### DIFF
--- a/src/backedges.jl
+++ b/src/backedges.jl
@@ -18,7 +18,7 @@ mutable struct SlotDep
 end
 function SlotDep(i::Int, stmt, slotdeps)
     deps = add_deps!(Int[], stmt, slotdeps)
-    SlotDep(isssa(stmt) ? 0 : i, deps)
+    SlotDep(i, deps)
 end
 function add_deps!(linedeps, stmt, slotdeps)
     if isssa(stmt)


### PR DESCRIPTION
I am not quite why the offending check was there (it doesn't seem to make a lot of sense), but it doesn't seem to break anything to remove it. I am guessing it's a legacy of the order in which stuff was developed.