### PR TITLE
Fix the handling of atsign-requires

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ OrderedCollections = "1"
 julia = "1"
 
 [extras]
+CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
 EndpointRanges = "340492b5-2a47-5f55-813d-aca7ddf97656"
 EponymTuples = "97e2ac4a-e175-5f49-beb1-4d6866a6cdc3"
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
@@ -33,4 +34,4 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "EndpointRanges", "Example", "EponymTuples", "InteractiveUtils", "MappedArrays", "Random", "Requires"]
+test = ["Test", "CatIndices", "EndpointRanges", "Example", "EponymTuples", "InteractiveUtils", "MappedArrays", "Random", "Requires"]

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -331,7 +331,7 @@ function add_require(sourcefile, modcaller, idmod, modname, expr)
         end
         fi = pkgdata.fileinfos[fileidx]
         # Tag the expr to ensure it is unique
-        expr = copy(expr)
+        expr = Expr(:block, copy(expr))
         push!(expr.args, :(__pkguuid__ = $idmod))
         # Add the expression to the fileinfo
         exsnew = ExprsSigs()


### PR DESCRIPTION
For a simple call expression inside the `@require`, this was adding a new argument.