### PR TITLE
Use composable AST transform on Julia 1.5

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -3,7 +3,25 @@
 ## Using Revise by default
 
 If you like Revise, you can ensure that every Julia session uses it by
-adding the following to your `.julia/config/startup.jl` file:
+launching it from your `.julia/config/startup.jl` file.
+
+**If you always use Julia-1.5-DEV.282 or higher**, this can be as simple as
+
+```julia
+using Revise
+```
+
+or, if you use different package depots and do not always have Revise available,
+
+```julia
+try
+    using Revise
+catch e
+    @warn(e.msg)
+end
+```
+
+**If you sometimes use versions of Julia prior to 1.5**, use
 
 ```julia
 atreplinit() do repl
@@ -15,6 +33,8 @@ atreplinit() do repl
     end
 end
 ```
+
+## Using Revise automatically within Jupyter/IJulia
 
 If you want Revise to launch automatically within IJulia, then you should also create a `.julia/config/startup_ijulia.jl` file with the contents
 


### PR DESCRIPTION
Because the startup file loads before the REPL is available, we still need to wait for it to become available. Consequently I've kept the whole `wait_steal_repl_backend`, and made that do something different as appropriate. An advantage is that we don't need to tell folks to change their startup.jl files again.

Closes #423
CC @stevengj
