### PR TITLE
Fix revising baremodules

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -112,7 +112,8 @@ end
 
 function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, frame, musteval; define=true, skip_include=true)
     mod = moduleof(frame)
-    modinclude = getfield(mod, :include)  # hoist this lookup for performance
+    # Hoist this lookup for performance. Don't throw even when `mod` is a baremodule:
+    modinclude = isdefined(mod, :include) ? getfield(mod, :include) : nothing
     signatures = []  # temporary for method signature storage
     pc = frame.pc
     while true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2168,6 +2168,34 @@ end
             pop!(hp.history)
         end
     end
+
+    @testset "baremodule" begin
+        testdir = newtestdir()
+        dn = joinpath(testdir, "Baremodule", "src")
+        mkpath(dn)
+        open(joinpath(dn, "Baremodule.jl"), "w") do io
+            println(io, """
+baremodule Baremodule
+f() = 1
+end
+""")
+        end
+        sleep(mtimedelay)
+        @eval using Baremodule
+        sleep(mtimedelay)
+        @test Baremodule.f() == 1
+        open(joinpath(dn, "Baremodule.jl"), "w") do io
+            println(io, """
+module Baremodule
+f() = 2
+end
+""")
+        end
+        yry()
+        @test Baremodule.f() == 2
+        rm_precompile("Baremodule")
+        pop!(LOAD_PATH)
+    end
 end
 
 @testset "Switching free/dev" begin


### PR DESCRIPTION
It looks like Revise.jl can't handle baremodules as it is assuming `include` to exist in all modules.  This PR adds a simple fix and a test.