### PR TITLE
Support user-specified callbacks

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -157,7 +157,15 @@ function remove_callback(key)
         delete!(cbs, key)
     end
     delete!(user_callbacks_by_key, key)
-    # TODO: stop watching these files
+
+    # possible future work: we may stop watching (some of) these files
+    # now. But we don't really keep track of what background tasks are running
+    # and Julia doesn't have an ergonomic way of task cancellation yet (see
+    # e.g.
+    #     https://github.com/JuliaLang/Juleps/blob/master/StructuredConcurrency.md
+    # so we'll omit this for now. The downside is that in pathological cases,
+    # this may exhaust inotify resources.
+
     nothing
 end
 

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -564,7 +564,7 @@ This is generally called via a [`Revise.Rescheduler`](@ref).
     latestfiles, stillwatching = watch_files_via_dir(dirname)  # will block here until file(s) change
     for (file, id) in latestfiles
         key = joinpath(dirname, file)
-        if key in keys(user_callbacks_by_file) # TODO: also do this for per-file watching
+        if key in keys(user_callbacks_by_file)
             union!(user_callbacks_queue, user_callbacks_by_file[key])
             notify(revision_event)
         end
@@ -603,6 +603,12 @@ function revise_file_queued(pkgdata::PkgData, file)
     end
 
     wait_changed(file)  # will block here until the file changes
+
+    if file in keys(user_callbacks_by_file)
+        union!(user_callbacks_queue, user_callbacks_by_file[file])
+        notify(revision_event)
+    end
+
     # Check to see if we're still watching this file
     dirfull, basename = splitdir(file)
     if haskey(watched_files, dirfull)

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -107,6 +107,18 @@ const user_callbacks_queue = Set{Any}()
 const user_callbacks_by_file = Dict{String, Set{Any}}()
 const user_callbacks_by_key = Dict{Any, Any}()
 
+"""
+    key = Revise.add_callback(f, files, modules=nothing; key=gensym())
+
+Add a user-specified callback, to be executed during the first run of
+`revise()` after a file in `files` or a module in `modules` is changed on the
+file system. In an interactive session like the REPL, Juno or Jupyter, this
+means the callback executes immediately before executing a new command / cell.
+
+You can use the return value `key` to remove the callback later
+(`Revise.remove_callback`) or to update it using another call
+to `Revise.add_callback` with `key=key`.
+"""
 function add_callback(f, files, modules=nothing; key=gensym())
     remove_callback(key)
 
@@ -134,6 +146,12 @@ function add_callback(f, files, modules=nothing; key=gensym())
     return key
 end
 
+"""
+    Revise.remove_callback(key)
+
+Remove a callback previously installed by a call to `Revise.add_callback(...)`.
+See its docstring for details.
+"""
 function remove_callback(key)
     for cbs in values(user_callbacks_by_file)
         delete!(cbs, key)

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -913,7 +913,6 @@ function entr(f::Function, files, modules=nothing; postpone=false, pause=0.02)
         sleep(pause)
         f()
     end
-    mycallbacks = [key]
     try
         while true
             wait(revision_event)

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -491,6 +491,7 @@ function watch_manifest(mfile)
                             maybe_parse_from_cache!(pkgdata, file)
                             push!(revision_queue, (pkgdata, file))
                             push!(files, file)
+                            notify(revision_event)
                         end
                         # Update the directory
                         pkgdata.info.basedir = pkgdir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2815,6 +2815,40 @@ do_test("callbacks") && @testset "callbacks" begin
         @test contents[] == "abcdef"
     end
 
+    testdir = newtestdir()
+    modname = "A355"
+    srcfile = joinpath(testdir, modname * ".jl")
+
+    function setvalue(x)
+        open(srcfile, "w") do io
+            print(io, "module $modname test() = $x end")
+        end
+    end
+
+    setvalue(1)
+
+    sleep(mtimedelay)
+    @eval using A355
+    sleep(mtimedelay)
+
+    A355_result = Ref(0)
+
+    Revise.add_callback([], [A355]) do
+        A355_result[] = A355.test()
+    end
+
+    sleep(mtimedelay)
+    setvalue(2)
+    # belt and suspenders -- make sure we trigger entr:
+    sleep(mtimedelay)
+    touch(srcfile)
+
+    yry()
+
+    @test A355_result[] == 2
+
+    rm_precompile(modname)
+
 end
 
 println("beginning cleanup")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2796,6 +2796,8 @@ do_test("callbacks") && @testset "callbacks" begin
         revise()
         @test contents[] == "abc"
 
+        sleep(mtimedelay)
+
         write(io, "def")
         flush(io)
         sleep(mtimedelay)
@@ -2803,6 +2805,7 @@ do_test("callbacks") && @testset "callbacks" begin
         @test contents[] == "abcdef"
 
         Revise.remove_callback(key)
+        sleep(mtimedelay)
 
         write(io, "ghi")
         flush(io)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2780,6 +2780,39 @@ do_test("entr with modules") && @testset "entr with modules" begin
 
 end
 
+do_test("callbacks") && @testset "callbacks" begin
+
+    mktemp() do path, io
+        contents = Ref("")
+        key = Revise.add_callback([path]) do
+            contents[] = read(path, String)
+        end
+
+        sleep(mtimedelay)
+
+        write(io, "abc")
+        flush(io)
+        sleep(mtimedelay)
+        revise()
+        @test contents[] == "abc"
+
+        write(io, "def")
+        flush(io)
+        sleep(mtimedelay)
+        revise()
+        @test contents[] == "abcdef"
+
+        Revise.remove_callback(key)
+
+        write(io, "ghi")
+        flush(io)
+        sleep(mtimedelay)
+        revise()
+        @test contents[] == "abcdef"
+    end
+
+end
+
 println("beginning cleanup")
 GC.gc(); GC.gc()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2782,7 +2782,11 @@ end
 
 do_test("callbacks") && @testset "callbacks" begin
 
-    mktemp() do path, io
+    append(path, x...) = open(path, append=true) do io
+        write(io, x...)
+    end
+
+    mktemp() do path, _
         contents = Ref("")
         key = Revise.add_callback([path]) do
             contents[] = read(path, String)
@@ -2790,16 +2794,14 @@ do_test("callbacks") && @testset "callbacks" begin
 
         sleep(mtimedelay)
 
-        write(io, "abc")
-        flush(io)
+        append(path, "abc")
         sleep(mtimedelay)
         revise()
         @test contents[] == "abc"
 
         sleep(mtimedelay)
 
-        write(io, "def")
-        flush(io)
+        append(path, "def")
         sleep(mtimedelay)
         revise()
         @test contents[] == "abcdef"
@@ -2807,8 +2809,7 @@ do_test("callbacks") && @testset "callbacks" begin
         Revise.remove_callback(key)
         sleep(mtimedelay)
 
-        write(io, "ghi")
-        flush(io)
+        append(path, "ghi")
         sleep(mtimedelay)
         revise()
         @test contents[] == "abcdef"


### PR DESCRIPTION
This feature is one half of what `Revise.entr` already does. The function `entr` allows the user to install callbacks for when a file or module changes, and also enters a blocking loop that catches any errors that might arise from the callbacks.

This new `add_callback` function allows installing callbacks and keeping them around in the background. This commit also reimplements `entr` in terms of `add_callback` and `remove_callback`.

(Basically, `add_callback` now does what I thought `entr` would do after seeing its signature.)

I'm hoping to use this in [`HAML.jl`](https://github.com/tkluck/HAML.jl) for updating generated code when its source file changes. It may be similarly useful for hot code reloading in web servers, etc.