### PR TITLE
Rescheduler: don't silently stop when errors are encountered

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -242,7 +242,12 @@ struct Rescheduler{F,A}
 end
 
 function (thunk::Rescheduler{F,A})() where {F,A}
-    if thunk.f(thunk.args...)::Bool
-        schedule(Task(thunk))
+    reschedule = true
+    try
+        reschedule = thunk.f(thunk.args...)::Bool
+    catch err
+        @warn "[Revise] Error during a background task" err
+    finally
+        reschedule && schedule(Task(thunk))
     end
 end


### PR DESCRIPTION
This was helpful during work on #443 to make sure my typos didn't pass silently. Maybe it's helpful for others too?

These thunks should be quite reliable (e.g., they don't contain user-specified code) but during development it's nice to have visibility on errors and keep the background workers functioning.