### PR TITLE
Avoid BoundsError on incomplete parsing (fixes #448)

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -41,7 +41,7 @@ function parse_source!(mod_exprs_sigs::ModuleExprsSigs, src::AbstractString, fil
     ex === nothing && return mod_exprs_sigs
     if isexpr(ex, :error) || isexpr(ex, :incomplete)
         prevex, pos = first_bad_position(src)
-        ln = count(isequal('\n'), SubString(src, 1, pos)) + 1
+        ln = count(isequal('\n'), SubString(src, 1, min(pos, length(src)))) + 1
         throw(LoadError(filename, ln, ex.args[1]))
     end
     modexs, docexprs = Tuple{Module,Expr}[], DocExprs()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,6 +118,27 @@ g(x) = 2
 h{x) = 3  # error
 k(x) = 4
 """, "test", Main)
+
+        # Issue #448
+        testdir = newtestdir()
+        file = joinpath(testdir, "badfile.jl")
+        open(file, "w") do io
+            println(io,
+            """
+            function g()
+                while t
+                c =
+                k
+            end
+            """)
+        end
+        try
+            includet(file)
+        catch err
+            @test isa(err, LoadError)
+            @test err.file == file
+            @test endswith(err.error, "requires end")
+        end
     end
 
     do_test("Signature extraction") && @testset "Signature extraction" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -691,6 +691,27 @@ end
         @test isempty(failedfiles)
     end
 
+    do_test("Recursive types (issue #417)") && @testset "Recursive types (issue #417)" begin
+        testdir = newtestdir()
+        fn = joinpath(testdir, "recursive.jl")
+        open(fn, "w") do io
+            println(io, """
+            module RecursiveTypes
+            struct Foo
+                x::Vector{Foo}
+
+                Foo() = new(Foo[])
+            end
+            end
+            """)
+        end
+        sleep(mtimedelay)
+        includet(fn)
+        @test isa(RecursiveTypes.Foo().x, Vector{RecursiveTypes.Foo})
+
+        pop!(LOAD_PATH)
+    end
+
     # issue #318
     do_test("Cross-module extension") && @testset "Cross-module extension" begin
         testdir = newtestdir()


### PR DESCRIPTION
Thanks for the nice reproducer, @KristofferC!

This also throws in another old commit I had failed to push, and a `test/Project.toml` file.