### PR TITLE
Fix up typo in filter_valid_cachefiles

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -81,7 +81,7 @@ end
 # that's easier to precompile. (This is a hotspot in loading Revise.)
 function filter_valid_cachefiles(sourcepath, paths)
     fpaths = String[]
-    sorcepath === nothing && return fpaths
+    sourcepath === nothing && return fpaths
     for path in paths
         if Base.stale_cachefile(sourcepath, path) !== true
             push!(fpaths, path)


### PR DESCRIPTION
This line threw an UndefVarError when I hit it, so I'm guessing this is just a simple typo fix.