### PR TITLE
Simplify Task structure

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -40,7 +40,7 @@ Revise.FileInfo
 Revise.PkgData
 Revise.WatchList
 Revise.SlotDep
-Revise.Rescheduler
+Revise.TaskThunk
 MethodSummary
 ```
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,8 +3,7 @@ function _precompile_()
 
     @assert precompile(Tuple{typeof(watch_manifest), String})
     @assert precompile(Tuple{typeof(watch_file), String, Int})
-    @assert precompile(Tuple{Rescheduler{typeof(watch_manifest), String}})
-    @assert precompile(Tuple{Rescheduler{typeof(revise_dir_queued),Tuple{String}}})
+    @assert precompile(Tuple{TaskThunk})
     @assert precompile(Tuple{typeof(revise)})
     @assert precompile(Tuple{typeof(includet), String})
     # setindex! doesn't fully precompile, but it's still beneficial to do it

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2616,7 +2616,7 @@ do_test("Switching free/dev") && @testset "Switching free/dev" begin
     devpath = joinpath(depot, "dev")
     mkpath(devpath)
     mfile = Revise.manifest_file()
-    schedule(Task(Revise.Rescheduler(Revise.watch_manifest, (mfile,))))
+    schedule(Task(Revise.TaskThunk(Revise.watch_manifest, (mfile,))))
     sleep(mtimedelay)
     pkgdevpath = make_a2d(devpath, 2, "w"; generate=false)
     cp(joinpath(ropkgpath, "Project.toml"), joinpath(devpath, "A2D/Project.toml"))


### PR DESCRIPTION
Instead of restarting new Tasks for file-watching, this introduces a loop. This seems a little easier to reason about, but this is mostly cosmetic. 

Inspired by investigating #459, but this does not fix it.