### PR TITLE
Don't stop file-watching with Ctrl-C

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -532,7 +532,12 @@ function revise_file_queued(pkgdata::PkgData, file)
             end
             break
         end
-        wait_changed(file)  # will block here until the file changes
+        try
+            wait_changed(file)  # will block here until the file changes
+        catch e
+            # issue #459
+            (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
+        end
         # Check to see if we're still watching this file
         stillwatching = haskey(watched_files, dirfull)
         push!(revision_queue, (pkgdata, file0))

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -355,7 +355,12 @@ function add_require(sourcefile, modcaller, idmod, modname, expr)
 end
 
 function watch_files_via_dir(dirname)
-    wait_changed(dirname)  # this will block until there is a modification
+    try
+        wait_changed(dirname)  # this will block until there is a modification
+    catch e
+        # issue #459
+        (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
+    end
     latestfiles = Pair{String,PkgId}[]
     # Check to see if we're still watching this directory
     stillwatching = haskey(watched_files, dirname)
@@ -481,7 +486,12 @@ end
 
 function watch_manifest(mfile)
     while true
-        wait_changed(mfile)
+        try
+            wait_changed(mfile)
+        catch e
+            # issue #459
+            (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
+        end
         try
             with_logger(_debug_logger) do
                 @debug "Pkg" _group="manifest_update" manifest_file=mfile

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -92,12 +92,30 @@ WatchList() = WatchList(systime(), Dict{String,PkgId}())
 Base.in(file, wl::WatchList) = haskey(wl.trackedfiles, file)
 
 @static if Sys.isapple()
-     # HFS+ rounds time to seconds, see #22
-     # https://developer.apple.com/library/archive/technotes/tn/tn1150.html#HFSPlusDates
-     newer(mtime, timestamp) = ceil(mtime) >= floor(timestamp)
- else
-     newer(mtime, timestamp) = mtime >= timestamp
- end
+    # HFS+ rounds time to seconds, see #22
+    # https://developer.apple.com/library/archive/technotes/tn/tn1150.html#HFSPlusDates
+    newer(mtime, timestamp) = ceil(mtime) >= floor(timestamp)
+else
+    newer(mtime, timestamp) = mtime >= timestamp
+end
+
+"""
+    success = throwto_repl(e::Exception)
+
+Try throwing `e` from the REPL's backend task. Returns `true` if the necessary conditions
+were met and the throw can be expected to succeed. The throw is generated from another
+task, so a `yield` will need to occur before it happens.
+"""
+function throwto_repl(e::Exception)
+    if isdefined(Base, :active_repl_backend) &&
+            Base.active_repl_backend.backend_task.state === :runnable &&
+            isempty(Base.Workqueue) &&
+            Base.active_repl_backend.in_eval
+        @async Base.throwto(Base.active_repl_backend.backend_task, e)
+        return true
+    end
+    return false
+end
 
 function printf_maxsize(f::Function, io::IO, args...; maxchars::Integer=500, maxlines::Integer=20)
     # This is dumb but certain to work


### PR DESCRIPTION
This fixes #459. It should also increase our test-coverage for the (atypical, except for FreeBSD) `watching_files[] = true` case.