### PR TITLE
Fix #470

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -819,9 +819,13 @@ function entr(f::Function, files, modules=nothing; postpone=false, pause=0.02)
         @sync begin
             postpone || f()
             for file in files
-                waitfor = isdir(file) ? watch_folder : watch_file
+                is_file_dir = isdir(file)
                 @async while active
-                    ret = waitfor(file, 1)
+                    if is_file_dir
+                        ret = watch_folder(file, 1)[2]
+                    else
+                        ret = watch_file(file, 1)
+                    end
                     if active && (ret.changed || ret.renamed)
                         sleep(pause)
                         revise()


### PR DESCRIPTION
Line 822 of Revise.jl calls `FileWatching.watch_folder`. It then calls `ret.changed` on the result. But `FileWatching.watch_folder` returns a pair:

```julia
julia> FileWatching.watch_folder("src")
"extra.jl" => FileWatching.FileEvent(false, true, false)
```
As the documentation says:
> The returned value is an pair where the first field is the name of the changed file (if available) and the second field is an object with boolean fields changed, renamed, and timedout, giving the event.

