### PR TITLE
Small tweaks to reduce invalidations

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -2,7 +2,7 @@ function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
 
     @assert precompile(Tuple{typeof(watch_manifest), String})
-    @assert precompile(Tuple{typeof(watch_file), String, Int})
+    @assert precompile(Tuple{typeof(revise_dir_queued), String})
     @assert precompile(Tuple{TaskThunk})
     @assert precompile(Tuple{typeof(revise)})
     @assert precompile(Tuple{typeof(includet), String})

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -19,10 +19,8 @@ end
 
 const ExLike = Union{Expr,RelocatableExpr}
 
-Base.convert(::Type{RelocatableExpr}, ex::Expr) = RelocatableExpr(ex)
-
 Base.convert(::Type{Expr}, rex::RelocatableExpr) = rex.ex
-Expr(rex::RelocatableExpr) = rex.ex
+# Expr(rex::RelocatableExpr) = rex.ex   # too costly (inference invalidation)
 
 Base.copy(rex::RelocatableExpr) = RelocatableExpr(copy(rex.ex))
 
@@ -66,7 +64,7 @@ struct LineSkippingIterator
     args::Vector{Any}
 end
 
-Base.IteratorSize(::Type{<:LineSkippingIterator}) = Base.SizeUnknown()
+Base.IteratorSize(::Type{LineSkippingIterator}) = Base.SizeUnknown()
 
 function Base.iterate(iter::LineSkippingIterator, i=0)
     i = skip_to_nonline(iter.args, i+1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,7 @@ end
                                     f(x) = x^2
                                     g(x) = sin(x)
                                     end)
-        @test length(Expr(rex).args) == 4  # including the line number expressions
+        @test length(rex.ex.args) == 4  # including the line number expressions
         exs = collectexprs(rex)
         @test length(exs) == 2
         @test isequal(exs[1], Revise.RelocatableExpr(:(f(x) = x^2)))
@@ -473,7 +473,7 @@ end
                 @eval @test $(fn6)() == 6
                 m = @eval first(methods($fn1))
                 rex = Revise.RelocatableExpr(definition(m))
-                @test rex == convert(Revise.RelocatableExpr, :( $fn1() = 1 ))
+                @test rex == Revise.RelocatableExpr(:( $fn1() = 1 ))
                 # Check that definition returns copies
                 rex2 = deepcopy(rex)
                 rex.ex.args[end].args[end] = 2


### PR DESCRIPTION
This reduces the number of invalidation entries from 160 to 28 on Julia 1.6 (using custom branches of Julia & SnoopCompile).