### PR TITLE
Fix tests when watching files, run entr tests on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,20 @@ notifications:
 git:
   depth: 99999999
 
-## uncomment/modify the following lines to allow failures
-## (tests will run but not make your overall status red)
-# matrix:
-#   allow_failures:
-#     - os: osx
-
 script:
     - export JULIA_PROJECT=""
     # Populate the precompile cache with an extraneous file, to catch issues like in #460
     - julia -e 'include(joinpath("test", "populate_compiled.jl"))'
     # Run the normal tests
     - julia --project -e 'using Pkg; Pkg.build(); Pkg.test(; coverage=true);'
+    # Run the normal tests with file-watching (only on Linux where there are lots of workers and they are fast)
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then julia --project -e 'if VERSION >= v"1.3" using Pkg; Pkg.build(); Pkg.test(; test_args=["REVISE_TESTS_WATCH_FILES"], coverage=true); end'; fi
     # The REPL wasn't initialized, so the "Methods at REPL" tests didn't run. Pick those up now.
     - julia --project --code-coverage=user -e 'using InteractiveUtils, REPL, Revise; @async(Base.run_main_repl(true, true, false, true, false)); Revise.async_steal_repl_backend(); include(joinpath("test", "runtests.jl")); REPL.eval_user_input(:(exit()), Base.active_repl_backend)' "Methods at REPL"
-    # We also need to pick up the Git tests, but for that we need to `dev` the package
-    - julia -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); include(joinpath("test", "runtests.jl"))' "Git"
     # Tests for when using polling
     - JULIA_REVISE_POLL=1 julia --code-coverage=user --project -e 'using Pkg, Revise; include(joinpath(dirname(pathof(Revise)), "..", "test", "polling.jl"))'
+    # We also need to pick up the Git tests, but for that we need to `dev` the package
+    - julia --code-coverage=user -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); include(joinpath("test", "runtests.jl"))' "Git"
     # Running out of inotify storage (see #26)
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then echo 4 | sudo tee -a /proc/sys/fs/inotify/max_user_watches; julia --project --code-coverage=user -e 'using Pkg, Revise; cd(joinpath(dirname(pathof(Revise)), "..", "test")); include("inotify.jl")'; fi
 
@@ -41,6 +37,12 @@ after_success:
   - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
 
 jobs:
+  # OSX workers are in short supply, so test fewer versions
+  exclude:
+    - os: osx
+      julia: 1.1
+    - os: osx
+      julia: 1.3
   include:
     - stage: "Documentation"
       julia: 1.0

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -27,7 +27,7 @@ Returns `true` if we watch files rather than their containing directory.
 FreeBSD and NFS-mounted systems should watch files, otherwise we prefer to watch
 directories.
 """
-const watching_files = Ref(Sys.KERNEL == :FreeBSD)
+const watching_files = Ref(Sys.KERNEL === :FreeBSD)
 
 """
     Revise.polling_files[]
@@ -648,7 +648,6 @@ This is generally called via a [`Revise.TaskThunk`](@ref).
 This is used only on platforms (like BSD) which cannot use [`Revise.revise_dir_queued`](@ref).
 """
 function revise_file_queued(pkgdata::PkgData, file)
-    file0 = file
     if !isabspath(file)
         file = joinpath(basedir(pkgdata), file)
     end
@@ -680,7 +679,7 @@ function revise_file_queued(pkgdata::PkgData, file)
 
         # Check to see if we're still watching this file
         stillwatching = haskey(watched_files, dirfull)
-        push!(revision_queue, (pkgdata, file0))
+        push!(revision_queue, (pkgdata, relpath(file, pkgdata)))
     end
     return
 end

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -679,7 +679,7 @@ function revise_file_queued(pkgdata::PkgData, file)
 
         # Check to see if we're still watching this file
         stillwatching = haskey(watched_files, dirfull)
-        push!(revision_queue, (pkgdata, relpath(file, pkgdata)))
+        PkgId(pkgdata) != NOPACKAGE && push!(revision_queue, (pkgdata, relpath(file, pkgdata)))
     end
     return
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -64,3 +64,9 @@ function get_code(f, typ)
 end
 
 do_test(name) = isempty(ARGS) || name in ARGS
+
+if !isempty(ARGS) && "REVISE_TESTS_WATCH_FILES" ∈ ARGS
+    Revise.watching_files[] = true
+    idx = findall(isequal("REVISE_TESTS_WATCH_FILES"), ARGS)
+    deleteat!(ARGS, idx)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3090,7 +3090,8 @@ GC.gc(); GC.gc()
                 end
             end
         end
-        isempty(ARGS) && @test occursin("is not an existing directory", read(warnfile, String))
+        msg = Revise.watching_files[] ? "is not an existing file" : "is not an existing directory"
+        isempty(ARGS) && @test occursin(msg, read(warnfile, String))
         rm(warnfile)
     end
 end


### PR DESCRIPTION
Thanks to #488 the `entr` tests may finally be reliable on OSX. Let's run them and see what happens.

This also adds CI testing for `Revise.watching_files[] == true`, and of course fixes a couple of bugs (one that was lurking for a while, another that was a missing check in #488). CC @ffevotte, @tkluck.

Because OSX workers are in short supply and also quite slow, this also tests fewer Julia versions and skips the `Revise.watching_files[] == true` tests on OSX.
