### PR TITLE
Handle order-dependent effects from asynchronous processes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,8 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+RoundingIntegers = "d5f540fe-1c90-5db3-b776-2e2f362d9394"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "CatIndices", "EndpointRanges", "Example", "EponymTuples", "IndirectArrays", "InteractiveUtils", "MappedArrays", "Random", "Requires"]
+test = ["Test", "CatIndices", "EndpointRanges", "Example", "EponymTuples", "IndirectArrays", "InteractiveUtils", "MappedArrays", "Random", "Requires", "RoundingIntegers"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CodeTracking = "0.5.9"
-JuliaInterpreter = "~0.7.1"
+JuliaInterpreter = "0.7.16"
 LoweredCodeUtils = "0.4"
 OrderedCollections = "1"
 julia = "1"

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -13,7 +13,8 @@ using Core: CodeInfo
 using OrderedCollections, CodeTracking, JuliaInterpreter, LoweredCodeUtils
 using CodeTracking: PkgFiles, basedir, srcfiles
 using JuliaInterpreter: whichtt, is_doc_expr, step_expr!, finish_and_return!, get_return
-using JuliaInterpreter: @lookup, moduleof, scopeof, pc_expr, prepare_thunk, split_expressions
+using JuliaInterpreter: @lookup, moduleof, scopeof, pc_expr, prepare_thunk, split_expressions,
+                        linetable, codelocs, LineTypes
 using LoweredCodeUtils: next_or_nothing!, isanonymous_typedef, define_anonymous
 
 export revise, includet, entr, MethodSummary

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -518,7 +518,7 @@ end
 # Eval and insert into CodeTracking data
 function eval_with_signatures(mod, ex::Expr; define=true, kwargs...)
     methodinfo = CodeTrackingMethodInfo(ex)
-    docexprs = Dict{Module,Vector{Expr}}()
+    docexprs = DocExprs()
     _, frame = methods_by_execution!(finish_and_return!, methodinfo, docexprs, mod, ex; define=define, kwargs...)
     return methodinfo.allsigs, methodinfo.deps, methodinfo.includes, frame
 end

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -61,7 +61,7 @@ end
 
 function methods_by_execution(mod::Module, ex::Expr; kwargs...)
     methodinfo = MethodInfo()
-    docexprs = Dict{Module,Vector{Expr}}()
+    docexprs = DocExprs()
     value, frame = methods_by_execution!(finish_and_return!, methodinfo, docexprs, mod, ex; kwargs...)
     return methodinfo, docexprs, frame
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -41,5 +41,8 @@ function _precompile_()
     @assert precompile(Tuple{Type{PkgData}, PkgId})
     @assert precompile(Tuple{typeof(Base._deleteat!), Vector{Tuple{Module,String,Float64}}, Vector{Int}})
 
+    @assert precompile(Tuple{typeof(track), Module, String})
+    @assert precompile(Tuple{typeof(add_require), String, Module, String, String, Expr})
+    @assert precompile(Tuple{typeof(_add_require), String, Module, String, String, Expr})
     return nothing
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -15,7 +15,20 @@ function _precompile_()
     @assert precompile(Tuple{typeof(setindex!), Dict{PkgId,PkgData}, PkgData, PkgId})
     @assert precompile(Tuple{typeof(setindex!), Dict{String,WatchList}, WatchList, String})
 
-    @assert precompile(Tuple{typeof(methods_by_execution!), Any, CodeTrackingMethodInfo, Dict{Module,Vector{Expr}}, Module, Expr})
+    MI = CodeTrackingMethodInfo
+    @assert precompile(Tuple{typeof(minimal_evaluation!), MI, Core.CodeInfo})
+    @assert precompile(Tuple{typeof(methods_by_execution!), Any, MI, DocExprs, Module, Expr})
+    @assert precompile(Tuple{typeof(methods_by_execution!), Any, MI, DocExprs, JuliaInterpreter.Frame, Vector{Bool}})
+    @assert precompile(Tuple{typeof(Core.kwfunc(methods_by_execution!)),
+                            NamedTuple{(:skip_include,),Tuple{Bool}},
+                            typeof(methods_by_execution!), Function, MI, DocExprs, Module, Expr})
+    @assert precompile(Tuple{typeof(Core.kwfunc(methods_by_execution!)),
+                            NamedTuple{(:define, :skip_include),Tuple{Bool,Bool}},
+                            typeof(methods_by_execution!), Function, MI, DocExprs, Module, Expr})
+    @assert precompile(Tuple{typeof(Core.kwfunc(methods_by_execution!)),
+                            NamedTuple{(:define, :skip_include),Tuple{Bool,Bool}},
+                            typeof(methods_by_execution!), Function, MI, DocExprs, JuliaInterpreter.Frame, Vector{Bool}})
+
     @assert precompile(Tuple{typeof(get_def), Method})
     @assert precompile(Tuple{typeof(parse_pkg_files), PkgId})
     @assert precompile(Tuple{typeof(Base.stale_cachefile), String, String})

--- a/src/types.jl
+++ b/src/types.jl
@@ -198,11 +198,11 @@ function Base.show(io::IO, pkgdata::PkgData)
         print(io, nparsed, '/', length(pkgdata.fileinfos), " parsed files, ", nexs, " expressions, ", nsigs, " signatures)")
     else
         show(io, pkgdata.info.id)
-        println(io, ':')
+        println(io, ", basedir \"", pkgdata.info.basedir, ':')
         for (f, fi) in zip(pkgdata.info.files, pkgdata.fileinfos)
             print(io, "  \"", f, "\": ")
             show(IOContext(io, :compact=>true), fi)
-            print('\n')
+            print(io, '\n')
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2402,7 +2402,6 @@ end
             sleep(mtimedelay)
             mod = @eval $(Symbol(modname))
             id = Base.PkgId(mod)
-            # id = Base.PkgId(Main)
             extrajl = joinpath(randdir, "src", "extra.jl")
             open(extrajl, "w") do io
                 println(io, """
@@ -2419,11 +2418,12 @@ end
             sleep(mtimedelay)
             repo = LibGit2.GitRepo(randdir)
             LibGit2.add!(repo, joinpath("src", "extra.jl"))
+            pkgdata = Revise.pkgdatas[id]
             logs, _ = Test.collect_test_logs() do
-                Revise.track_subdir_from_git(id, joinpath(randdir, "src"); commit="HEAD")
+                Revise.track_subdir_from_git!(pkgdata, joinpath(randdir, "src"); commit="HEAD")
             end
             yry()
-            @test Revise.hasfile(Revise.pkgdatas[id], mainjl)
+            @test Revise.hasfile(pkgdata, mainjl)
             @test startswith(logs[end].message, "skipping src/extra.jl") || startswith(logs[end-1].message, "skipping src/extra.jl")
             rm_precompile("ModuleWithNewFile")
             pop!(LOAD_PATH)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -940,7 +940,7 @@ end
         lwr = Meta.lower(ChangeDocstring, ex)
         frame = JuliaInterpreter.prepare_thunk(ChangeDocstring, lwr, true)
         methodinfo = Revise.MethodInfo()
-        docexprs = Dict{Module,Vector{Expr}}()
+        docexprs = Revise.DocExprs()
         ret = Revise.methods_by_execution!(JuliaInterpreter.finish_and_return!, methodinfo,
                                            docexprs, frame, trues(length(frame.framecode.src.code)); define=false)
         ds = @doc(ChangeDocstring.f)


### PR DESCRIPTION
This takes a multifaceted approach to resolving #431, which was a much trickier and problematic issue than a simple "not watching" warning might suggest. We were getting path corruption and duplication in the `pkgdatas` and other nasty issues stemming from race conditions among `track` and the handling of `@require`.

The key steps are:
- insert a new `pkgdata` into `pkgdatas` only when it is complete. This allows `add_require` to wait until the end of module initialization. Note this does not introduce any dependency on an actual lock.
- Have `track` bail if it's being called from `@require`. Since Revise 2.4, all `include` statements have been handled automatically, so this is redundant. This will issue a depwarn for all packages except Plots, for which I have a PR to fix it already prepared.
-  Add locking on the handling of `@require` statements. This prevents contention in nested `@require` statements. While this still introduces a lock, it's a lot more limited than #487.

Given how long CI takes, this throws in a few other commits too, like improvements in invalidations and better precompilation.
