### PR TITLE
Allow `entr` to watch directories (fixes #470)

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -26,8 +26,19 @@ Revise.basebuilddir
 Revise.pkgdatas
 Revise.watched_files
 Revise.revision_queue
+Revise.NOPACKAGE
 Revise.queue_errors
 Revise.included_files
+```
+
+The following are specific to user callbacks (see [`Revise.add_callback`](@ref)) and
+the implementation of [`entr`](@ref):
+
+```@docs
+Revise.revision_event
+Revise.user_callbacks_queue
+Revise.user_callbacks_by_file
+Revise.user_callbacks_by_key
 ```
 
 ## Types
@@ -75,6 +86,14 @@ Revise.revise_dir_queued
 Revise.revise_file_queued
 ```
 
+The following functions support user callbacks, and are used in the implementation of `entr`
+but can be used more broadly:
+
+```@docs
+Revise.add_callback
+Revise.remove_callback
+```
+
 ### Evaluating changes (revising) and computing diffs
 
 [`revise`](@ref) is the primary entry point for implementing changes. Additionally,
@@ -96,10 +115,29 @@ Revise.parse_source
 Revise.parse_source!
 ```
 
+### Lowered source code
+
+Much of the "brains" of Revise comes from doing analysis on lowered code.
+This part of the package is not as well documented.
+
+```@docs
+Revise.hastrackedexpr
+```
+
 ### Modules and paths
 
 ```@docs
 Revise.modulefiles
+```
+
+### Handling errors
+
+In current releases of Julia, hitting Ctrl-C from the REPL can stop tasks running in the background.
+This risks stopping Revise's ability to watch for changes in files and directories.
+Revise has a work-around for this problem.
+
+```@docs
+Revise.throwto_repl
 ```
 
 ### Git integration

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -858,18 +858,10 @@ function track(mod::Module, file::AbstractString; kwargs...)
     id = PkgId(mod)
     if haskey(pkgdatas, id)
         pkgdata = pkgdatas[id]
-        file = abspath(file)
-        # `Base.locate_package`, which is how `pkgdata` gets initialized, might strip pieces of the path.
-        # For example, on Travis macOS the paths returned by `abspath`
-        # can be preceded by "/private" which is not present in the value returned by `Base.locate_package`.
-        idx = findfirst(basedir(pkgdata), file)
-        if idx !== nothing
-            idx = first(idx)
-            if idx > 1
-                file = file[idx:end]
-            end
-            hasfile(pkgdata, file) && return nothing
-        end
+        relfile = relpath(abspath(file), pkgdata)
+        hasfile(pkgdata, relfile) && return nothing
+        # Use any "fixes" provided by relpath
+        file = joinpath(basedir(pkgdata), relfile)
     else
         # Check whether `track` was called via a @require. Ref issue #403 & #431.
         st = stacktrace(backtrace())

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -144,9 +144,11 @@ You can use the return value `key` to remove the callback later
 to `Revise.add_callback` with `key=key`.
 """
 function add_callback(f, files, modules=nothing; key=gensym())
+    fix_trailing(path) = isdir(path) ? joinpath(path, "") : path   # insert a trailing '/' if missing, see https://github.com/timholy/Revise.jl/issues/470#issuecomment-633298553
+
     remove_callback(key)
 
-    files = map(abspath, files)
+    files = map(fix_trailing, map(abspath, files))
     init_watching(files)
 
     if modules !== nothing
@@ -949,7 +951,7 @@ includet(file::AbstractString) = includet(Main, file)
     entr(f, files; postpone=false, pause=0.02)
     entr(f, files, modules; postpone=false, pause=0.02)
 
-Execute `f()` whenever files listed in `files`, or code in `modules`, updates.
+Execute `f()` whenever files or directories listed in `files`, or code in `modules`, updates.
 `entr` will process updates (and block your command line) until you press Ctrl-C.
 Unless `postpone` is `true`, `f()` will be executed also when calling `entr`,
 regardless of file changes. The `pause` is the period (in seconds) that `entr`

--- a/test/common.jl
+++ b/test/common.jl
@@ -63,10 +63,18 @@ function get_code(f, typ)
     return code
 end
 
-do_test(name) = isempty(ARGS) || name in ARGS
+function do_test(name)
+    runtest = isempty(ARGS) || name in ARGS
+    # Sometimes we get "no output received for 10 minutes" on CI,
+    # to debug this it may be useful to know what test is being run.
+    runtest && haskey(ENV, "CI") && println("Starting test ", name)
+    return runtest
+end
+
 
 if !isempty(ARGS) && "REVISE_TESTS_WATCH_FILES" ∈ ARGS
     Revise.watching_files[] = true
+    println("Running tests with `Revise.watching_files[] = true`")
     idx = findall(isequal("REVISE_TESTS_WATCH_FILES"), ARGS)
     deleteat!(ARGS, idx)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2367,11 +2367,6 @@ end
     end
 
     do_test("Git") && @testset "Git" begin
-        # if haskey(ENV, "CI")   # if we're doing CI testing (Travis, Appveyor, etc.)
-        #     # First do a full git checkout of a package (we'll use Revise itself)
-        #     @warn "checking out a development copy of Revise for testing purposes"
-        #     pkg = Pkg.develop("Revise")
-        # end
         loc = Base.find_package("Revise")
         if occursin("dev", loc)
             repo, path = Revise.git_repo(loc)
@@ -2606,6 +2601,7 @@ do_test("Switching free/dev") && @testset "Switching free/dev" begin
     empty!(DEPOT_PATH)
     push!(DEPOT_PATH, depot)
     # Skip cloning the General registry since that is slow and unnecessary
+    ENV["JULIA_PKG_SERVER"] = ""
     registries = Pkg.Types.DEFAULT_REGISTRIES
     old_registries = copy(registries)
     empty!(registries)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2984,6 +2984,35 @@ do_test("entr") && @testset "entr" begin
         @test isa(err, LoadError)
         @test err.error.msg == "stop"
     end
+
+    # Watch directories (#470)
+    dn = joinpath(tempdir(), randtmp())
+    mkdir(dn)
+    fn = joinpath(dn, "trigger.txt")
+    open(fn, "w") do io
+        println(io, "blank")
+    end
+    counter = Ref(0)
+    stop = Ref(false)
+    try
+        @sync begin
+            @async begin
+                entr([dn]) do
+                    counter[] += 1
+                    stop[] && error("stopping")
+                end
+            end
+            sleep(mtimedelay)
+            touch(fn)
+            sleep(mtimedelay)
+            @test counter[] == 1
+            stop[] = true
+            touch(fn)
+            sleep(mtimedelay)
+        end
+    catch
+        @test counter[] == 2
+    end
 end
 
 const A354_result = Ref(0)


### PR DESCRIPTION
Fixes #470, CC @ffevotte.

Also updates the devdocs for all the latest changes.