### PR TITLE
Fix #494 & improve `entr` tests

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -973,8 +973,9 @@ function entr(f::Function, files, modules=nothing; postpone=false, pause=0.02)
         end
     catch err
         isa(err, InterruptException) || rethrow(err)
+    finally
+        remove_callback(key)
     end
-    remove_callback(key)
     nothing
 end
 


### PR DESCRIPTION
Tests are modified so as to check that `entr`:
1. behaves well in cases of clustered events -> this is OK in the current master; it looks like incorrectly reported this as being a problem. Or perhaps it is only an issue when working with directories... At least we now have a way to check for this.
2. correctly removes user callbacks even when they throw -> this was indeed an issue ; a small fix is introduced in this PR.

Closes #494
(also related to #492)