### PR TITLE
Allow `entr` to watch directories (fixes #470)

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -661,7 +661,7 @@ function revise_file_queued(pkgdata::PkgData, file)
     dirfull, basename = splitdir(file)
     stillwatching = true
     while stillwatching
-        if !file_exists(file)
+        if !file_exists(file) && !isdir(file)
             with_logger(SimpleLogger(stderr)) do
                 @warn "$file is not an existing file, Revise is not watching"
             end

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -144,9 +144,11 @@ You can use the return value `key` to remove the callback later
 to `Revise.add_callback` with `key=key`.
 """
 function add_callback(f, files, modules=nothing; key=gensym())
+    fix_trailing(path) = isdir(path) ? joinpath(path, "") : path   # insert a trailing '/' if missing, see https://github.com/timholy/Revise.jl/issues/470#issuecomment-633298553
+
     remove_callback(key)
 
-    files = map(abspath, files)
+    files = map(fix_trailing, map(abspath, files))
     init_watching(files)
 
     if modules !== nothing
@@ -941,7 +943,7 @@ includet(file::AbstractString) = includet(Main, file)
     entr(f, files; postpone=false, pause=0.02)
     entr(f, files, modules; postpone=false, pause=0.02)
 
-Execute `f()` whenever files listed in `files`, or code in `modules`, updates.
+Execute `f()` whenever files or directories listed in `files`, or code in `modules`, updates.
 `entr` will process updates (and block your command line) until you press Ctrl-C.
 Unless `postpone` is `true`, `f()` will be executed also when calling `entr`,
 regardless of file changes. The `pause` is the period (in seconds) that `entr`

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -381,7 +381,12 @@ function watch_files_via_dir(dirname)
         wf = watched_files[dirname]
         for (file, id) in wf.trackedfiles
             fullpath = joinpath(dirname, file)
-            if !file_exists(fullpath)
+            if isdir(fullpath)
+                # Detected a modification in a directory that we're watching in
+                # itself (not as a container for watched files)
+                push!(latestfiles, file=>id)
+                continue
+            elseif !file_exists(fullpath)
                 # File may have been deleted. But be very sure.
                 sleep(0.1)
                 if !file_exists(fullpath)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3003,32 +3003,70 @@ do_test("entr") && @testset "entr" begin
 
 
     # Watch directories (#470)
-    dn = joinpath(tempdir(), randtmp())
-    mkdir(dn)
-    fn = joinpath(dn, "trigger.txt")
-    open(fn, "w") do io
-        println(io, "blank")
-    end
-    counter = Ref(0)
-    stop = Ref(false)
     try
-        @sync begin
+        @sync let
+            srcdir = joinpath(tempdir(), randtmp())
+            mkdir(srcdir)
+
+            trigger = joinpath(srcdir, "trigger.txt")
+
+            counter = Ref(0)
+            stop = Ref(false)
+
             @async begin
-                entr([dn]) do
+                entr([srcdir]; pause=0.5) do
                     counter[] += 1
-                    stop[] && error("stopping")
+                    stop[] && error("stop watching directory")
                 end
             end
-            sleep(mtimedelay)
-            touch(fn)
-            sleep(mtimedelay)
-            @test counter[] == 1
+            sleep(1)
+            @test length(readdir(srcdir)) == 0 # directory should still be empty
+            @test counter[] == 1               # postpone=false
+
+            # File creation
+            touch(trigger)
+            sleep(1)
+            @test counter[] == 2
+
+            # File modification
+            touch(trigger)
+            sleep(1)
+            @test counter[] == 3
+
+            # File deletion -> the directory should be empty again
+            rm(trigger)
+            sleep(1)
+            @test length(readdir(srcdir)) == 0
+            @test counter[] == 4
+
+            # Two events in quick succession (w.r.t. the `pause` argument)
+            touch(trigger)       # creation
+            sleep(0.1)
+            touch(trigger)       # modification
+            sleep(1)
+            @test counter[] == 5 # Callback should have been called only once
+
+            # Stop
             stop[] = true
-            touch(fn)
-            sleep(mtimedelay)
+            touch(trigger)
         end
-    catch
-        @test counter[] == 2
+
+        # `entr` should have errored by now
+        @test false
+    catch err
+        while err isa CompositeException
+            err = err.exceptions[1]
+            @static if VERSION >= v"1.3.0-alpha.110"
+                if  err isa TaskFailedException
+                    err = err.task.exception
+                end
+            end
+            if err isa CapturedException
+                err = err.ex
+            end
+        end
+        @test isa(err, ErrorException)
+        @test err.msg == "stop watching directory"
     end
 end
 


### PR DESCRIPTION
This PR extends the work done in #492 to allow `entr` to watch directories. It is also re-based on the current `master`, in order to benefit from the latest bug fixes in `entr`.

At this stage, everything works in the case where `Revise.watching_files[] == false`. The tests performed for `entr` on directories mirror those defined for `entr` on files. In particular, they check that:
1. file creations, modifications and deletions in the directory are correctly detected;
1. clustered notifications trigger the callback only once;
1. empty directories are correctly handled (i.e. they remain in the watch list even when all files in them are deleted).

Upcoming commits should complete this PR to handle the case where `Revise.watching_files[]` is set.