### PR TITLE
Add an `all` kwarg to `entr` to watch all known files

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -137,16 +137,26 @@ all without restarting your Julia session.
 Revise can be used to perform work when files update.
 For example, let's say you want to regenerate a set of web pages whenever your code changes.
 Suppose you've placed your Julia code in a package called `MyWebCode`,
-and the pages depend on "file1.css" and "file2.js"; then
+and the pages depend on "file.js" and all files in the "assets/" directory; then
 
 ```julia
-entr(["file1.css", "file2.js"], [MyWebCode]) do
+entr(["file.js", "assets"], [MyWebCode]) do
     build_webpages(args...)
 end
 ```
 
 will execute `build_webpages(args...)` whenever you save updates to the listed files
 or `MyWebCode`.
+
+If you want to regenerate the web page as soon as any change is detected, not
+only in `MyWebCode` but also in any package tracked by Revise, you can provide
+the `all` keyword argument to [`entr`](@ref):
+
+```julia
+entr(["file.js", "assets"]; all=true) do
+    build_webpages(args...)
+end
+```
 
 ## Taking advantage of Revise in other packages
 

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -956,9 +956,10 @@ includet(file::AbstractString) = includet(Main, file)
     entr(f, files, modules; all=false, postpone=false, pause=0.02)
 
 Execute `f()` whenever files or directories listed in `files`, or code in `modules`, updates.
+If `all` is `true`, also execute `f()` as soon as code updates are detected in
+any module tracked by Revise.
+
 `entr` will process updates (and block your command line) until you press Ctrl-C.
-If `all` is `true`, also execute `f()` whenever any file already monitored by
-Revise changes.
 Unless `postpone` is `true`, `f()` will be executed also when calling `entr`,
 regardless of file changes. The `pause` is the period (in seconds) that `entr`
 will wait between being triggered and actually calling `f()`, to handle

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -136,20 +136,30 @@ const user_callbacks_by_key = Dict{Any, Any}()
 
 Add a user-specified callback, to be executed during the first run of
 `revise()` after a file in `files` or a module in `modules` is changed on the
-file system. In an interactive session like the REPL, Juno or Jupyter, this
-means the callback executes immediately before executing a new command / cell.
+file system. If `all` is set to `true`, also execute the callback whenever any
+file already monitored by Revise changes. In an interactive session like the
+REPL, Juno or Jupyter, this means the callback executes immediately before
+executing a new command / cell.
 
 You can use the return value `key` to remove the callback later
 (`Revise.remove_callback`) or to update it using another call
 to `Revise.add_callback` with `key=key`.
 """
-function add_callback(f, files, modules=nothing; key=gensym())
+function add_callback(f, files, modules=nothing; all=false, key=gensym())
     fix_trailing(path) = isdir(path) ? joinpath(path, "") : path   # insert a trailing '/' if missing, see https://github.com/timholy/Revise.jl/issues/470#issuecomment-633298553
 
     remove_callback(key)
 
     files = map(fix_trailing, map(abspath, files))
     init_watching(files)
+
+    # in case the `all` kwarg was set:
+    # add all files which are already known to Revise
+    if all
+        for pkgdata in values(pkgdatas)
+            append!(files, joinpath.(Ref(basedir(pkgdata)), srcfiles(pkgdata)))
+        end
+    end
 
     if modules !== nothing
         for mod in modules
@@ -163,11 +173,13 @@ function add_callback(f, files, modules=nothing; key=gensym())
         end
     end
 
+    # There might be duplicate entries in `files`, but it shouldn't cause any
+    # problem with the sort of things we do here
     for file in files
         cb = get!(Set, user_callbacks_by_file, file)
         push!(cb, key)
-        user_callbacks_by_key[key] = f
     end
+    user_callbacks_by_key[key] = f
 
     return key
 end
@@ -940,11 +952,13 @@ end
 includet(file::AbstractString) = includet(Main, file)
 
 """
-    entr(f, files; postpone=false, pause=0.02)
-    entr(f, files, modules; postpone=false, pause=0.02)
+    entr(f, files; all=false, postpone=false, pause=0.02)
+    entr(f, files, modules; all=false, postpone=false, pause=0.02)
 
 Execute `f()` whenever files or directories listed in `files`, or code in `modules`, updates.
 `entr` will process updates (and block your command line) until you press Ctrl-C.
+If `all` is `true`, also execute `f()` whenever any file already monitored by
+Revise changes.
 Unless `postpone` is `true`, `f()` will be executed also when calling `entr`,
 regardless of file changes. The `pause` is the period (in seconds) that `entr`
 will wait between being triggered and actually calling `f()`, to handle
@@ -961,10 +975,10 @@ end
 This will print "update" every time `"/tmp/watched.txt"` or any of the code defining
 `Pkg1` or `Pkg2` gets updated.
 """
-function entr(f::Function, files, modules=nothing; postpone=false, pause=0.02)
+function entr(f::Function, files, modules=nothing; all=false, postpone=false, pause=0.02)
     yield()
     postpone || f()
-    key = add_callback(files, modules) do
+    key = add_callback(files, modules; all=all) do
         sleep(pause)
         f()
     end


### PR DESCRIPTION
As requested in #469.

With this feature, `entr` and `add_callback`accept a new keyword argument `all`, which allows watching all files currently known to Revise, in addition to those specified in the regular positional arguments `files` and `modules`:
```
entr(f::Function, files, modules=nothing; all=false, postpone=false, pause=0.02)
add_callback(f, files, modules=nothing; all=false, key=gensym())
```

This change is not breaking since `all=false` by default.

TODO:
- [x] implement the feature
- [x] add specific tests
- [x] update documentation