### PR TITLE
Add TOML to list of stdlibs for Julia v1.6

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -186,6 +186,9 @@ const stdlib_names = Set([
     :OldPkg, :Pkg, :Printf, :Profile, :Random, :REPL,
     :Serialization, :SHA, :SharedArrays, :Sockets, :SparseArrays,
     :Statistics, :SuiteSparse, :Test, :Unicode, :UUIDs])
+if VERSION >= v"1.6.0-DEV.734"
+    push!(stdlib_names, :TOML)
+end
 
 # This replacement is needed because the path written during compilation differs from
 # the git source path


### PR DESCRIPTION
Without this change, I encountered the following while trying to test-revise part of Julia:
```
$ make test-revise-Mmap
    JULIA test/revise-Mmap
ERROR: LoadError: no Revise.track recipe for module TOML
Stacktrace:
  [1] error(::String, ::Symbol)
    @ Base ./error.jl:42
...
```
I'm not sure if having `:TOML` added to the set conditional on the Julia version is what you want or not, so I can easily switch that to just a simple insert into the list if preferred.