### PR TITLE
Pluto support 🎈

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -440,11 +440,13 @@ function eval_new!(exs_sigs_new::ExprsSigs, exs_sigs_old, mod::Module)
                     if VERSION < v"1.3.0" || !isexpr(thunk, :thunk)
                         thunk = ex
                     end
-                    for p in workers()
-                        p == myid() && continue
-                        try   # don't error if `mod` isn't defined on the worker
-                            remotecall(Core.eval, p, mod, thunk)
-                        catch
+                    if myid() == 1
+                        for p in workers()
+                            p == myid() && continue
+                            try   # don't error if `mod` isn't defined on the worker
+                                remotecall(Core.eval, p, mod, thunk)
+                            catch
+                            end
                         end
                     end
                     storedeps(deps, rex, mod)
@@ -1264,7 +1266,10 @@ function init_worker(p)
 end
 
 function __init__()
-    myid() == 1 || return nothing
+    run_on_worker = get(ENV, "JULIA_REVISE_ON_WORKER", "0")
+    if !(myid() == 1 || run_on_worker == "1")
+        return nothing
+    end
     if isfile(silencefile[])
         pkgs = readlines(silencefile[])
         for pkg in pkgs

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -1266,7 +1266,7 @@ function init_worker(p)
 end
 
 function __init__()
-    run_on_worker = get(ENV, "JULIA_REVISE_ON_WORKER", "0")
+    run_on_worker = get(ENV, "JULIA_REVISE_WORKER_ONLY", "0")
     if !(myid() == 1 || run_on_worker == "1")
         return nothing
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2373,7 +2373,7 @@ end
         # https://github.com/timholy/Revise.jl/pull/527
         favorite_proc, boring_proc = addprocs(2)
 
-        Distributed.remotecall_eval(Main, [favorite_proc, boring_proc], :(ENV["JULIA_REVISE_ON_WORKER"] = "1"))
+        Distributed.remotecall_eval(Main, [favorite_proc, boring_proc], :(ENV["JULIA_REVISE_WORKER_ONLY"] = "1"))
 
         dirname = randtmp()
         mkdir(dirname)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2368,6 +2368,94 @@ end
         pop!(LOAD_PATH)
     end
 
+
+    do_test("Distributed on worker") && @testset "Distributed on worker" begin
+        # https://github.com/timholy/Revise.jl/pull/527
+        favorite_proc, boring_proc = addprocs(2)
+
+        Distributed.remotecall_eval(Main, [favorite_proc, boring_proc], :(ENV["JULIA_REVISE_ON_WORKER"] = "1"))
+
+        dirname = randtmp()
+        mkdir(dirname)
+        push!(to_remove, dirname)
+
+        @everywhere push_LOAD_PATH!(dirname) = push!(LOAD_PATH, dirname)  # Don't want to share this LOAD_PATH
+        remotecall_wait(push_LOAD_PATH!, favorite_proc, dirname)
+        
+        modname = "ReviseDistributedOnWorker"
+        dn = joinpath(dirname, modname, "src")
+        mkpath(dn)
+        
+        s527_old = """
+        module ReviseDistributedOnWorker
+        
+        f() = π
+        g(::Int) = 0
+        
+        end
+        """
+        open(joinpath(dn, modname*".jl"), "w") do io
+            println(io, s527_old)
+        end
+
+        # In the first tests, we only load Revise on our favorite process. The other (boring) process should be unaffected by the upcoming tests.
+        Distributed.remotecall_eval(Main, [favorite_proc], :(using Revise))
+        sleep(mtimedelay)
+        Distributed.remotecall_eval(Main, [favorite_proc], :(using ReviseDistributedOnWorker))
+        sleep(mtimedelay)
+        
+        @test Distributed.remotecall_eval(Main, favorite_proc, :(ReviseDistributedOnWorker.f())) == π
+        @test Distributed.remotecall_eval(Main, favorite_proc, :(ReviseDistributedOnWorker.g(1))) == 0
+        
+        # we only loaded ReviseDistributedOnWorker on our favorite process
+        @test_throws RemoteException Distributed.remotecall_eval(Main, boring_proc, :(ReviseDistributedOnWorker.f()))
+        @test_throws RemoteException Distributed.remotecall_eval(Main, boring_proc, :(ReviseDistributedOnWorker.g(1)))
+
+        s527_new = """
+        module ReviseDistributedOnWorker
+        
+        f() = 3.0
+        
+        end
+        """
+        open(joinpath(dn, modname*".jl"), "w") do io
+            println(io, s527_new)
+        end
+        sleep(mtimedelay)
+        Distributed.remotecall_eval(Main, [favorite_proc], :(Revise.revise()))
+        sleep(mtimedelay)
+
+
+        @test Distributed.remotecall_eval(Main, favorite_proc, :(ReviseDistributedOnWorker.f())) == 3.0
+        @test_throws RemoteException Distributed.remotecall_eval(Main, favorite_proc, :(ReviseDistributedOnWorker.g(1)))
+        
+        @test_throws RemoteException Distributed.remotecall_eval(Main, boring_proc, :(ReviseDistributedOnWorker.f()))
+        @test_throws RemoteException Distributed.remotecall_eval(Main, boring_proc, :(ReviseDistributedOnWorker.g(1)))
+
+        # In the second part, we'll also load Revise on the boring process, which should have no effect.
+        Distributed.remotecall_eval(Main, [boring_proc], :(using Revise))
+
+        open(joinpath(dn, modname*".jl"), "w") do io
+            println(io, s527_old)
+        end
+
+        sleep(mtimedelay)
+        @test !Distributed.remotecall_eval(Main, favorite_proc, :(Revise.revision_queue |> isempty))
+        @test Distributed.remotecall_eval(Main, boring_proc, :(Revise.revision_queue |> isempty))
+
+        Distributed.remotecall_eval(Main, [favorite_proc, boring_proc], :(Revise.revise()))
+        sleep(mtimedelay)
+
+        
+        @test Distributed.remotecall_eval(Main, favorite_proc, :(ReviseDistributedOnWorker.f())) == π
+        @test Distributed.remotecall_eval(Main, favorite_proc, :(ReviseDistributedOnWorker.g(1))) == 0
+        
+        @test_throws RemoteException Distributed.remotecall_eval(Main, boring_proc, :(ReviseDistributedOnWorker.f()))
+        @test_throws RemoteException Distributed.remotecall_eval(Main, boring_proc, :(ReviseDistributedOnWorker.g(1)))
+
+        rmprocs(favorite_proc, boring_proc; waitfor=10)
+    end
+
     do_test("Git") && @testset "Git" begin
         loc = Base.find_package("Revise")
         if occursin("dev", loc)


### PR DESCRIPTION
Hi!

Today I worked on a [highly requested Pluto feature](https://github.com/fonsp/Pluto.jl/issues/238): Revise support! Here is the [PR at Pluto](https://github.com/fonsp/Pluto.jl/pull/416/files#diff-446048a8133a25e0a07ba1f827fa93a2R37).

(It was surprisingly simple!) For this to work, I believe that we need a small change to Revise. 

_To explain why, some background on Pluto:_

Pluto uses `Distributed` to create notebook processes. The (HTTP) server has PID 1, notebooks are worker processes. These workers run independently from each other - they don't share code, loaded modules, package environments, etc., and if one notebook calls `using Revise`, then it is only loaded on that notebook's process. 

This is different from how Revise was designed to work inside Distributed, which is to load Revise [on the main process](https://github.com/timholy/Revise.jl/blob/95354947560efbc9eea1ea7d57e9c2f4566a4f60/docs/src/limitations.md#distributed-computing-multiple-workers-and-anonymous-functions). This PR adds support for a different configuration: Revise can be loaded on (some of) the worker processes, and the revised code is only loaded on one process. This feature is hidden behind a new ENV variable: `JULIA_REVISE_ON_WORKER`. (Feel free to suggest a different way to switch this feature.)

Let me know what you think!

How should this new "feature" be documented? Is it useful outside of Pluto support?