### PR TITLE
Add `Revise.retry()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.0.0"
+version = "3.1.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/docs/src/user_reference.md
+++ b/docs/src/user_reference.md
@@ -1,7 +1,7 @@
 # User reference
 
-There are really only five functions that most users would be expected to call manually:
-`revise`, `includet`, `Revise.track`, `entr`, and `Revise.errors`.
+There are really only six functions that most users would be expected to call manually:
+`revise`, `includet`, `Revise.track`, `entr`, `Revise.retry`, and `Revise.errors`.
 Other user-level constructs might apply if you want to debug Revise or
 prevent it from watching specific packages, or for fine-grained handling of callbacks.
 
@@ -10,6 +10,7 @@ revise
 Revise.track
 includet
 entr
+Revise.retry
 Revise.errors
 ```
 

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -708,6 +708,18 @@ function errors(revision_errors=keys(queue_errors))
 end
 
 """
+    Revise.retry()
+
+Attempt to perform previously-failed revisions. This can be useful in cases of order-dependent errors.
+"""
+function retry()
+    for (k, v) in queue_errors
+        push!(revision_queue, k)
+    end
+    revise()
+end
+
+"""
     revise(; throw=false)
 
 `eval` any changes in the revision queue. See [`Revise.revision_queue`](@ref).
@@ -785,7 +797,7 @@ function revise(; throw=false)
             end
             str = String(take!(io))
             @warn """The running code does not match the saved version for the following files:$str
-            If the error was due to evaluation order, it can sometimes be resolved by calling `revise()` manually.
+            If the error was due to evaluation order, it can sometimes be resolved by calling `Revise.retry()`.
             Use Revise.errors() to report errors again. Only the first error in each file is shown.
             Your prompt color may be yellow until the errors are resolved."""
             maybe_set_prompt_color(:warn)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -967,7 +967,9 @@ end
         @info "The following error messge is expected for this broken test"
         yry()
         @test_broken Order2.f(Order2.Ord2()) == 1
-        empty!(Revise.queue_errors)   # FIXME delete when test isn't broken
+        # Resolve it with retry
+        Revise.retry()
+        @test Order2.f(Order2.Ord2()) == 1
 
         # Cross-module dependencies
         dn3 = joinpath(testdir, "Order3", "src")


### PR DESCRIPTION
After order-dependent errors, manually calling `revise()` wasn't adequate (what was I thinking??). `retry` fixes the problem nicely.

Feels weird to be releasing 3.1 so quickly, but it's a new feature, and I swear it wasn't me, semver made me do it mamma!