### PR TITLE
Check for existing project_file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.1.0"
+version = "3.1.1"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ to run Revise automatically, as described in the "Configuration" section of the 
 ## Credits
 
 Revise became possible because of Jameson Nash's fix of [Julia issue 265](https://github.com/JuliaLang/julia/issues/265).
-[Juno](http://junolab.org/) is an IDE that offers an editor-based mechanism for achieving some
-of the same aims.
+[Julia for VSCode](https://www.julia-vscode.org/) and [Juno](http://junolab.org/) are IDEs that offer an editor-based mechanism for achieving a subset of
+Revise's aims.
 
 ## Major releases
 

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -385,7 +385,7 @@ end
 # Much of this is adapted from base/loading.jl
 
 function manifest_file(project_file)
-    if project_file isa String
+    if project_file isa String && isfile(project_file)
         mfile = @static if isdefined(Base, :TOMLCache)
             Base.project_file_manifest_path(project_file, Base.TOMLCache())
         else

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -192,6 +192,12 @@ end
 if VERSION >= v"1.6.0-DEV.890"   # https://github.com/JuliaLang/julia/pull/37320
     push!(stdlib_names, :Artifacts)
 end
+if VERSION >= v"1.6.0-DEV.938"   # https://github.com/JuliaLang/julia/pull/37340
+    push!(stdlib_names, :LibCURL_jll)
+    push!(stdlib_names, :LibCURL)
+    push!(stdlib_names, :MozillaCACerts_jll)
+    push!(stdlib_names, :Downloads)
+end
 
 # This replacement is needed because the path written during compilation differs from
 # the git source path

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3558,15 +3558,6 @@ end
 
 GC.gc(); GC.gc(); GC.gc()   # work-around for https://github.com/JuliaLang/julia/issues/28306
 
-include("backedges.jl")
-
-do_test("Base signatures") && @testset "Base signatures" begin
-    println("beginning signatures tests")
-    # Using the extensive repository of code in Base as a testbed
-    include("sigtest.jl")
-end
-
-
 # see #532 Fix InitError opening none existent Project.toml
 function load_in_empty_project_test()
 
@@ -3574,26 +3565,26 @@ function load_in_empty_project_test()
     # with an empty enviroment (missing Project.toml)
 
     julia = Base.julia_cmd()
-    revise_proj = Base.active_project()
+    revise_proj = escape_string(Base.active_project())
     @assert isfile(revise_proj)
 
     src = """
-    
+
         import Pkg
         Pkg.activate("fake_env")
         @assert !isfile(Base.active_project())
-        
+
         # force to load the package env Revise version
         empty!(LOAD_PATH)
         push!(LOAD_PATH, "$revise_proj")
-        
+
         @info "A warning about no Manifest.toml file found is expected"
         try; using Revise
             catch err
                 # just fail for this error (see #532)
                 err isa InitError && rethrow(err)
         end
-        
+
     """
     cmd = `$julia --project=@. -E $src`
 
@@ -3604,4 +3595,12 @@ function load_in_empty_project_test()
 end
 @testset "Import in empty enviroment (issue #532)" begin
     load_in_empty_project_test();
+end
+
+include("backedges.jl")
+
+do_test("Base signatures") && @testset "Base signatures" begin
+    println("beginning signatures tests")
+    # Using the extensive repository of code in Base as a testbed
+    include("sigtest.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3565,3 +3565,43 @@ do_test("Base signatures") && @testset "Base signatures" begin
     # Using the extensive repository of code in Base as a testbed
     include("sigtest.jl")
 end
+
+
+# see #532 Fix InitError opening none existent Project.toml
+function load_in_empty_project_test()
+
+    # This will try to load Revise in a julia seccion
+    # with an empty enviroment (missing Project.toml)
+
+    julia = Base.julia_cmd()
+    revise_proj = Base.active_project()
+    @assert isfile(revise_proj)
+
+    src = """
+    
+        import Pkg
+        Pkg.activate("fake_env")
+        @assert !isfile(Base.active_project())
+        
+        # force to load the package env Revise version
+        empty!(LOAD_PATH)
+        push!(LOAD_PATH, "$revise_proj")
+        
+        @info "A warning about no Manifest.toml file found is expected"
+        try; using Revise
+            catch err
+                # just fail for this error (see #532)
+                err isa InitError && rethrow(err)
+        end
+        
+    """
+    cmd = `$julia --project=@. -E $src`
+
+    @test begin
+        wait(run(cmd))
+        true
+    end
+end
+@testset "Import in empty enviroment (issue #532)" begin
+    load_in_empty_project_test();
+end

--- a/test/sigtest.jl
+++ b/test/sigtest.jl
@@ -92,7 +92,7 @@ module Lowering end
 end
 
 for lib in Revise.stdlib_names
-    lib in (:OldPkg, :TOML, :Artifacts) && continue
+    lib in (:OldPkg, :TOML, :Artifacts, :LibCURL, :LibCURL_jll, :MozillaCACerts_jll, :Downloads) && continue
     @eval using $lib
 end
 basefiles = Set{String}()
@@ -101,6 +101,7 @@ basefiles = Set{String}()
     # https://github.com/JuliaLang/julia/issues/37590
     endswith(file, "Artifacts.jl") && continue
     endswith(file, "TOML.jl") && continue
+    endswith(file, "Downloads.jl") && continue
     file = Revise.fixpath(file)
     push!(basefiles, reljpath(file))
     mexs = Revise.parse_source(file, mod)


### PR DESCRIPTION
Hi, I'm having this issue. If I initialize julia in an empty environment (using `--project`) with and non-existent (yet) `Project.toml` file Revise complaint that it can not load the `Project.toml`

```julia
~ julia --project=.  
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.1.0 (2019-01-21)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

shell> ls Project.toml
ls: Project.toml: No such file or directory

julia> using Revise
ERROR: InitError: SystemError: opening file "/Users/Pereiro/Project.toml": No such file or directory
Stacktrace:
 [1] #systemerror#43(::Nothing, ::Function, ::String, ::Bool) at ./error.jl:134
 [2] systemerror at ./error.jl:134 [inlined]
 [3] #open#309(::Nothing, ::Nothing, ::Nothing, ::Nothing, ::Nothing, ::Function, ::String) at ./iostream.jl:283
 [4] open at ./iostream.jl:275 [inlined]
 [5] #open#310(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::getfield(Base, Symbol("##651#652")){String}, ::String) at ./iostream.jl:367
 [6] open at ./iostream.jl:367 [inlined]
 [7] project_file_manifest_path at ./loading.jl:369 [inlined]
 [8] manifest_file at /Users/Pereiro/.julia/packages/Revise/ucYAZ/src/pkgs.jl:453 [inlined]
 [9] manifest_file at /Users/Pereiro/.julia/packages/Revise/ucYAZ/src/pkgs.jl:461 [inlined]
 [10] __init__() at /Users/Pereiro/.julia/packages/Revise/ucYAZ/src/Revise.jl:1329
 [11] _include_from_serialized(::String, ::Array{Any,1}) at ./loading.jl:633
 [12] _require_search_from_serialized(::Base.PkgId, ::String) at ./loading.jl:713
 [13] _require(::Base.PkgId) at ./loading.jl:937
 [14] require(::Base.PkgId) at ./loading.jl:858
 [15] require(::Module, ::Symbol) at ./loading.jl:853
during initialization of module Revise

(Pereiro) pkg> add Example
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
 Resolving package versions...
  Updating `~/Project.toml`
  [7876af07] + Example v0.5.3
  Updating `~/Manifest.toml`
  [7876af07] + Example v0.5.3

shell> ls Project.toml
Project.toml

julia> using Revise
# Now it works

(v1.1) pkg> status Revise
    Status `~/.julia/environments/v1.1/Project.toml`
  [aa1ae85d] JuliaInterpreter v0.7.26
  [295af30f] Revise v2.7.6
```
I just add a check for the existence of `project_file`.

NOTE: I couldn't test this in the lastest release (I got some dependency problems), but tests succeeded in version `2.7.6`.

Thanks