### PR TITLE
Add Downloads stdlibs and dependents

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -192,6 +192,12 @@ end
 if VERSION >= v"1.6.0-DEV.890"   # https://github.com/JuliaLang/julia/pull/37320
     push!(stdlib_names, :Artifacts)
 end
+if VERSION >= v"1.6.0-DEV.938"   # https://github.com/JuliaLang/julia/pull/37340
+    push!(stdlib_names, :LibCURL_jll)
+    push!(stdlib_names, :LibCURL)
+    push!(stdlib_names, :MozillaCACerts_jll)
+    push!(stdlib_names, :Downloads)
+end
 
 # This replacement is needed because the path written during compilation differs from
 # the git source path

--- a/test/sigtest.jl
+++ b/test/sigtest.jl
@@ -92,7 +92,7 @@ module Lowering end
 end
 
 for lib in Revise.stdlib_names
-    lib in (:OldPkg, :TOML, :Artifacts) && continue
+    lib in (:OldPkg, :TOML, :Artifacts, :LibCURL, :LibCURL_jll, :MozillaCACerts_jll, :Downloads) && continue
     @eval using $lib
 end
 basefiles = Set{String}()
@@ -101,6 +101,7 @@ basefiles = Set{String}()
     # https://github.com/JuliaLang/julia/issues/37590
     endswith(file, "Artifacts.jl") && continue
     endswith(file, "TOML.jl") && continue
+    endswith(file, "Downloads.jl") && continue
     file = Revise.fixpath(file)
     push!(basefiles, reljpath(file))
     mexs = Revise.parse_source(file, mod)


### PR DESCRIPTION
Stdlibs are breeding like rabbits these days!

Required for `make test-revise-*` to work.