### PR TITLE
Add a fake Requires dependency and pin it at 1.0.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
@@ -20,6 +21,7 @@ CodeTracking = "1"
 JuliaInterpreter = "0.8"
 LoweredCodeUtils = "1.2"
 OrderedCollections = "1"
+Requires = "~1.0"
 julia = "1"
 
 [extras]
@@ -55,9 +57,4 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Base64", "CRC32c", "CatIndices", "Dates", "DelimitedFiles",
-        "EndpointRanges", "EponymTuples", "Example", "Future", "IndirectArrays",
-        "InteractiveUtils", "Libdl", "LinearAlgebra", "Logging", "MappedArrays",
-        "Markdown", "Mmap", "Printf", "Profile", "Random", "Requires",
-        "RoundingIntegers", "SHA", "Serialization", "SharedArrays", "Sockets",
-        "SparseArrays", "Statistics", "SuiteSparse"]
+test = ["Test", "Base64", "CRC32c", "CatIndices", "Dates", "DelimitedFiles", "EndpointRanges", "EponymTuples", "Example", "Future", "IndirectArrays", "InteractiveUtils", "Libdl", "LinearAlgebra", "Logging", "MappedArrays", "Markdown", "Mmap", "Printf", "Profile", "Random", "Requires", "RoundingIntegers", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "SuiteSparse"]


### PR DESCRIPTION
~~Fixes~~Workaround for the breakage caused by Requires 1.1.0. See https://github.com/JuliaPackaging/Requires.jl/issues/94