### PR TITLE
handle `GlobalRef` case in `matches_eval`:

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -52,7 +52,7 @@ function matches_eval(stmt::Expr)
     f = stmt.args[1]
     return f === :eval ||
            (callee_matches(f, Base, :getproperty) && is_quotenode_egal(stmt.args[end], :eval)) ||
-           (isa(f, GlobalRef) && f.name === :eval)
+           (isa(f, GlobalRef) && f.name === :eval) || is_quotenode_egal(f, Core.eval)
 end
 
 function categorize_stmt(stmt)

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -50,7 +50,9 @@ end
 function matches_eval(stmt::Expr)
     stmt.head === :call || return false
     f = stmt.args[1]
-    return f === :eval || (callee_matches(f, Base, :getproperty) && is_quotenode_egal(stmt.args[end], :eval))
+    return f === :eval ||
+           (callee_matches(f, Base, :getproperty) && is_quotenode_egal(stmt.args[end], :eval)) ||
+           (isa(f, GlobalRef) && f.name === :eval)
 end
 
 function categorize_stmt(stmt)


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/37573 seems to have changed lowering:
```julia
julia> lwr = Meta.@lower begin
           for T in (Int, Float64, String)
               @eval mytypeof(x::$T) = $T
           end
       end
:($(Expr(:thunk, CodeInfo(
    @ none:2 within `top-level scope'
1 ─ %1  = Core.tuple(Int, Float64, String)
│         #s192 = Base.iterate(%1)
│   %3  = #s192 === nothing
│   %4  = Base.not_int(%3)
└──       goto #4 if not %4
2 ┄ %6  = #s192
│         T = Core.getfield(%6, 1)
│   %8  = Core.getfield(%6, 2)
│  └
│   @ none:3 within `top-level scope'
│   %9  = Core._expr(:(::), :x, T)
│   %10 = Core._expr(:call, :mytypeof, %9)
│   %11 = Core._expr(:block, $(QuoteNode(:(#= none:3 =#))), T)
│   %12 = Core._expr(:(=), %10, %11)
│         Core.eval(Main, %12)
│         #s192 = Base.iterate(%1, %8)
│   %15 = #s192 === nothing
│   %16 = Base.not_int(%15)
└──       goto #4 if not %16
3 ─       goto #2
4 ┄       return nothing
))))

julia> first(lwr.args).code[13]
:(Core.eval(Main, %12)) # <= `GlobalRef`
```

this will fix this test case that is broken on the current Julia master: 
https://github.com/timholy/Revise.jl/blob/397db6d63b0f1c845ae51fa879c4c2645e35072b/test/runtests.jl#L1731-L1734
maybe there're other places where changes are needed  ¯\_(ツ)_/¯