### PR TITLE
Exclude only Requires version 1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,8 @@ CodeTracking = "1"
 JuliaInterpreter = "0.8"
 LoweredCodeUtils = "1.2"
 OrderedCollections = "1"
-Requires = "~1.0"
+# Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94
+Requires = "~1.0, ^1.1.1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
I *think* this is the correct syntax for excluding only Requires-1.1.0. Testing locally seemed to work despite the lack of registration triggering at https://github.com/JuliaPackaging/Requires.jl/commit/4a23093e13208a4eec7e268802443d1712189cdd.