### PR TITLE
Fix revise() of non-package files with entr / add_callback

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3599,6 +3599,35 @@ do_test("callbacks") && @testset "callbacks" begin
 
     rm_precompile(modname)
 
+    # Issue 574 - ad-hoc revision of a file, combined with add_callback()
+    A574_path = joinpath(testdir, "A574.jl")
+
+    function set_foo_A574(x)
+        open(A574_path, "w") do io
+            println(io, "foo_574() = $x")
+        end
+    end
+
+    set_foo_A574(1)
+    includet(@__MODULE__, A574_path)
+    @test Base.invokelatest(foo_574) == 1
+
+    foo_A574_result = Ref(0)
+    key = Revise.add_callback([A574_path]) do
+        foo_A574_result[] = foo_574()
+    end
+
+    set_foo_A574(2)
+    revise()
+    @test Base.invokelatest(foo_574) == 2
+    @test foo_A574_result[] == 2
+
+    Revise.remove_callback(key)
+
+    set_foo_A574(3)
+    revise()
+    @test Base.invokelatest(foo_574) == 3
+    @test foo_A574_result[] == 2 # <- callback removed - no longer updated
 end
 
 println("beginning cleanup")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3617,6 +3617,7 @@ do_test("callbacks") && @testset "callbacks" begin
         foo_A574_result[] = foo_574()
     end
 
+    sleep(mtimedelay)
     set_foo_A574(2)
     sleep(mtimedelay)
     revise()
@@ -3625,6 +3626,7 @@ do_test("callbacks") && @testset "callbacks" begin
 
     Revise.remove_callback(key)
 
+    sleep(mtimedelay)
     set_foo_A574(3)
     sleep(mtimedelay)
     revise()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3618,6 +3618,7 @@ do_test("callbacks") && @testset "callbacks" begin
     end
 
     set_foo_A574(2)
+    sleep(mtimedelay)
     revise()
     @test Base.invokelatest(foo_574) == 2
     @test foo_A574_result[] == 2
@@ -3625,6 +3626,7 @@ do_test("callbacks") && @testset "callbacks" begin
     Revise.remove_callback(key)
 
     set_foo_A574(3)
+    sleep(mtimedelay)
     revise()
     @test Base.invokelatest(foo_574) == 3
     @test foo_A574_result[] == 2 # <- callback removed - no longer updated


### PR DESCRIPTION
The problem here was that `add_callback()` calls `init_watching` with no
`pkgdata`, so the id of the files which are now watched by the callback
gets set unconditionally to NOPACKAGE. In turn, this breaks revision of
any of these files which were already being revised, because the id
check in `revise_dir_queued` fails and it no longer adds them to the
revision queue.

Instead, change init_watching to not update an existing id when pkgdata
== NOPACKAGE is supplied, unless we're not already watching the file.

This fixes #574.  I'm not sure it's the *best* way to fix it, but without providing a module to `add_callback` where the files will be `revise()`d within, it seems somewhat reasonable. I suppose the other option would be to default to `Main` like `Revise.track` does, but that might just lead to confusion as well.