### PR TITLE
Test fix for #579

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CodeTracking = "1"
-JuliaInterpreter = "0.8"
+JuliaInterpreter = "0.8.4"
 LoweredCodeUtils = "1.2"
 OrderedCollections = "1"
 # Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1440,8 +1440,6 @@ end
             function my_fun end
 
             macro some_macro(value)
-                println("running with ", value)
-                display(stacktrace(backtrace()))
                 return esc(@q \$MacroLineNos568.my_fun() = \$value)
             end
 
@@ -1453,7 +1451,6 @@ end
         @eval using MacroLineNos568
         sleep(mtimedelay)
         @test MacroLineNos568.my_fun() == 20
-        println("initial def is done")
         open(joinpath(dn, "MacroLineNos568.jl"), "w") do io
             println(io, """
             module MacroLineNos568
@@ -1462,8 +1459,6 @@ end
             function my_fun end
 
             macro some_macro(value)
-                println("running with ", value)
-                display(stacktrace(backtrace()))
                 return esc(@q \$MacroLineNos568.my_fun() = \$value)
             end
 
@@ -1471,9 +1466,7 @@ end
             end
             """)
         end
-        println("about to revise")
         yry()
-        println("done revising")
         @test MacroLineNos568.my_fun() == 30
         rm_precompile("MacroLineNos568")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3790,7 +3790,7 @@ function load_in_empty_project_test()
         true
     end
 end
-@testset "Import in empty enviroment (issue #532)" begin
+do_test("Import in empty enviroment (issue #532)") && @testset "Import in empty enviroment (issue #532)" begin
     load_in_empty_project_test();
 end
 


### PR DESCRIPTION
#579 was fixed by https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/443, but we should test it here too.

This doesn't address #239, since any internal references to the name still refer to the old binding.
