### PR TITLE
Tweaks to reduce latency

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -29,6 +29,7 @@ function _precompile_()
 
     MI = CodeTrackingMethodInfo
     @assert precompile(Tuple{typeof(minimal_evaluation!), MI, Core.CodeInfo, Symbol})
+    @assert precompile(Tuple{typeof(minimal_evaluation!), Any, MI, Core.CodeInfo, Symbol})
     @assert precompile(Tuple{typeof(methods_by_execution!), Any, MI, DocExprs, Module, Expr})
     @assert precompile(Tuple{typeof(methods_by_execution!), Any, MI, DocExprs, JuliaInterpreter.Frame, Vector{Bool}})
     @assert precompile(Tuple{typeof(Core.kwfunc(methods_by_execution!)),

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -98,8 +98,8 @@ function Base.isequal(itera::LineSkippingIterator, iterb::LineSkippingIterator)
     while true
         reta === nothing && retb === nothing && return true
         (reta === nothing || retb === nothing) && return false
-        vala, ia = reta
-        valb, ib = retb
+        vala, ia = reta::Tuple{Any,Int}
+        valb, ib = retb::Tuple{Any,Int}
         if isa(vala, Expr) && isa(valb, Expr)
             vala, valb = vala::Expr, valb::Expr
             vala.head == valb.head || return false


### PR DESCRIPTION
Investigation via `SnoopCompile.@snoopi_deep` identified several
opportunities to reduce latency:
- https://github.com/JuliaLang/julia/pull/38906
- https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/461
- https://github.com/JuliaDebug/LoweredCodeUtils.jl/pull/58

Together with the changes here, the aggregate effect is to reduce
the time for the first revision from 3.1s
to about 1.5s. That's much more reasonable.