### PR TITLE
Fix trivial test breakage on nightly

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2930,7 +2930,7 @@ end
         m = @which show([1,2,3])
         @test definition(m) isa Expr
         m = @which redirect_stdout()
-        @test definition(m).head === :function
+        @test definition(m).head ∈ (:function, :(=))
 
         # Tracking stdlibs
         Revise.track(Unicode)

--- a/test/sigtest.jl
+++ b/test/sigtest.jl
@@ -1,4 +1,6 @@
-using Revise, Test, CodeTracking, LoweredCodeUtils
+using Revise, Test
+using Revise.CodeTracking
+using Revise.LoweredCodeUtils
 
 function isdefinedmod(mod::Module)
     # Not all modules---e.g., LibGit2---are reachable without loading the stdlib


### PR DESCRIPTION
`redirect_std*` changed its implementation, and one of Revise's
tests indavertently depended on the former implementation.

Also load CodeTracking & LoweredCodeUtils via Revise for
the signatures test (facilitates `include("runtests.jl")` testing).