### PR TITLE
Don't drop extra fields from FileInfo

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -106,7 +106,7 @@ Initialze an empty FileInfo for a file that is `include`d into `mod`.
 """
 FileInfo(mod::Module, cachefile::AbstractString="") = FileInfo(ModuleExprsSigs(mod), cachefile)
 
-FileInfo(fm::ModuleExprsSigs, fi::FileInfo) = FileInfo(fm, fi.cachefile)
+FileInfo(fm::ModuleExprsSigs, fi::FileInfo) = FileInfo(fm, fi.cachefile, copy(fi.cacheexprs), Ref(fi.extracted[]))
 
 function Base.show(io::IO, fi::FileInfo)
     print(io, "FileInfo(")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -493,6 +493,9 @@ end
                 @test signatures_at(m3file, 1) == [m3.sig]
                 @test signatures_at(eval(Symbol(modname)), joinpath("src", "subdir", "file3.jl"), 1) == [m3.sig]
 
+                id = Base.PkgId(eval(Symbol(modname)))   # for testing #596
+                pkgdata = Revise.pkgdatas[id]
+
                 # Change the definition of function 1 (easiest to just rewrite the whole file)
                 open(joinpath(dn, modname*".jl"), "w") do io
                     println(io, """
@@ -515,6 +518,8 @@ end
 """)  # just for fun we skipped the whitespace
                 end
                 yry()
+                fi = pkgdata.fileinfos[1]
+                @test fi.extracted[]          # issue 596
                 @eval @test $(fn1)() == -1
                 @eval @test $(fn2)() == 2
                 @eval @test $(fn3)() == 3


### PR DESCRIPTION
Fixes #596

The first revision will still be slow due to running the interpreter,
but the later ones will not repeat that work.