### PR TITLE
Set Julia paths during __init__

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,92 @@
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[CodeTracking]]
+deps = ["InteractiveUtils", "UUIDs"]
+git-tree-sha1 = "8ad457cfeb0bca98732c97958ef81000a543e73e"
+uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+version = "1.0.5"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JuliaInterpreter]]
+deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
+git-tree-sha1 = "86439cef50a24fa981583476f48b197b7dea691e"
+uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
+version = "0.8.9"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[LoweredCodeUtils]]
+deps = ["JuliaInterpreter"]
+path = "/home/tim/.julia/dev/LoweredCodeUtils"
+uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
+version = "1.2.8"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[OrderedCollections]]
+git-tree-sha1 = "4fa2ba51070ec13fcc7517db714445b4ab986bdf"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.0"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "cfbac6c1ed70c002ec6361e7fd334f02820d6419"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.1.2"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -99,10 +99,10 @@ end
 function read_from_cache(pkgdata::PkgData, file::AbstractString)
     fi = fileinfo(pkgdata, file)
     filep = joinpath(basedir(pkgdata), file)
-    if fi.cachefile == basesrccache
+    if fi.cachefile == basesrccache[]
         # Get the original path
         filec = get(cache_file_key, filep, filep)
-        return open(basesrccache) do io
+        return open(basesrccache[]) do io
             Base._read_dependency_src(io, filec)
         end
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -44,17 +44,17 @@ function _track(id, modname; modified_files=revision_queue)
     if isbase || isstdlib
         # Test whether we know where to find the files
         if isbase
-            srcdir = fixpath(joinpath(juliadir, "base"))
+            srcdir = fixpath(joinpath(juliadir[], "base"))
             dirs = ["base"]
         else
             stdlibv = joinpath("stdlib", vstring, String(modname))
-            srcdir = fixpath(joinpath(juliadir, stdlibv))
+            srcdir = fixpath(joinpath(juliadir[], stdlibv))
             if !isdir(srcdir)
-                srcdir = fixpath(joinpath(juliadir, "stdlib", String(modname)))
+                srcdir = fixpath(joinpath(juliadir[], "stdlib", String(modname)))
             end
             if !isdir(srcdir)
                 # This can happen for Pkg, since it's developed out-of-tree
-                srcdir = joinpath(juliadir, "usr", "share", "julia", stdlibv)  # omit fixpath deliberately
+                srcdir = joinpath(juliadir[], "usr", "share", "julia", stdlibv)  # omit fixpath deliberately
             end
             dirs = ["stdlib", String(modname)]
         end
@@ -62,7 +62,7 @@ function _track(id, modname; modified_files=revision_queue)
             @error "unable to find path containing source for $modname, tracking is not possible"
         end
         # Determine when the basesrccache was built
-        mtcache = mtime(basesrccache)
+        mtcache = mtime(basesrccache[])
         # Initialize expression-tracking for files, and
         # note any modified since Base was built
         pkgdata = get(pkgdatas, id, nothing)
@@ -79,7 +79,7 @@ function _track(id, modname; modified_files=revision_queue)
                 cache_file_key[fullpath] = filename
                 src_file_key[filename] = fullpath
             end
-            push!(pkgdata, rpath=>FileInfo(submod, basesrccache))
+            push!(pkgdata, rpath=>FileInfo(submod, basesrccache[]))
             if mtime(ffilename) > mtcache
                 with_logger(_debug_logger) do
                     @debug "Recipe for Base/StdLib" _group="Watching" filename=filename mtime=mtime(filename) mtimeref=mtcache
@@ -94,7 +94,7 @@ function _track(id, modname; modified_files=revision_queue)
         # Save the result (unnecessary if already in pkgdatas, but doesn't hurt either)
         pkgdatas[id] = pkgdata
     elseif modname === :Compiler
-        compilerdir = normpath(joinpath(juliadir, "base", "compiler"))
+        compilerdir = normpath(joinpath(juliadir[], "base", "compiler"))
         pkgdata = get(pkgdatas, id, nothing)
         if pkgdata === nothing
             pkgdata = PkgData(id, compilerdir)
@@ -108,7 +108,7 @@ function _track(id, modname; modified_files=revision_queue)
 end
 
 # Fix paths to files that define Julia (base and stdlibs)
-function fixpath(filename::AbstractString; badpath=basebuilddir, goodpath=juliadir)
+function fixpath(filename::AbstractString; badpath=basebuilddir[], goodpath=juliadir[])
     startswith(filename, badpath) || return normpath(filename)
     filec = filename
     relfilename = relpath(filename, badpath)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -739,7 +739,7 @@ end
 
     # issue #131
     do_test("Base & stdlib file paths") && @testset "Base & stdlib file paths" begin
-        @test isfile(Revise.basesrccache)
+        @test isfile(Revise.basesrccache[])
         targetfn = Base.Filesystem.path_separator * joinpath("good", "path", "mydir", "myfile.jl")
         @test Revise.fixpath("/some/bad/path/mydir/myfile.jl"; badpath="/some/bad/path", goodpath="/good/path") == targetfn
         @test Revise.fixpath("/some/bad/path/mydir/myfile.jl"; badpath="/some/bad/path/", goodpath="/good/path") == targetfn
@@ -2926,7 +2926,7 @@ end
 
         # Tracking Base
         # issue #250
-        @test_throws ErrorException("use Revise.track(Base) or Revise.track(<stdlib module>)") Revise.track(joinpath(Revise.juliadir, "base", "intfuncs.jl"))
+        @test_throws ErrorException("use Revise.track(Base) or Revise.track(<stdlib module>)") Revise.track(joinpath(Revise.juliadir[], "base", "intfuncs.jl"))
 
         id = Base.PkgId(Base)
         pkgdata = Revise.pkgdatas[id]
@@ -2961,8 +2961,8 @@ end
         Revise.get_tracked_id(Core)   # just test that this doesn't error
 
         # Determine whether a git repo is available. Travis & Appveyor do not have this.
-        repo, path = Revise.git_repo(Revise.juliadir)
-        if repo != nothing
+        repo, path = Revise.git_repo(Revise.juliadir[])
+        if repo !== nothing
             # Tracking Core.Compiler
             Revise.track(Core.Compiler)
             id = Base.PkgId(Core.Compiler)


### PR DESCRIPTION
This allows one to move the Julia directory after Revise gets precompiled. This adds a latency of ~30ms, which is more than ideal but perhaps livable.
    
Fixes #601

CC @jishnub. I'm frankly on the fence about whether it's worth merging this. The workaround is to delete the cache files for Revise after moving Julia.

NOTE: the second commit is for testing purposes, it should not be part of what gets merged.