### PR TITLE
Test whether windows fail correlates with LCU1.2.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 CodeTracking = "1"
 JuliaInterpreter = "0.8.6"
-LoweredCodeUtils = "= 1.2.7"
+LoweredCodeUtils = "1.2"
 OrderedCollections = "1"
 # Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94
 Requires = "~1.0, ^1.1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 CodeTracking = "1"
 JuliaInterpreter = "0.8.6"
-LoweredCodeUtils = "1.2"
+LoweredCodeUtils = "~1.2.7"
 OrderedCollections = "1"
 # Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94
 Requires = "~1.0, ^1.1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 CodeTracking = "1"
 JuliaInterpreter = "0.8.6"
-LoweredCodeUtils = "~1.2.7"
+LoweredCodeUtils = "= 1.2.7"
 OrderedCollections = "1"
 # Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94
 Requires = "~1.0, ^1.1.1"

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -221,6 +221,8 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, mod
             methods_by_execution!(recurse, methodinfo, docexprs, frame, isrequired; mode=mode, kwargs...)
         catch err
             @show mod ex mode
+            LoweredCodeUtils.print_with_code(stdout, frame.framecode.src, isrequired)
+            @show frame.pc
             (always_rethrow || isa(err, InterruptException)) && (disablebp && foreach(enable, active_bp_refs); rethrow(err))
             loc = location_string(whereis(frame)...)
             sfs = []  # crafted for interaction with Base.show_backtrace

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -220,6 +220,7 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, mod
         ret = try
             methods_by_execution!(recurse, methodinfo, docexprs, frame, isrequired; mode=mode, kwargs...)
         catch err
+            @show mod ex mode
             (always_rethrow || isa(err, InterruptException)) && (disablebp && foreach(enable, active_bp_refs); rethrow(err))
             loc = location_string(whereis(frame)...)
             sfs = []  # crafted for interaction with Base.show_backtrace

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,7 +74,7 @@ const pair_op_compact = let io = IOBuffer()
     print(IOContext(io, :compact=>true), Dict(1=>2))
     String(take!(io))[7:end-2]
 end
-
+#=
 @testset "Revise" begin
     do_test("PkgData") && @testset "PkgData" begin
         # Related to #358
@@ -3829,7 +3829,7 @@ do_test("Import in empty enviroment (issue #532)") && @testset "Import in empty 
 end
 
 include("backedges.jl")
-
+=#
 do_test("Base signatures") && @testset "Base signatures" begin
     println("beginning signatures tests")
     # Using the extensive repository of code in Base as a testbed


### PR DESCRIPTION
LCU1.2.8 fixed two issues (#599 and #557), so it seems like a good
change. This tests whether it's causing the CI failures in #608.