### PR TITLE
allow Revise to work when put into a sysimage

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -22,7 +22,7 @@ function _precompile_()
     @warnpcfail precompile(Tuple{typeof(revise_file_queued), PkgData, String})
     @warnpcfail precompile(Tuple{typeof(init_watching), PkgData, Vector{String}})
     @warnpcfail precompile(Tuple{typeof(add_revise_deps)})
-    @warnpcfail precompile(Tuple{typeof(swap_watch_package), PkgId})
+    @warnpcfail precompile(Tuple{typeof(watch_package_callback), PkgId})
 
     @warnpcfail precompile(Tuple{typeof(revise)})
     @warnpcfail precompile(Tuple{typeof(revise_first), Expr})


### PR DESCRIPTION
Fixes https://github.com/timholy/Revise.jl/issues/549

Slightly rework the latency hiding mechanism to no longer be dependent on having the `package_callbacks` fire just after the Revise `__init__` method runs.

Note, I have not done significant latency testing with this.