### PR TITLE
Stop pushing results to backend.response_channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
         julia --project --code-coverage=user -e 'ENV["JULIA_REVISE_POLL"]="1"; using Pkg, Revise; include(joinpath(dirname(pathof(Revise)), "..", "test", "polling.jl"))'
         # The REPL wasn't initialized, so the "Methods at REPL" tests didn't run. Pick those up now.
         TERM="xterm" julia --project --code-coverage=user -e 'using InteractiveUtils, REPL, Revise; @async(Base.run_main_repl(true, true, false, true, false)); sleep(2); Revise.async_steal_repl_backend(); include(joinpath("test", "runtests.jl")); REPL.eval_user_input(:(exit()), Base.active_repl_backend)' "Methods at REPL"
+        # Tests for out-of-process updates to manifest
+        bash test/envs/use_exputils/setup.sh
+        julia --project --code-coverage=user test/envs/use_exputils/switch_version.jl
         # We also need to pick up the Git tests, but for that we need to `dev` the package
         julia --code-coverage=user -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); include(joinpath("test", "runtests.jl"))' "Git"
     # # Running out of inotify storage (see #26)

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/src/figures/diagram.pdf
 Manifest.toml
 src/aliasnewstruct.jl
 .vscode
+test/envs/use_exputils/Project.toml

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -501,6 +501,7 @@ function watch_manifest(mfile)
             # issue #459
             (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
         end
+        manifest_file() == mfile || continue   # process revisions only if this is the active manifest
         try
             with_logger(_debug_logger) do
                 @debug "Pkg" _group="manifest_update" manifest_file=mfile
@@ -522,12 +523,20 @@ function watch_manifest(mfile)
                             end
                             # Revise code as needed
                             files = String[]
+                            mustnotify = false
                             for file in srcfiles(pkgdata)
-                                maybe_extract_sigs!(maybe_parse_from_cache!(pkgdata, file))
+                                fi = try
+                                    maybe_parse_from_cache!(pkgdata, file)
+                                catch err
+                                    @error "error parsing cache for $(basedir(pkgdata)) : $file" exception=(err, trim_toplevel!(catch_backtrace()))
+                                    fileinfo(pkgdata, file)
+                                end
+                                maybe_extract_sigs!(fi)
                                 push!(revision_queue, (pkgdata, file))
                                 push!(files, file)
-                                notify(revision_event)
+                                mustnotify = true
                             end
+                            mustnotify && notify(revision_event)
                             # Update the directory
                             pkgdata.info.basedir = pkgdir
                             # Restart watching, if applicable
@@ -539,11 +548,17 @@ function watch_manifest(mfile)
                 end
             end
         catch err
-            @static if VERSION >= v"1.2.0-DEV.253"
-                put!(Base.active_repl_backend.response_channel, (Base.catch_stack(), true))
-            else
-                put!(Base.active_repl_backend.response_channel, (err, catch_backtrace()))
-            end
+            @error "Error watching manifest" exception=(err, trim_toplevel!(catch_backtrace()))
         end
     end
+end
+
+function active_project_watcher()
+    mfile = manifest_file()
+    if mfile ∉ watched_manifests
+        push!(watched_manifests, mfile)
+        wmthunk = TaskThunk(watch_manifest, (mfile,))
+        schedule(Task(wmthunk))
+    end
+    return
 end

--- a/test/envs/use_exputils/install.jl
+++ b/test/envs/use_exputils/install.jl
@@ -1,0 +1,8 @@
+# This gets run by setup.sh
+
+using Pkg
+
+Pkg.activate(@__DIR__)
+Pkg.add(name="ExponentialUtilities", version=ARGS[1])
+
+using ExponentialUtilities

--- a/test/envs/use_exputils/setup.sh
+++ b/test/envs/use_exputils/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Ensure that packages that get updated indirectly by external
+# manifest updates work as well as can be hoped.
+# See https://github.com/timholy/Revise.jl/issues/647
+
+# Install and compile two versions of ExponentialUtilities
+dn=$(dirname "$BASH_SOURCE")
+julia $dn/install.jl "1.10.0"
+julia $dn/install.jl "1.9.0"

--- a/test/envs/use_exputils/switch_version.jl
+++ b/test/envs/use_exputils/switch_version.jl
@@ -14,17 +14,12 @@ pkgdata = Revise.pkgdatas[id]
 A = rand(3, 3); A = A'*A; A = A' + A;
 @test_throws UndefVarError exponential!(A)   # not present on v1.9
 # From a different process, switch the active version of ExponentialUtilities
-#### TODO: get rid of the `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`
-#### The issue is that the cache file name is *not* version-dependent!
-#### Consequently the cache file gets overwritten before we have a chance to
-#### retrieve the source-text of the previous version.
-#### This needs to be fixed in Julia itself.
-run(Cmd(`julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; using Pkg; Pkg.activate("."); Pkg.add(name="ExponentialUtilities", version="1.10.0")'`; dir=thisdir))
+run(Cmd(`julia -e 'using Pkg; Pkg.activate("."); Pkg.add(name="ExponentialUtilities", version="1.10.0")'`; dir=thisdir))
 sleep(0.2)
 revise()
 @test exponential!(A) isa Matrix   # present on v1.9
 # ...and then switch back (check that it's bidirectional and also to reset state)
-run(Cmd(`julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; using Pkg; Pkg.activate("."); Pkg.add(name="ExponentialUtilities", version="1.9.0")'`; dir=thisdir))
+run(Cmd(`julia -e 'using Pkg; Pkg.activate("."); Pkg.add(name="ExponentialUtilities", version="1.9.0")'`; dir=thisdir))
 sleep(0.2)
 revise()
 @test_throws MethodError exponential!(A)   # not present on v1.9

--- a/test/envs/use_exputils/switch_version.jl
+++ b/test/envs/use_exputils/switch_version.jl
@@ -1,0 +1,30 @@
+# This test is intended to be run after `setup.sh` runs. ExponentialUtilities
+# should be held at v1.9.0.
+
+using Revise, Pkg, Test
+
+const thisdir = dirname(@__FILE__)
+Pkg.activate(thisdir)
+# This is only needed on Pkg versions that don't notify
+Revise.active_project_watcher()
+
+using ExponentialUtilities
+id = Base.PkgId(ExponentialUtilities)
+pkgdata = Revise.pkgdatas[id]
+A = rand(3, 3); A = A'*A; A = A' + A;
+@test_throws UndefVarError exponential!(A)   # not present on v1.9
+# From a different process, switch the active version of ExponentialUtilities
+#### TODO: get rid of the `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`
+#### The issue is that the cache file name is *not* version-dependent!
+#### Consequently the cache file gets overwritten before we have a chance to
+#### retrieve the source-text of the previous version.
+#### This needs to be fixed in Julia itself.
+run(Cmd(`julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; using Pkg; Pkg.activate("."); Pkg.add(name="ExponentialUtilities", version="1.10.0")'`; dir=thisdir))
+sleep(0.2)
+revise()
+@test exponential!(A) isa Matrix   # present on v1.9
+# ...and then switch back (check that it's bidirectional and also to reset state)
+run(Cmd(`julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; using Pkg; Pkg.activate("."); Pkg.add(name="ExponentialUtilities", version="1.9.0")'`; dir=thisdir))
+sleep(0.2)
+revise()
+@test_throws MethodError exponential!(A)   # not present on v1.9


### PR DESCRIPTION
Fixes #647
Fixes #645 
Fixes #617

This also allows one to switch among package versions more reliably. Good support for changing environments will require https://github.com/JuliaLang/Pkg.jl/pull/2744.