### PR TITLE
Add overall docstring for module

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -1,7 +1,7 @@
 """
 Revise.jl tracks source code changes and incorporates the changes to a running Julia session. 
 
-Revise.jl works behind-the-scene. To track a package, e.g. `Example`:
+Revise.jl works behind-the-scenes. To track a package, e.g. `Example`:
 ```julia
 (@v1.6) pkg> dev Example        # make a development copy of the package
 [...pkg output omitted...]
@@ -10,17 +10,15 @@ julia> using Revise             # this must come before the package under develo
 
 julia> using Example            
 
-[...develop the package...]
-
-(@v1.6) pkg> free Example       # Revise.jl will automatically track the package's released version
+[...develop the package...]     # Revise.jl will automatically update package functionality to match code changes  
 
 ```
 
-Functions in Revise.jl that may come handy:
-- `revise`: evaluate any changes in `Revise.revision_queue` or every definition in a module
+Functions in Revise.jl that may come handy in special circumstances:
 - `Revise.track`: track updates to `Base` Julia itself or `Core.Compiler`
 - `includet`: load a file and track future changes. Intended for small, quick works
 - `entr`: call an additional function whenever code updates
+- `revise`: evaluate any changes in `Revise.revision_queue` or every definition in a module
 - `Revise.retry`: perform previously-failed revisions. Useful in cases of order-dependent errors
 - `Revise.errors`: report the errors represented in `Revise.queue_errors`
 """


### PR DESCRIPTION
Revise.jl lacks a overall docstring. While the online doc is very informative and Revise.jl mostly works on its own, having a docstring can still be helpful. 

I made a docstring for Revise.jl based on [Introduction to Revise](https://timholy.github.io/Revise.jl/stable/) and its [User reference](https://timholy.github.io/Revise.jl/stable/user_reference/). The goals are to provide a compact example for general usage and to provide a short list of functions that may be manually called. 

Currently:

![revise_wo_docstring](https://user-images.githubusercontent.com/30315851/138334886-847cc3f6-c703-47ab-8cc4-b44251c7e24a.PNG)

With docstring:

![docstring_for_revise](https://user-images.githubusercontent.com/30315851/138334380-1aed19c6-2482-42c0-b984-3d0d17c87b93.PNG)

