### PR TITLE
Simplify precompiles

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -46,7 +46,7 @@ You can use the return value `key` to remove the callback later
 (`Revise.remove_callback`) or to update it using another call
 to `Revise.add_callback` with `key=key`.
 """
-function add_callback(f, files, modules=nothing; all=false, key=gensym())
+function add_callback(@nospecialize(f), files, modules=nothing; all=false, key=gensym())
     fix_trailing(path) = isdir(path) ? joinpath(path, "") : path   # insert a trailing '/' if missing, see https://github.com/timholy/Revise.jl/issues/470#issuecomment-633298553
 
     remove_callback(key)
@@ -91,7 +91,7 @@ end
 Remove a callback previously installed by a call to `Revise.add_callback(...)`.
 See its docstring for details.
 """
-function remove_callback(key)
+function remove_callback(@nospecialize(key))
     for cbs in values(user_callbacks_by_file)
         delete!(cbs, key)
     end
@@ -152,7 +152,7 @@ end
 This will print "update" every time `"/tmp/watched.txt"` or any of the code defining
 `Pkg1` or `Pkg2` gets updated.
 """
-function entr(f::Function, files, modules=nothing; all=false, postpone=false, pause=0.02)
+function entr(@nospecialize(f), files, modules=nothing; all=false, postpone=false, pause=0.02)
     yield()
     postpone || f()
     key = add_callback(files, modules; all=all) do

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -24,7 +24,7 @@ add_dependencies!(methodinfo::MethodInfo, be::CodeEdges, src, isrequired) = meth
 add_includes!(methodinfo::MethodInfo, mod::Module, filename) = methodinfo
 
 # This is not generally used, see `is_method_or_eval` instead
-function hastrackedexpr(stmt; heads=LoweredCodeUtils.trackedheads)
+function hastrackedexpr(@nospecialize(stmt); heads=LoweredCodeUtils.trackedheads)
     haseval = false
     if isa(stmt, Expr)
         haseval = matches_eval(stmt)
@@ -122,7 +122,7 @@ end
 function methods_by_execution(mod::Module, ex::Expr; kwargs...)
     methodinfo = MethodInfo()
     docexprs = DocExprs()
-    value, frame = methods_by_execution!(JuliaInterpreter.Compiled(), methodinfo, docexprs, mod, ex; kwargs...)
+    value, frame = methods_by_execution!(Base.inferencebarrier(JuliaInterpreter.Compiled()), methodinfo, docexprs, mod, ex; kwargs...)
     return methodinfo, docexprs, frame
 end
 
@@ -233,7 +233,7 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, mod
     return ret, lwr
 end
 methods_by_execution!(methodinfo, docexprs, mod::Module, ex::Expr; kwargs...) =
-    methods_by_execution!(JuliaInterpreter.Compiled(), methodinfo, docexprs, mod, ex; kwargs...)
+    methods_by_execution!(Base.inferencebarrier(JuliaInterpreter.Compiled()), methodinfo, docexprs, mod, ex; kwargs...)
 
 function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, frame::Frame, isrequired::AbstractVector{Bool}; mode::Symbol=:eval, skip_include::Bool=true)
     isok(lnn::LineTypes) = !iszero(lnn.line) || lnn.file !== :none   # might fail either one, but accept anything

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,4 +1,4 @@
-module __RInternal__
+module var"#Internal"
 ftmp() = 1
 end
 
@@ -23,12 +23,12 @@ function _precompile_()
     add_revise_deps(true)
     revise()
     revise_first(:(1+1))
-    eval_with_signatures(__RInternal__, :(f() = 1))
-    eval_with_signatures(__RInternal__, :(f2() = 1); skip_include=true)
+    eval_with_signatures(var"#Internal", :(f() = 1))
+    eval_with_signatures(var"#Internal", :(f2() = 1); skip_include=true)
     add_require(pathof(LoweredCodeUtils), LoweredCodeUtils, "295af30f-e4ad-537b-8983-00126c2a3abe", "Revise", :(include("somefile.jl")))
     add_require(pathof(JuliaInterpreter), JuliaInterpreter, "295af30f-e4ad-537b-8983-00126c2a3abe", "Revise", :(f(x) = 7))
     pkgdata = pkgdatas[PkgId(LoweredCodeUtils)]
-    eval_require_now(pkgdata, length(pkgdata.info.files), last(pkgdata.info.files)*"__@require__", joinpath(basedir(pkgdata), last(pkgdata.info.files)), Revise, :(__RInternal__.ftmp(::Int) = 0))
+    eval_require_now(pkgdata, length(pkgdata.info.files), last(pkgdata.info.files)*"__@require__", joinpath(basedir(pkgdata), last(pkgdata.info.files)), Revise, :(var"#Internal".ftmp(::Int) = 0))
     # Now empty the stores to prevent them from being serialized
     empty!(watched_files)
     empty!(watched_manifests)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1200,7 +1200,7 @@ end
         frame = Frame(ChangeDocstring, lwr.args[1])
         methodinfo = Revise.MethodInfo()
         docexprs = Revise.DocExprs()
-        ret = Revise.methods_by_execution!(JuliaInterpreter.finish_and_return!, methodinfo,
+        ret = Revise.methods_by_execution!(Base.inferencebarrier(JuliaInterpreter.finish_and_return!), methodinfo,
                                            docexprs, frame, trues(length(frame.framecode.src.code)); mode=:sigs)
         ds = @doc(ChangeDocstring.f)
         @test get_docstring(ds) == "g"


### PR DESCRIPTION
This switches to "do a little work" for precompilation,
rather than explicitly spelling out the specific signatures.
This should be more maintainable and potentially more
exhaustive (or could be made to be so) since it
precompiles across runtime dispatch boundaries.

This also uses `Base.inferencebarrier` in several places to
prevent an argument from being specialized.

I was using this as a test case for https://github.com/JuliaLang/julia/pull/43990 to see if I can eliminate all inference from Revise. It turns out there's one CodeInstance whose inferred code is either not cached or is deleted after compilation. Needs investigation. But the total inference time is <50ms, so in practice it's not a big deal.