### PR TITLE
fix `includet` using `mod` argument

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -875,7 +875,7 @@ If this produces many errors, check that you specified `mod` correctly.
 function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
     isfile(file) || error(file, " is not a file")
     # Determine whether we're already tracking this file
-    id = PkgId(mod, string(mod))
+    id = Base.moduleroot(mod) == Main ? PkgId(mod, string(mod)) : PkgId(mod)  # see #689 for `Main`
     if haskey(pkgdatas, id)
         pkgdata = pkgdatas[id]
         relfile = relpath(abspath(file), pkgdata)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -875,7 +875,7 @@ If this produces many errors, check that you specified `mod` correctly.
 function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
     isfile(file) || error(file, " is not a file")
     # Determine whether we're already tracking this file
-    id = PkgId(mod)
+    id = PkgId(mod, string(mod))
     if haskey(pkgdatas, id)
         pkgdata = pkgdatas[id]
         relfile = relpath(abspath(file), pkgdata)
@@ -984,10 +984,10 @@ they will not be automatically tracked.
 """
 function includet(mod::Module, file::AbstractString)
     prev = Base.source_path(nothing)
-    if prev === nothing
-        file = abspath(file)
+    file = if prev === nothing
+        abspath(file)
     else
-        file = normpath(joinpath(dirname(prev), file))
+        normpath(joinpath(dirname(prev), file))
     end
     tls = task_local_storage()
     tls[:SOURCE_PATH] = file

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3541,7 +3541,7 @@ do_test("includet with mod arg (issue #689)") && @testset "multiple with mod arg
         println(io, """
         module Routines
             using Revise
-            includet(@__MODULE__, "$common")
+            includet(@__MODULE__, raw"$common")
             using .Common
         end 
         """)
@@ -3552,7 +3552,7 @@ do_test("includet with mod arg (issue #689)") && @testset "multiple with mod arg
         println(io, """
         module Codes
             using Revise
-            includet(@__MODULE__, "$common")
+            includet(@__MODULE__, raw"$common")
             using .Common
         end
         """)
@@ -3563,9 +3563,9 @@ do_test("includet with mod arg (issue #689)") && @testset "multiple with mod arg
         println(io, """
         module Driver
             using Revise
-            includet(@__MODULE__, "$routines")
+            includet(@__MODULE__, raw"$routines")
             using .Routines
-            includet(@__MODULE__, "$codes")
+            includet(@__MODULE__, raw"$codes")
             using .Codes
         end
         """)


### PR DESCRIPTION
Fix https://github.com/timholy/Revise.jl/issues/689.

Shouldn't all `PkgId(mod)` be mapped to `PkgId(mod, string(mod)` (else `PkgId(mod)` maps to `PkgId(mod, "Main")`) ?