### PR TITLE
fix `parentfile`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,22 +23,13 @@ jobs:
         arch:
           - x64
     steps:
-    - uses: actions/checkout@v2
-    - uses: julia-actions/setup-julia@v1
+    - uses: actions/checkout@v3
+    - uses: julia-actions/setup-julia@latest
       with:
         version: ${{ matrix.version }}
         arch: ${{ matrix.arch }}
         show-versioninfo: ${{ matrix.version == 'nightly' }}
-    - uses: actions/cache@v1
-      env:
-        cache-name: cache-artifacts
-      with:
-        path: ~/.julia/artifacts
-        key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-test-${{ env.cache-name }}-
-          ${{ runner.os }}-test-
-          ${{ runner.os }}-
+    - uses: julia-actions/cache@v1
     - uses: julia-actions/julia-buildpkg@latest
     # Revise's tests need significant customization
     # Populate the precompile cache with an extraneous file, to catch issues like in #460
@@ -54,21 +45,41 @@ jobs:
       run: |
         echo $TERM
         # Tests for when using polling
-        julia --project --code-coverage=user -e 'ENV["JULIA_REVISE_POLL"]="1"; using Pkg, Revise; include(joinpath(dirname(pathof(Revise)), "..", "test", "polling.jl"))'
+        julia --project --code-coverage=user -e '
+          ENV["JULIA_REVISE_POLL"]="1"
+          using Pkg, Revise
+          include(joinpath(dirname(pathof(Revise)), "..", "test", "polling.jl"))
+        '
         # The REPL wasn't initialized, so the "Methods at REPL" tests didn't run. Pick those up now.
-        TERM="xterm" julia --project --code-coverage=user -e 'using InteractiveUtils, REPL, Revise; @async(Base.run_main_repl(true, true, false, true, false)); while !isdefined(Base, :active_repl_backend) sleep(0.1) end; pushfirst!(Base.active_repl_backend.ast_transforms, Revise.revise_first); include(joinpath("test", "runtests.jl")); REPL.eval_user_input(:(exit()), Base.active_repl_backend)' "Methods at REPL"
+        TERM="xterm" julia --project --code-coverage=user -e '
+          using InteractiveUtils, REPL, Revise
+          @async(Base.run_main_repl(true, true, false, true, false))
+          while !isdefined(Base, :active_repl_backend) sleep(0.1) end
+          pushfirst!(Base.active_repl_backend.ast_transforms, Revise.revise_first)
+          include(joinpath("test", "runtests.jl"))
+          REPL.eval_user_input(:(exit()), Base.active_repl_backend)
+        ' "Methods at REPL"
         # Tests for out-of-process updates to manifest
         bash test/envs/use_exputils/setup.sh
         julia --project --code-coverage=user test/envs/use_exputils/switch_version.jl
         # We also need to pick up the Git tests, but for that we need to `dev` the package
-        julia --code-coverage=user -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); include(joinpath("test", "runtests.jl"))' "Git"
+        julia --code-coverage=user -e '
+          using Pkg; Pkg.develop(PackageSpec(path="."))
+          include(joinpath("test", "runtests.jl"))
+        ' "Git"
         # Check #664
         TERM="xterm" julia --startup-file=no --project test/start_late.jl
+        # Check #697
+        dn=$(mktemp -d)
+        ver=$(julia -e 'println(VERSION)')
+        curl -s -L https://github.com/JuliaLang/julia/archive/refs/tags/v$ver.tar.gz --output - | tar -xz -C $dn
+        julia --project test/juliadir.jl "$dn/julia-$ver"
+
     # # Running out of inotify storage (see #26)
     # - name: inotify
     #   if: ${{ matrix.os == 'ubuntu-latest' }}
     #   run: echo 4 | sudo tee -a /proc/sys/fs/inotify/max_user_watches; julia --project --code-coverage=user -e 'using Pkg, Revise; cd(joinpath(dirname(pathof(Revise)), "..", "test")); include("inotify.jl")'
-    - uses: julia-actions/julia-processcoverage@v1
-    - uses: codecov/codecov-action@v1
+    - uses: julia-actions/julia-processcoverage@latest
+    - uses: codecov/codecov-action@v3
       with:
         file: lcov.info

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -61,6 +61,9 @@ function modulefiles(mod::Module)
     id = PkgId(mod)
     if id.name == "Base" || Symbol(id.name) ∈ stdlib_names
         parentfile = normpath(Base.find_source_file(parentfile))
+        if !startswith(parentfile, juliadir)
+            parentfile = replace(parentfile, fallback_juliadir()=>juliadir)
+        end
         filedata = Base._included_files
         included_files = filter(mf->mf[1] == mod, filedata)
         return keypath(parentfile), [keypath(mf[2]) for mf in included_files]

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -156,6 +156,25 @@ const basebuilddir = begin
     dirname(dirname(sysimg))
 end
 
+function fallback_juliadir()
+    jldir = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia")
+    if !isdir(joinpath(jldir, "base"))
+        while true
+            trydir = joinpath(jldir, "base")
+            isdir(trydir) && break
+            trydir = joinpath(jldir, "share", "julia", "base")
+            if isdir(trydir)
+                jldir = joinpath(jldir, "share", "julia")
+                break
+            end
+            jldirnext = dirname(jldir)
+            jldirnext == jldir && break
+            jldir = jldirnext
+        end
+    end
+    normpath(jldir)
+end
+
 """
     Revise.juliadir
 
@@ -168,21 +187,7 @@ const juliadir = begin
         isdir(joinpath(jldir, "base")) || throw(ErrorException("$(jldir) does not have \"base\""))
     catch
         # Binaries probably end up here. We fall back on Sys.BINDIR
-        jldir = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia")
-        if !isdir(joinpath(jldir, "base"))
-            while true
-                trydir = joinpath(jldir, "base")
-                isdir(trydir) && break
-                trydir = joinpath(jldir, "share", "julia", "base")
-                if isdir(trydir)
-                    jldir = joinpath(jldir, "share", "julia")
-                    break
-                end
-                jldirnext = dirname(jldir)
-                jldirnext == jldir && break
-                jldir = jldirnext
-            end
-        end
+        jldir = fallback_juliadir()
     end
     normpath(jldir)
 end

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -157,22 +157,22 @@ const basebuilddir = begin
 end
 
 function fallback_juliadir()
-    jldir = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia")
-    if !isdir(joinpath(jldir, "base"))
+    candidate = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia")
+    if !isdir(joinpath(candidate, "base"))
         while true
-            trydir = joinpath(jldir, "base")
+            trydir = joinpath(candidate, "base")
             isdir(trydir) && break
-            trydir = joinpath(jldir, "share", "julia", "base")
+            trydir = joinpath(candidate, "share", "julia", "base")
             if isdir(trydir)
-                jldir = joinpath(jldir, "share", "julia")
+                candidate = joinpath(candidate, "share", "julia")
                 break
             end
-            jldirnext = dirname(jldir)
-            jldirnext == jldir && break
-            jldir = jldirnext
+            next_candidate = dirname(candidate)
+            next_candidate == candidate && break
+            candidate = next_candidate
         end
     end
-    normpath(jldir)
+    normpath(candidate)
 end
 
 """
@@ -181,16 +181,14 @@ end
 Constant specifying full path to julia top-level source directory.
 This should be reliable even for local builds, cross-builds, and binary installs.
 """
-const juliadir = begin
-    local jldir = basebuilddir
-    try
-        isdir(joinpath(jldir, "base")) || throw(ErrorException("$(jldir) does not have \"base\""))
-    catch
-        # Binaries probably end up here. We fall back on Sys.BINDIR
-        jldir = fallback_juliadir()
+const juliadir = normpath(
+    if isdir(joinpath(basebuilddir, "base"))
+        basebuilddir
+    else
+        fallback_juliadir()  # Binaries probably end up here. We fall back on Sys.BINDIR
     end
-    normpath(jldir)
-end
+)
+
 const cache_file_key = Dict{String,String}() # corrected=>uncorrected filenames
 const src_file_key   = Dict{String,String}() # uncorrected=>corrected filenames
 

--- a/test/juliadir.jl
+++ b/test/juliadir.jl
@@ -1,0 +1,11 @@
+using Revise, InteractiveUtils, Test
+
+@eval Revise juliadir = ARGS[1]
+
+@test Revise.juliadir != Revise.basebuilddir
+@test Revise.juliadir != Revise.fallback_juliadir()
+
+@show Revise.juliadir
+
+# https://github.com/timholy/Revise.jl/issues/697
+@test Revise.definition(@which(Float32(π))) isa Expr


### PR DESCRIPTION
`parentfile` is inconsistent with `filedata`: on a local build of julia, where `juliadir` points to `basebuilddir`, `parentfile` returns a path starting with `Sys.BINDIR/Base.DATAROOTDIR` because of `Base.find_source_file`.

This is not consistent with `filedata` (`Base._included_files`) which point to files in `basebuilddir`.

- fix https://github.com/timholy/Revise.jl/issues/697;
- add a specific ci test using a forced `juliadir` path (`test/juliadir.jl`).
- update `ci.yaml`, use `@latest` if possible, rewrite some parts for clarity;
- use `julia-actions/cache@v1`;