### PR TITLE
Fix require nothing bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,6 +39,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 RoundingIntegers = "d5f540fe-1c90-5db3-b776-2e2f362d9394"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 
 [targets]
-test = ["CatIndices", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]
+test = ["CatIndices", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays", "POMDPs"]

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -180,7 +180,9 @@ end
 # Use locking to prevent races between inner and outer @require blocks
 const requires_lock = ReentrantLock()
 
-function add_require(sourcefile::String, modcaller::Module, idmod::String, modname::String, expr::Expr)
+function add_require(sourcefile::String, modcaller::Module, idmod::String, modname::String, expr::Union{Expr,Symbol})
+    # make sure we are always dealing with an expression, not a Symbol
+    expr = expr isa Expr ? expr : Expr(expr)
     id = PkgId(modcaller)
     # If this fires when the module is first being loaded (because the dependency
     # was already loaded), Revise may not yet have the pkgdata for this package.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3093,6 +3093,7 @@ do_test("New files & Requires.jl") && @testset "New files & Requires.jl" begin
                 export testfunc
                 include("testfile.jl")
             end
+            @require POMDPs="a93abf59-7444-517b-a68a-c42f96afdd7d" nothing
             @require CatIndices="aafaddc9-749c-510e-ac4f-586e18779b91" onearg(1)
             @require IndirectArrays="9b13fd28-a010-5f03-acff-a1bbcff69959" @eval SubModule include("st.jl")
             @require RoundingIntegers="d5f540fe-1c90-5db3-b776-2e2f362d9394" begin
@@ -3132,6 +3133,9 @@ do_test("New files & Requires.jl") && @testset "New files & Requires.jl" begin
     @eval using IndirectArrays
     sleep(mtimedelay)
     notified && @test TrackRequires.SubModule.h(TrackRequires.SubModule.NewType()) == 3
+    # Check that we also handle symbols (rather than expressions) in `@require`
+    @eval using POMDPs # to trigger Requires
+    sleep(mtimedelay)
     # Check a non-block expression
     warnfile = randtmp()
     open(warnfile, "w") do io


### PR DESCRIPTION
I recently hit an [edge case in LazySets.jl](https://github.com/JuliaReach/LazySets.jl/issues/3040) where a `@require Package="<UUID>" nothing` statement would not hit the `add_require` dispatch in Revise because the `nothing` is parsed as a `Symbol`, not an `Expression`. I have thus widened the type constraint in `add_expression` to accept `Union{Expr,Symbol}` and adjusted the body to always convert to an Expr first.

The test that I added fails on master but works with this PR. However, there may be a more meaningful test to write here. I'm not too familiar with the test structure here.