### PR TITLE
test: hanging `1.8` ci

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -358,9 +358,10 @@ end
 
 # These are typically bypassed in favor of expression-by-expression evaluation to
 # allow handling of new `include` statements.
-function eval_new!(exs_sigs_new::ExprsSigs, exs_sigs_old, mod::Module; mode::Symbol=:eval)
+function eval_new!(exs_sigs_new::ExprsSigs, exs_sigs_old, mod::Module; mode::Symbol=:eval, debug=false)
     includes = Vector{Pair{Module,String}}()
     for rex in keys(exs_sigs_new)
+        debug && @show rex.ex
         sigs, _includes = eval_rex(rex, exs_sigs_old, mod; mode=mode)
         if sigs !== nothing
             exs_sigs_new[rex] = sigs
@@ -372,7 +373,7 @@ function eval_new!(exs_sigs_new::ExprsSigs, exs_sigs_old, mod::Module; mode::Sym
     return exs_sigs_new, includes
 end
 
-function eval_new!(mod_exs_sigs_new::ModuleExprsSigs, mod_exs_sigs_old; mode::Symbol=:eval)
+function eval_new!(mod_exs_sigs_new::ModuleExprsSigs, mod_exs_sigs_old; mode::Symbol=:eval, debug=false)
     includes = Vector{Pair{Module,String}}()
     for (mod, exs_sigs_new) in mod_exs_sigs_new
         # Allow packages to override the supplied mode
@@ -380,6 +381,7 @@ function eval_new!(mod_exs_sigs_new::ModuleExprsSigs, mod_exs_sigs_old; mode::Sy
             mode = getfield(mod, :__revise_mode__)::Symbol
         end
         exs_sigs_old = get(mod_exs_sigs_old, mod, empty_exs_sigs)
+        debug && @show mod exs_sigs_old exs_sigs_new mode
         _, _includes = eval_new!(exs_sigs_new, exs_sigs_old, mod; mode=mode)
         append!(includes, _includes)
     end

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -383,6 +383,7 @@ function eval_new!(mod_exs_sigs_new::ModuleExprsSigs, mod_exs_sigs_old; mode::Sy
         exs_sigs_old = get(mod_exs_sigs_old, mod, empty_exs_sigs)
         debug && @show mod exs_sigs_old exs_sigs_new mode
         _, _includes = eval_new!(exs_sigs_new, exs_sigs_old, mod; mode=mode)
+        debug && @show includes
         append!(includes, _includes)
     end
     return mod_exs_sigs_new, includes

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -188,8 +188,10 @@ function add_require(sourcefile::String, modcaller::Module, idmod::String, modna
         watch_package(id)
     end
 
+    println("about to get the lock")
     lock(requires_lock)
     try
+        println("got the lock")
         # Get/create the FileInfo specifically for tracking @require blocks
         pkgdata = pkgdatas[id]
         filekey = relpath(sourcefile, pkgdata) * "__@require__"

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -208,10 +208,12 @@ function add_require(sourcefile::String, modcaller::Module, idmod::String, modna
         push!(expr.args, :(__pkguuid__ = $idmod))
         # Add the expression to the fileinfo
         complex = true     # is this too complex to delay?
+        @show fi.extracted[]
         if !fi.extracted[]
             # If we haven't yet extracted signatures, do our best to avoid it now in case the
             # signature-extraction code has not yet been compiled (latency reduction)
             includes, complex = deferrable_require(expr)
+            @show complex
             if !complex
                 # [(modcaller, inc) for inc in includes] but without precompiling a Generator
                 modincludes = Tuple{Module,String}[]
@@ -227,12 +229,14 @@ function add_require(sourcefile::String, modcaller::Module, idmod::String, modna
                 end
             end
         end
+        @show complex
         if complex
             Base.invokelatest(eval_require_now, pkgdata, fileidx, filekey, sourcefile, modcaller, expr)
         end
     finally
         unlock(requires_lock)
     end
+    println("released the lock")
 end
 
 function deferrable_require(expr)

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -267,27 +267,34 @@ function deferrable_require!(includes, expr::Expr)
 end
 
 function eval_require_now(pkgdata::PkgData, fileidx::Int, filekey::String, sourcefile::String, modcaller::Module, expr::Expr)
+    @show fileidx filekey sourcefile modcaller expr
     fi = pkgdata.fileinfos[fileidx]
     exsnew = ExprsSigs()
     exsnew[RelocatableExpr(expr)] = nothing
     mexsnew = ModuleExprsSigs(modcaller=>exsnew)
     # Before executing the expression we need to set the load path appropriately
     prev = Base.source_path(nothing)
+    @show :ern_1
     tls = task_local_storage()
     tls[:SOURCE_PATH] = sourcefile
     # Now execute the expression
     mexsnew, includes = try
+        @show :ern_2
         eval_new!(mexsnew, fi.modexsigs)
     finally
+        @show :ern_3
         if prev === nothing
             delete!(tls, :SOURCE_PATH)
         else
             tls[:SOURCE_PATH] = prev
         end
     end
+    @show :ern_4
     # Add any new methods or `include`d files to tracked objects
     pkgdata.fileinfos[fileidx] = FileInfo(mexsnew, fi)
+    @show :ern_5
     ret = maybe_add_includes_to_pkgdata!(pkgdata, filekey, includes; eval_now=true)
+    @show :ern_6
     return ret
 end
 

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -280,7 +280,7 @@ function eval_require_now(pkgdata::PkgData, fileidx::Int, filekey::String, sourc
     # Now execute the expression
     mexsnew, includes = try
         @show :ern_2
-        eval_new!(mexsnew, fi.modexsigs)
+        eval_new!(mexsnew, fi.modexsigs; debug=true)
     finally
         @show :ern_3
         if prev === nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -108,8 +108,13 @@ function pushex!(exsigs::ExprsSigs, ex::Expr)
 end
 
 ## WatchList utilities
+function systime()
+    # It's important to use the same clock used by the filesystem
+    tv = Libc.TimeVal()
+    tv.sec + tv.usec/10^6
+end
 function updatetime!(wl::WatchList)
-    wl.timestamp = time()
+    wl.timestamp = systime()
 end
 Base.push!(wl::WatchList, filenameid::Pair{<:AbstractString,PkgId}) =
     push!(wl.trackedfiles, filenameid)
@@ -117,7 +122,7 @@ Base.push!(wl::WatchList, filenameid::Pair{<:AbstractString,PkgFiles}) =
     push!(wl, filenameid.first=>filenameid.second.id)
 Base.push!(wl::WatchList, filenameid::Pair{<:AbstractString,PkgData}) =
     push!(wl, filenameid.first=>filenameid.second.info)
-WatchList() = WatchList(time(), Dict{String,PkgId}())
+WatchList() = WatchList(systime(), Dict{String,PkgId}())
 Base.in(file, wl::WatchList) = haskey(wl.trackedfiles, file)
 
 @static if Sys.isapple()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3157,6 +3157,8 @@ do_test("New files & Requires.jl") && @testset verbose=true "New files & Require
     @eval using RoundingIntegers
     @show 502
     sleep(2)  # allow time for the @async in all @require blocks to finish
+    println("finished waiting for RoundingIntegers")
+    @show notified
     if notified
         @test TrackRequires.ftrack() == 1
         id = Base.PkgId(TrackRequires)
@@ -3170,6 +3172,7 @@ do_test("New files & Requires.jl") && @testset verbose=true "New files & Require
     end
     @show 503
     @test_throws UndefVarError TrackRequires.fauto()
+    println("got past all of RoundingIntegers")
     @eval using UnsafeArrays
     @show 504
     sleep(2)  # allow time for the @async in all @require blocks to finish
@@ -3553,14 +3556,14 @@ end
 
 do_test("includet with mod arg (issue #689)") && @testset "includet with mod arg (issue #689)" begin
     testdir = newtestdir()
-    
+
     common = joinpath(testdir, "common.jl")
     write(common, """
         module Common
             const foo = 2
         end
         """)
-    
+
     routines = joinpath(testdir, "routines.jl")
     write(routines, """
         module Routines
@@ -3569,7 +3572,7 @@ do_test("includet with mod arg (issue #689)") && @testset "includet with mod arg
             using .Common
         end
         """)
-    
+
     codes = joinpath(testdir, "codes.jl")
     write(codes, """
         module Codes


### PR DESCRIPTION
Test reverting https://github.com/timholy/Revise.jl/pull/679, in order to determine if it is the cause of `1.8.1` failures / hang in ci.
Tests on master are passing locally on `1.8.1`.
They should take around ~3min, but hang in CI (~6h).

1.8.1 ✘ (master):
https://github.com/timholy/Revise.jl/actions/runs/3055718432/jobs/4940473518

1.7.3 (previous commit, without pr) ✔:
https://github.com/timholy/Revise.jl/actions/runs/2767526837/jobs/4349142764