### PR TITLE
add type to `sfs` in `methods_by_execution!`

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -218,7 +218,7 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, mod
         catch err
             (always_rethrow || isa(err, InterruptException)) && (disablebp && foreach(enable, active_bp_refs); rethrow(err))
             loc = location_string(whereis(frame)...)
-            sfs = []  # crafted for interaction with Base.show_backtrace
+            sfs = Base.StackTraces.StackFrame[]  # crafted for interaction with Base.show_backtrace
             frame = JuliaInterpreter.leaf(frame)
             while frame !== nothing
                 push!(sfs, (Base.StackTraces.StackFrame(frame), 1))


### PR DESCRIPTION
At one point, before https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/547, this line was contributing a bunch of invalidations in StaticArrays. Tonight, I forgot that that PR had fixed those invalidations - before I realized they had already been fixed, I found this line and realized that changing it would've fixed a bunch of those invalidations.

It's not really a cause of anything bad anymore; but now that I had looked at it, I figured I'd submit a PR regardless, since it might be nice for it to be typed anyway.