### PR TITLE
docs: update dead link

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -34,7 +34,7 @@ because code moves around within the same file.
 but Revise takes pains to correct these, see below.)
 
 Conceptually, Revise implements
-[`diff` and `patch`](https://linuxacademy.com/blog/linux/introduction-using-diff-and-patch/)
+[`diff` and `patch`](https://acloudguru.com/blog/engineering/introduction-using-diff-and-patch/)
 for a running Julia session. Schematically, Revise's inner loop (`revise()`) looks like this:
 
 ```julia


### PR DESCRIPTION
An alternative link is http://web.archive.org/web/20200722031736/https://linuxacademy.com/blog/linux/introduction-using-diff-and-patch/

..but that loads a bit slower