### PR TITLE
Wait for repl async to allow for startup.jl loading sequence

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1317,14 +1317,22 @@ function __init__()
         else
             pushfirst!(REPL.repl_ast_transforms, revise_first)
             # #664: once a REPL is started, it no longer interacts with REPL.repl_ast_transforms
-            iter = 0
-            # wait for active_repl_backend to exist
-            while !isdefined(Base, :active_repl_backend) && iter < 20
-                sleep(0.05)
-                iter += 1
-            end
             if isdefined(Base, :active_repl_backend)
                 push!(Base.active_repl_backend.ast_transforms, revise_first)
+            else
+                # wait for active_repl_backend to exist
+                # #719: do this async in case Revise is being loaded from startup.jl
+                t = @async begin
+                    iter = 0
+                    while !isdefined(Base, :active_repl_backend) && iter < 20
+                        sleep(0.05)
+                        iter += 1
+                    end
+                    if isdefined(Base, :active_repl_backend)
+                        push!(Base.active_repl_backend.ast_transforms, revise_first)
+                    end
+                end
+                isdefined(Base, :errormonitor) && Base.errormonitor(t)
             end
         end
         if isdefined(Main, :Atom)


### PR DESCRIPTION
Fixes #719 (speeds up loading Revise from 1.2 to 0.2 seconds when loading from startup.jl)

```
$ ./julia
using Revise: 0.225344 seconds (556.59 k allocations: 36.000 MiB)
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.0-DEV.215 (2022-12-28)
 _/ |\__'_|_|_|\__'_|  |  Commit 82fbf54131 (0 days old master)
|__/                   |

julia> includet("test.jl")

julia> foo(1)
1

#edit foo in file

julia> foo(1)
2
```