### PR TITLE
Rely on code-edge dependency analysis

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.4.0"
+version = "3.5.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -19,7 +19,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 CodeTracking = "1.1"
 JuliaInterpreter = "0.9"
-LoweredCodeUtils = "2.2"
+LoweredCodeUtils = "2.3"
 OrderedCollections = "1"
 # Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94
 Requires = "~1.0, ^1.1.1"

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -102,8 +102,8 @@ function minimal_evaluation!(@nospecialize(predicate), methodinfo, src::Core.Cod
     end
     # All tracked expressions are marked. Now add their dependencies.
     # LoweredCodeUtils.print_with_code(stdout, src, isrequired)
-    lines_required!(isrequired, src, edges;
-                    norequire=mode===:sigs ? LoweredCodeUtils.exclude_named_typedefs(src, edges) : ())
+    lines_required!(isrequired, src, edges;)
+                    # norequire=mode===:sigs ? LoweredCodeUtils.exclude_named_typedefs(src, edges) : ())
     # LoweredCodeUtils.print_with_code(stdout, src, isrequired)
     add_dependencies!(methodinfo, edges, src, isrequired)
     return isrequired, evalassign


### PR DESCRIPTION
Formerly we excluded interpretation of type definitions, solely because they didn't seem to be needed (in most cases) and because omitting them avoided some problems of type re-definition. However, Julia has become more sophisticated about avoiding re-definition and LoweredCodeUtils is significantly better at determining code-dependencies. Currently `test/sigtest.jl` has failures that stem from referencing types only defined on Windows on a Linux system; with this PR, we rely on LoweredCodeUtils to discover that this code shouldn't be executed, thus fixing the bug.