### PR TITLE
Insulate Revise methods from invalidation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-CodeTracking = "1.1"
+CodeTracking = "1.2"
 JuliaInterpreter = "0.9"
 LoweredCodeUtils = "2.3"
 OrderedCollections = "1"


### PR DESCRIPTION
Loading a package like StaticArrays invalidates
much of Revise's code. This protects it by using
runtime-dispatch for the invalidating calls.

Exploits https://github.com/timholy/CodeTracking.jl/pull/101