### PR TITLE
Fix several sources of invalidation

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -316,7 +316,6 @@ end
 
 function eval_rex(rex::RelocatableExpr, exs_sigs_old::ExprsSigs, mod::Module; mode::Symbol=:eval)
     return with_logger(_debug_logger) do
-        sigs, includes = nothing, nothing
         rexo = getkey(exs_sigs_old, rex, nothing)
         # extract the signatures and update the line info
         if rexo === nothing
@@ -337,13 +336,16 @@ function eval_rex(rex::RelocatableExpr, exs_sigs_old::ExprsSigs, mod::Module; mo
                 end
             end
             storedeps(deps, rex, mod)
+            return sigs, includes
         else
-            sigs = exs_sigs_old[rexo]
+            sigs, includes = exs_sigs_old[rexo], nothing
             # Update location info
             ln, lno = firstline(unwrap(rex)), firstline(unwrap(rexo))
             if sigs !== nothing && !isempty(sigs) && ln != lno
                 ln, lno = ln::LineNumberNode, lno::LineNumberNode
-                @debug "LineOffset" _group="Action" time=time() deltainfo=(sigs, lno=>ln)
+                let sigs=sigs   # #15276
+                    @debug "LineOffset" _group="Action" time=time() deltainfo=(sigs, lno=>ln)
+                end
                 for sig in sigs
                     locdefs = CodeTracking.method_info[sig]::AbstractVector
                     ld = map(pr->linediff(lno, pr[1]), locdefs)
@@ -356,8 +358,8 @@ function eval_rex(rex::RelocatableExpr, exs_sigs_old::ExprsSigs, mod::Module; mo
                     locdefs[idx] = (newloc(methloc, ln, lno), methdef)
                 end
             end
+            return sigs, includes
         end
-        return sigs, includes
     end
 end
 
@@ -655,7 +657,7 @@ function handle_deletions(pkgdata, file)
     end
     topmod = first(keys(mexsold))
     fileok = file_exists(String(filep)::String)
-    mexsnew = fileok ? parse_source(filep, topmod) : ModuleExprsSigs(topmod)
+    mexsnew = fileok ? Base.invokelatest(parse_source, filep, topmod) : ModuleExprsSigs(topmod)
     if mexsnew !== nothing
         delete_missing!(mexsold, mexsnew)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,7 +27,8 @@ end
 function unique_dirs(iter)
     udirs = Set{String}()
     for file in iter
-        dir, basename = splitdir(file)
+        isa(file, AbstractString) || continue
+        dir, basename = splitdir(file::String)
         push!(udirs, dir)
     end
     return udirs


### PR DESCRIPTION
These changes fix invalidation from the JuliaData ecosystem,
presumably mostly due to new AbstractString subtypes.