### PR TITLE
Fix nightly

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -249,7 +249,7 @@ function delete_missing!(exs_sigs_old::ExprsSigs, exs_sigs_new)
             # ex was deleted
             sigs === nothing && continue
             for sig in sigs
-                ret = Base._methods_by_ftype(sig, -1, typemax(UInt))
+                ret = Base._methods_by_ftype(sig, -1, Base.get_world_counter())
                 success = false
                 if !isempty(ret)
                     m = get_method_from_match(ret[end])   # the last method returned is the least-specific that matches, and thus most likely to be type-equal
@@ -1239,7 +1239,7 @@ Revise itself does not need to be running on `p`.
 function init_worker(p)
     remotecall(Core.eval, p, Main, quote
         function whichtt(sig)
-            ret = Base._methods_by_ftype(sig, -1, typemax(UInt))
+            ret = Base._methods_by_ftype(sig, -1, Base.get_world_counter())
             isempty(ret) && return nothing
             m = ret[end][3]::Method   # the last method returned is the least-specific that matches, and thus most likely to be type-equal
             methsig = m.sig


### PR DESCRIPTION
Nightly has changed the internals of method-lookup, this uses the
world age rather than `typemax(UInt)`.