### PR TITLE
fix `Revise.track(PkgA, "src/PkgA.jl")`

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -651,7 +651,11 @@ function handle_deletions(pkgdata, file)
     idx = fileindex(pkgdata, file)
     filep = pkgdata.info.files[idx]
     if isa(filep, AbstractString)
-        filep = normpath(joinpath(basedir(pkgdata), file))
+        if file ≠ "."
+            filep = normpath(basedir(pkgdata), file)
+        else
+            filep = normpath(basedir(pkgdata))
+        end
     end
     topmod = first(keys(mexsold))
     fileok = file_exists(String(filep)::String)


### PR DESCRIPTION
Just noticed that `Revise.track(PkgA, "src/PkgA.jl")` fails on Revise@3.5.2:
```julia
julia> using JET

julia> using Revise

julia> Revise.track(JET, normpath(pkgdir(JET), "src/JET.jl"))

# edit JET.jl to define `hello() = "hello"` method

julia> JET.hello()
┌ Warning: /Users/aviatesk/julia/packages/JET/src/JET.jl/ no longer exists, deleted all methods
└ @ Revise ~/julia/packages/Revise/src/packagedef.jl:668
ERROR: UndefVarError: `hello` not defined
Stacktrace:
 [1] top-level scope
   @ REPL[4]:1
```

The issue here seems to be that `file` passed to `handle_deletions` can be `"."`, causing https://github.com/timholy/Revise.jl/blob/eb0bd3ff9c353191eb2c6af2f56194616bce471c/src/packagedef.jl#L654 to return invalid file path.
This commit aims to fix it by adding a special case for the `file == "."` case in `handle_deletions`.