### PR TITLE
make REPL AST transform work when `active_module` is set to `Core.Compiler`

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1231,7 +1231,7 @@ function revise_first(ex)
         isa(exu, Expr) && exu.head === :call && length(exu.args) == 1 && exu.args[1] === :exit && return ex
     end
     # Check for queued revisions, and if so call `revise` first before executing the expression
-    return Expr(:toplevel, :(isempty($revision_queue) || Base.invokelatest($revise)), ex)
+    return Expr(:toplevel, :($isempty($revision_queue) || $(Base.invokelatest)($revise)), ex)
 end
 
 steal_repl_backend(args...) = @warn "`steal_repl_backend` has been removed from Revise, please update your `~/.julia/config/startup.jl`.\nSee https://timholy.github.io/Revise.jl/stable/config/"


### PR DESCRIPTION
Otherwise REPL will result in the following error since `isempty` is resolved within `Core.Compiler` context module:
```julia
Core.Compiler) julia> 42
ERROR: MethodError: no method matching iterate(::Base.Set{Tuple{Revise.PkgData, String}})
You may have intended to import Base.iterate

Closest candidates are:
  iterate(::MethodSpecializations)
   @ Core reflection.jl:1146
  iterate(::MethodSpecializations, ::Nothing)
   @ Core reflection.jl:1152
  iterate(::MethodSpecializations, ::Int64)
   @ Core reflection.jl:1153
  ...

Stacktrace:
 [1] isempty(itr::Base.Set{Tuple{Revise.PkgData, String}})
   @ Core.Compiler ./essentials.jl:952
 [2] top-level scope
   @ none:1
```