### PR TITLE
Julia 1.7 compat: use a more compatible cd version

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -358,10 +358,19 @@ function has_writable_paths(pkgdata::PkgData)
     dir = basedir(pkgdata)
     isdir(dir) || return true
     haswritable = false
-    cd(dir) do
+    # Compatibility note:
+    # The following can be written in cd(dir) do ... end block
+    # but that would trigger Julia to crash for some corner cases.
+    # This is identified on Julia 1.7.3 + modified ubuntu 18.04, and it is
+    # verified that doesn't happen for Julia 1.9.2 on the same machine.
+    current_dir = pwd()
+    try
+        cd(dir)
         for file in srcfiles(pkgdata)
             haswritable |= iswritable(file)
         end
+    finally
+        cd(current_dir)
     end
     return haswritable
 end


### PR DESCRIPTION
Julia 1.7.3 would crash in a customized Ubuntu 18.04 version. This patch rewrites the crashing part with a more compatible version.

The root julia issue isn't identified yet, but it's verified that Julia 1.9.2 works on the same machine, so it's highly likely fixed already. My best guess is https://github.com/JuliaLang/julia/issues/33413, but that seems fixed before 1.7 is ever released.

The following figure is a screenshot from the server. We can see that it somehow crashes while calling `cd` inside the `has_writable_paths` function.

![image](https://github.com/timholy/Revise.jl/assets/8684355/c3d368f0-3384-4084-b32f-6c8585e78da3)

It's behind the enterprise firewall, so we use `dev` to reproduce the environment. All codes are not modified (directly downloaded & unzipped from original repos). I also believe this is a customized Ubuntu server because we can't reproduce this locally with `docker run -it --rm ubuntu:18.04`.

If this patch is not wanted upstream, feel free to close this PR.