### PR TITLE
Correct default use of `skip_include` in `includet` docstring

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -985,7 +985,7 @@ This can be automated using [`entr`](@ref).
 
 `includet` is essentially shorthand for
 
-    Revise.track(Main, filename; mode=:eval, skip_include=true)
+    Revise.track(Main, filename; mode=:includet, skip_include=true)
 
 Do *not* use `includet` for packages, as those should be handled by `using` or `import`.
 If `using` and `import` aren't working, you may have packages in a non-standard location;

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -985,7 +985,7 @@ This can be automated using [`entr`](@ref).
 
 `includet` is essentially shorthand for
 
-    Revise.track(Main, filename; mode=:eval, skip_include=false)
+    Revise.track(Main, filename; mode=:eval, skip_include=true)
 
 Do *not* use `includet` for packages, as those should be handled by `using` or `import`.
 If `using` and `import` aren't working, you may have packages in a non-standard location;


### PR DESCRIPTION
The default behaviour is to skip recursively included files for tracking. This is now correctly mirrored in the doctring