### PR TITLE
When receiving a package callback, start watching the current environment.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
 EndpointRanges = "340492b5-2a47-5f55-813d-aca7ddf97656"
 EponymTuples = "97e2ac4a-e175-5f49-beb1-4d6866a6cdc3"
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
@@ -41,4 +42,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [targets]
-test = ["CatIndices", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]
+test = ["CatIndices", "EndpointRanges", "EponymTuples", "Example", "Git", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,6 @@ CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
 EndpointRanges = "340492b5-2a47-5f55-813d-aca7ddf97656"
 EponymTuples = "97e2ac4a-e175-5f49-beb1-4d6866a6cdc3"
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
-Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
@@ -42,4 +41,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [targets]
-test = ["CatIndices", "EndpointRanges", "EponymTuples", "Example", "Git", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]
+test = ["CatIndices", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -331,6 +331,9 @@ This function gets called via a callback registered with `Base.require`, at the 
 of module-loading by `using` or `import`.
 """
 function watch_package(id::PkgId)
+    # we may have switched environments, so make sure we're watching the right manifest
+    active_project_watcher()
+
     pkgdata = get(pkgdatas, id, nothing)
     pkgdata !== nothing && return pkgdata
     lock(wplock)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2990,7 +2990,7 @@ do_test("Switching environments") && @testset "Switching environments" begin
         end
 
         # install the package
-        Pkg.add(url="file://$(pkg)")
+        Pkg.add(url=pkg)
         sleep(mtimedelay)
 
         @eval using TestPackage
@@ -3006,7 +3006,7 @@ do_test("Switching environments") && @testset "Switching environments" begin
         end
 
         # install the update
-        Pkg.add(url="file://$(pkg)")
+        Pkg.add(url=pkg)
         sleep(mtimedelay)
 
         revise()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2983,8 +2983,8 @@ do_test("Switching environments") && @testset "Switching environments" begin
         root = mktempdir()
         pkg = generate_package(root, 1)
         LibGit2.with(LibGit2.init(pkg)) do repo
-            LibGit2.add!(repo, joinpath("Project.toml"))
-            LibGit2.add!(repo, joinpath("src", "TestPackage.jl"))
+            LibGit2.add!(repo, "Project.toml")
+            LibGit2.add!(repo, "src/TestPackage.jl")
             test_sig = LibGit2.Signature("TEST", "TEST@TEST.COM", round(time(); digits=0), 0)
             LibGit2.commit(repo, "version 1"; author=test_sig, committer=test_sig)
         end
@@ -3000,7 +3000,7 @@ do_test("Switching environments") && @testset "Switching environments" begin
         # update the package
         generate_package(root, 2)
         LibGit2.with(LibGit2.GitRepo(pkg)) do repo
-            LibGit2.add!(repo, joinpath("src", "TestPackage.jl"))
+            LibGit2.add!(repo, "src/TestPackage.jl")
             test_sig = LibGit2.Signature("TEST", "TEST@TEST.COM", round(time(); digits=0), 0)
             LibGit2.commit(repo, "version 2"; author=test_sig, committer=test_sig)
         end


### PR DESCRIPTION
Otherwise Revise doesn't detect when having switched environments.

MWE:

```julia
using Revise

using Pkg
Pkg.activate(; temp=true)

Pkg.add(url="https://github.com/maleadt/ReviseTest.jl",
        rev="cf766c822806398f4ac8e89fb7b588d551e70d1f")
using ReviseTest

@show ReviseTest.test()

Pkg.add(url="https://github.com/maleadt/ReviseTest.jl",
        rev="6396547c3871f07830744267391cfba5146eba12")

Revise.revise()
@show ReviseTest.test()
```

The first revision has `test() = 1`, the second one `test() = 2`. Currently, Revise  only has a manifest watcher for the main environment Revise was imported in, i.e., not the temporary one that contains the ReviseTest package. By adding a new watcher when we receive the package callback hook when importing ReviseTest, we detect changes to the temporary manifest and correctly update the definition of the `test()` function.

Fixes https://github.com/timholy/Revise.jl/issues/709.