### PR TITLE
Check for no manifest in active_project_watcher

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -493,6 +493,7 @@ end
 
 function active_project_watcher()
     mfile = manifest_file()
+    mfile === nothing && return nothing
     if mfile ∉ watched_manifests
         push!(watched_manifests, mfile)
         wmthunk = TaskThunk(watch_manifest, (mfile,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2326,6 +2326,13 @@ const issue639report = []
         @test basename(srcfile) ∈ Revise.watched_files[dirname(srcfile)]
         push!(to_remove, srcfile)
 
+        # Do not error when there are no active manifest (issue #762)
+        old_project = Base.ACTIVE_PROJECT[]
+        Pkg.activate(temp=true)
+        @test isnothing(Revise.manifest_file())
+        @test isnothing(Revise.active_project_watcher())
+        Base.ACTIVE_PROJECT[] = old_project
+
         # Double-execution (issue #263)
         srcfile = joinpath(tempdir(), randtmp()*".jl")
         write(srcfile, "println(\"executed\")")


### PR DESCRIPTION
I'm giving this PR a go here - although the tests fails for me locally with seemingly completely unrelated errors.