### PR TITLE
Update to Documenter v1

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.24"
+Documenter = "1"

--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -32,7 +32,7 @@ Both options are described below.
     and [here](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup).
     It's also helpful to sign up for a [GitHub account](https://github.com/)
     and set git's `github.user` variable.
-    The [PkgTemplates documentation](https://invenia.github.io/PkgTemplates.jl/stable/)
+    The [PkgTemplates documentation](https://juliaci.github.io/PkgTemplates.jl/stable/)
     may also be useful.
 
     If you struggle with this part, consider trying the "plain" `Pkg` variant below.

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -29,6 +29,7 @@ Revise.revision_queue
 Revise.NOPACKAGE
 Revise.queue_errors
 Revise.included_files
+Revise.watched_manifests
 ```
 
 The following are specific to user callbacks (see [`Revise.add_callback`](@ref)) and

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -115,7 +115,7 @@ julia> Example.f()
 ```
 
 Revise is not tied to any particular editor.
-(The [EDITOR or JULIA_EDITOR](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.edit-Tuple{AbstractString,Integer}) environment variables can be used to specify your preference for which editor gets launched by Julia's `edit` function.)
+(The [EDITOR or JULIA_EDITOR](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_EDITOR) environment variables can be used to specify your preference for which editor gets launched by Julia's `edit` function.)
 
 If you don't want to have to remember to say `using Revise` each time you start
 Julia, see [Using Revise by default](@ref).

--- a/docs/src/user_reference.md
+++ b/docs/src/user_reference.md
@@ -28,3 +28,9 @@ Revise.diffs
 Revise.dont_watch_pkgs
 Revise.silence
 ```
+
+### Revise module
+
+```@docs
+Revise
+```


### PR DESCRIPTION
This gives many nice convenience features like, e.g., a better search, a GitHub link to the repo at the top of the docs, collapsable docstrings and many more. I only had to fix a few mistakes in the docs (which under v1 lead to errors instead of warnings), like a few dead links etc.

Tested locally, let's see what CI says.