### PR TITLE
fix: add check for `nothing` as manifest file in active_project_watcher

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -493,7 +493,7 @@ end
 
 function active_project_watcher()
     mfile = manifest_file()
-    if mfile ∉ watched_manifests
+    if !isnothing(mfile) && mfile ∉ watched_manifests
         push!(watched_manifests, mfile)
         wmthunk = TaskThunk(watch_manifest, (mfile,))
         schedule(Task(wmthunk))


### PR DESCRIPTION
Since `manifest_file()` can return `nothing` as well, add a check/guard for when it's `nothing` in `active_project_watcher`.

Fixes #762.