### PR TITLE
Fix `parse_cache_header` signature change

### DIFF
--- a/src/loading.jl
+++ b/src/loading.jl
@@ -4,7 +4,11 @@ function pkg_fileinfo(id::PkgId)
     cachepath = origin.cachepath
     cachepath === nothing && return nothing, nothing, nothing
     provides, includes_requires, required_modules = try
-        Base.parse_cache_header(cachepath; srcfiles_only=true)
+        @static if VERSION ≥ v"1.11.0-DEV.683"
+            Base.parse_cache_header(cachepath)
+        else
+            Base.parse_cache_header(cachepath, srcfiles_only = true)
+        end
     catch
         return nothing, nothing, nothing
     end


### PR DESCRIPTION
`Base.parse_cache_headers` removed its keyword `srcfiles_only` in https://github.com/JuliaLang/julia/pull/49866, which makes Revise non-functional in nightly.

There are a bunch of other test failures, and I'm not sure I understand the internals enough to address them, but I could identify least two sources (there are probably more):
- `LoadError` seems to now (sometimes?) hold a `Meta.ParseError` value for its `.error` field, breaking a few tests which expect a `String` instead. A bunch of related error messages seem to have changed too.
- Source files can't be located for `Pkg` (the associated `(::PkgData).info.files` is empty, probably that's because of that), breaking related tests.

Anyway, we can probably merge this fix and worry about other failures on `nightly` later, such that `Revise` works again on nightly. Or if anyone wants to address nightly failures in a wider swath, that works for me too.