### PR TITLE
allow CI nightly to fail so badge is green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,17 @@ jobs:
         version:
           - '1.6'     # LTS
           - '1'       # current stable
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         arch:
           - x64
+        include:
+          - version: 'nightly'
+            os: ubuntu-latest
+            arch: x64
+            allow_failure: true
     steps:
     - uses: actions/checkout@v4
     - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
There are two ways of doing this, another possibility is to have a separate `ci_nightly.yml`, let me know if maintainers prefer that route.