### PR TITLE
Workaround lowering error in docstring method signatures

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -175,6 +175,13 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, mod
     mode ∈ (:sigs, :eval, :evalmeth, :evalassign) || error("unsupported mode ", mode)
     lwr = Meta.lower(mod, ex)
     isa(lwr, Expr) || return nothing, nothing
+    # Targeted hack around https://github.com/timholy/Revise.jl/issues/735
+    if Meta.isexpr(lwr, :error, 1) && lwr.args[1] == "invalid \"::\" syntax" &&
+       mode === :sigs
+        @debug "methods_by_execution!: skipping expression where lowering failed " *
+               "(see https://github.com/timholy/Revise.jl/issues/735)" expr=ex lowered=lwr
+        return nothing, nothing
+    end
     if lwr.head === :error || lwr.head === :incomplete
         error("lowering returned an error, ", lwr)
     end


### PR DESCRIPTION
This patch adds a (minimal?) targeted hack to workaround an issue where a method signature for documentation fails lowering (#735).

Specifically, when revising the following code:

```julia
struct Foo{T} end

"docs"
Foo{T}(::Int) where T
```

lowering errors for the expression `:(Foo{T}(::Int) where T)` with `"invalid :: syntax"`. This patch simply ignores the expression when this situation is detected. Note that, just after, the full expression (docstring + signature) is lowered together succesfully. In particular this means that the docstring will still be updated correctly.