### PR TITLE
Restore filtering of non-src files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.5.8"
+version = "3.5.9"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -4,8 +4,10 @@ function pkg_fileinfo(id::PkgId)
     cachepath = origin.cachepath
     cachepath === nothing && return nothing, nothing, nothing
     provides, includes_requires, required_modules = try
-        @static if VERSION ≥ v"1.11.0-DEV.683"
-            Base.parse_cache_header(cachepath)
+        @static if VERSION ≥ v"1.11.0-DEV.683" # https://github.com/JuliaLang/julia/pull/49866
+            provides, (_, includes_srcfiles_only, requires), required_modules, _... =
+                Base.parse_cache_header(cachepath)
+            provides, (includes_srcfiles_only, requires), required_modules
         else
             Base.parse_cache_header(cachepath, srcfiles_only = true)
         end


### PR DESCRIPTION
This patch restores the filtering of non-src files that was lost
in https://github.com/timholy/Revise.jl/pull/767. After https://github.com/JuliaLang/julia/pull/49866,
`Base.parse_cache_header` returns both the non-filtered and filtered
list instead of doing filtering internally based on the
`srcfiles_only::Bool` keyword argument.

There is a test for this failure mode that fails on Revise master branch
and passes with this patch (see
https://github.com/timholy/Revise.jl/blob/1059181bed06387e9fbcea137dce28a80c5c45d9/test/runtests.jl#L3070-L3080).