### PR TITLE
minor updates on old code

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -38,7 +38,7 @@ using OrderedCollections, CodeTracking, JuliaInterpreter, LoweredCodeUtils
 using CodeTracking: PkgFiles, basedir, srcfiles, line_is_decl, basepath
 using JuliaInterpreter: whichtt, is_doc_expr, step_expr!, finish_and_return!, get_return,
                         @lookup, moduleof, scopeof, pc_expr, is_quotenode_egal,
-                        linetable, codelocs, LineTypes, is_GotoIfNot, isassign, isidentical
+                        linetable, codelocs, LineTypes, isassign, isidentical
 using LoweredCodeUtils: next_or_nothing!, trackedheads, callee_matches
 
 include("packagedef.jl")

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -435,8 +435,7 @@ pop_expr!(methodinfo::CodeTrackingMethodInfo) = (pop!(methodinfo.exprstack); met
 function add_dependencies!(methodinfo::CodeTrackingMethodInfo, edges::CodeEdges, src, musteval)
     isempty(src.code) && return methodinfo
     stmt1 = first(src.code)
-    if (isexpr(stmt1, :gotoifnot) && (dep = (stmt1::Expr).args[1]; isa(dep, Union{GlobalRef,Symbol}))) ||
-       (is_GotoIfNot(stmt1) && (dep = stmt1.cond; isa(dep, Union{GlobalRef,Symbol})))
+    if isa(stmt1, Core.GotoIfNot) && (dep = stmt1.cond; isa(dep, Union{GlobalRef,Symbol}))
         # This is basically a hack to look for symbols that control definition of methods via a conditional.
         # It is aimed at solving #249, but this will have to be generalized for anything real.
         for (stmt, me) in zip(src.code, musteval)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -88,8 +88,6 @@ unwrap(rex::RelocatableExpr) = RelocatableExpr(unwrap(rex.ex))
 
 istrivial(a) = a === nothing || isa(a, LineNumberNode)
 
-isgoto(stmt) = isa(stmt, Core.GotoNode) | isexpr(stmt, :gotoifnot)
-
 function unwrap_where(ex::Expr)
     while isexpr(ex, :where)
         ex = ex.args[1]


### PR DESCRIPTION
Since the minimum version compat for Revise is now 1.6, we can expect `GotoIfNot` to be defined within `Core` always.