### PR TITLE
Fix tests that were broken by 1.10

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -91,3 +91,6 @@ if !isempty(ARGS) && "REVISE_TESTS_WATCH_FILES" ∈ ARGS
     idx = findall(isequal("REVISE_TESTS_WATCH_FILES"), ARGS)
     deleteat!(ARGS, idx)
 end
+
+errmsg(err::Base.Meta.ParseError) = err.msg
+errmsg(err::AbstractString) = err

--- a/test/populate_compiled.jl
+++ b/test/populate_compiled.jl
@@ -1,4 +1,4 @@
-# This runs only on Travis. The goal is to populate the `.julia/compiled/v*` directory
+# This runs only on CI. The goal is to populate the `.julia/compiled/v*` directory
 # with some additional files, so that `filter_valid_cachefiles` has to run.
 # This is to catch problems like #460.
 
@@ -12,5 +12,5 @@ paths = Base.find_all_in_cache_path(id)
 Pkg.rm("EponymTuples") # we don't need it anymore
 path = first(paths)
 base, ext = splitext(path)
-mv(path, base*"blahblah"*ext)
+mv(path, base*"blahblah"*ext; force=true)
 Pkg.add(PackageSpec(name="EponymTuples"))

--- a/test/sigtest.jl
+++ b/test/sigtest.jl
@@ -104,7 +104,7 @@ end
 
 basefiles = Set{String}()
 @time for (i, (mod, file)) in enumerate(Base._included_files)
-    endswith(file, "sysimg.jl") && continue
+    (endswith(file, "sysimg.jl") || endswith(file, "Base.jl")) && continue
     file = Revise.fixpath(file)
     push!(basefiles, reljpath(file))
     mexs = Revise.parse_source(file, mod)


### PR DESCRIPTION
In particular, the new parser generates different (and much better) error messages; we were testing the content of the error message, so that has to change.

Also skips a portion of the old signature tests due to usage of `include(mapexpr, file)`, which is not (and may never be) supported by Revise.