### PR TITLE
Correct pc for empty function definition

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -281,7 +281,7 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, fra
                             add_signature!(methodinfo, sig, lnn)
                         end
                     end
-                    pc = ret
+                    pc += 1
                 else
                     pc, pc3 = ret
                     # Get the line number from the body

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -680,6 +680,32 @@ const issue639report = []
         rm_precompile("A339")
         rm_precompile("B339")
 
+        # Combining `include` with empty functions (issue #758)
+        write(joinpath(testdir, "Issue758.jl"), """
+            module Issue758
+            global gvar = true
+            function f end
+            include("Issue758helperfile.jl")
+            end
+            """)
+        write(joinpath(testdir, "Issue758helperfile.jl"), "")
+        sleep(mtimedelay)
+        using Issue758
+        sleep(mtimedelay)
+        @test_throws MethodError Issue758.f()
+        sleep(mtimedelay)
+        write(joinpath(testdir, "Issue758.jl"), """
+            module Issue758
+            global gvar = true
+            function f end
+            f() = 1
+            include("Issue758helperfile.jl")
+            end
+            """)
+        yry()
+        @test Issue758.f() == 1
+        rm_precompile("Issue758")
+
         pop!(LOAD_PATH)
     end
 


### PR DESCRIPTION
Setting `pc=nothing` is premature at this stage.
Together with https://github.com/JuliaDebug/LoweredCodeUtils.jl/pull/91, this fixes #758.

This will fail the new test because I haven't tagged a new release of LoweredCodeUtils. However, that's a bit unsafe to release without this change---it will trigger this bug more often than it used to. So I'll let this test fail, merge & make a new Revise release, and then release LoweredCodeUtils.