### PR TITLE
Prevent double-execution of thunks

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -448,6 +448,7 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, fra
                 end
             else
                 # An Expr we don't want to intercept
+                frame.pc = pc
                 pc = step_expr!(recurse, frame, stmt, true)
             end
         else


### PR DESCRIPTION
An error in `sigtest` was triggered by an anonymous-function thunk being executed twice ("invalid redefinition..."). This ensures synchrony between the local variable `pc` and `frame.pc` and prevents double-execution.