### PR TITLE
Reduced reassignment to global consts

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -39,8 +39,7 @@ function _precompile_()
     @warnpcfail precompile(Tuple{typeof(setindex!), Dict{String,WatchList}, WatchList, String})
 
     MI = CodeTrackingMethodInfo
-    @warnpcfail precompile(Tuple{typeof(minimal_evaluation!), MI, Core.CodeInfo, Symbol})
-    @warnpcfail precompile(Tuple{typeof(minimal_evaluation!), Any, MI, Core.CodeInfo, Symbol})
+    @warnpcfail precompile(Tuple{typeof(minimal_evaluation!), Any, MI, Module, Core.CodeInfo, Symbol})
     @warnpcfail precompile(Tuple{typeof(methods_by_execution!), Any, MI, DocExprs, Module, Expr})
     @warnpcfail precompile(Tuple{typeof(methods_by_execution!), Any, MI, DocExprs, JuliaInterpreter.Frame, Vector{Bool}})
     @warnpcfail precompile(Tuple{typeof(Core.kwfunc(methods_by_execution!)),

--- a/test/backedges.jl
+++ b/test/backedges.jl
@@ -1,4 +1,5 @@
-using Revise, JuliaInterpreter, Test
+using Revise, Test
+using Revise.JuliaInterpreter: Frame
 using Base.Meta: isexpr
 
 isdefined(@__MODULE__, :do_test) || include("common.jl")

--- a/test/backedges.jl
+++ b/test/backedges.jl
@@ -1,4 +1,4 @@
-using Revise, Test
+using Revise, JuliaInterpreter, Test
 using Base.Meta: isexpr
 
 isdefined(@__MODULE__, :do_test) || include("common.jl")
@@ -9,12 +9,13 @@ flag = false    # this needs to be defined for the conditional part to work
 end
 
 do_test("Backedges") && @testset "Backedges" begin
-    src = Meta.lower(Base, :(max_values(T::Union{map(X -> Type{X}, BitIntegerSmall_types)...}) = 1 << (8*sizeof(T)))).args[1]
+    frame = Frame(Base, :(max_values(T::Union{map(X -> Type{X}, BitIntegerSmall_types)...}) = 1 << (8*sizeof(T))))
+    src = frame.framecode.src
     # Find the inner struct def for the anonymous function
     idtype = findall(stmt->isexpr(stmt, :thunk) && isa(stmt.args[1], Core.CodeInfo), src.code)[end]
     src2 = src.code[idtype].args[1]
     methodinfo = Revise.MethodInfo()
-    isrequired = Revise.minimal_evaluation!(methodinfo, src, :sigs)[1]
+    isrequired = Revise.minimal_evaluation!(methodinfo, frame, :sigs)[1]
     @test sum(isrequired) == length(src.code)-2  # skips the `return` at the end
 
     src = """


### PR DESCRIPTION
When a single top-level expression contains both `const` definitions and methods that use those consts, the `add_named_dependencies!` step of `lines_required!` can induce a dependency on the statement assigning to the `const`. This is problematic when your only goal is to parse signatures, as it can trigger overwriting of `consts` that may be needed.

Fixes #789