### PR TITLE
Let Base handle parsing errors on Julia 1.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         version:
           - '1.6'     # LTS
+          - '1.9'     # parsing errors branch on 1.10, so test the last pre-1.10 version
           - '1'       # current stable
         os:
           - ubuntu-latest

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -40,6 +40,9 @@ function parse_source!(mod_exprs_sigs::ModuleExprsSigs, src::AbstractString, fil
     ex = Base.parse_input_line(src; filename=filename)
     ex === nothing && return mod_exprs_sigs
     if isexpr(ex, :error) || isexpr(ex, :incomplete)
+        if Base.VERSION >= v"1.10"
+            eval(ex)   # this will throw, so the statements below will not execute
+        end
         prevex, pos = first_bad_position(src)
         ln = count(isequal('\n'), SubString(src, 1, min(pos, length(src)))) + 1
         throw(LoadError(filename, ln, ex.args[1]))
@@ -79,13 +82,15 @@ function process_source!(mod_exprs_sigs::ModuleExprsSigs, ex, filename, mod::Mod
     return mod_exprs_sigs
 end
 
-function first_bad_position(str)
-    ex, pos, n = nothing, 1, length(str)
-    while pos < n
-        ex, pos = Meta.parse(str, pos; greedy=true, raise=false)
-        if isexpr(ex, :error) || isexpr(ex, :incomplete)
-            return ex, pos
+if Base.VERSION < v"1.10"
+    function first_bad_position(str)
+        ex, pos, n = nothing, 1, length(str)
+        while pos < n
+            ex, pos = Meta.parse(str, pos; greedy=true, raise=false)
+            if isexpr(ex, :error) || isexpr(ex, :incomplete)
+                return ex, pos
+            end
         end
+        error("expected an error, finished without one")
     end
-    error("expected an error, finished without one")
 end


### PR DESCRIPTION
Now that sufficient line information is incorporated into the
error-expressions returned by parsing, we can eliminate our
old hack to try to find some identifying information.

(Thanks, @c42f!)

Fixes #655