### PR TITLE
Groundwork for a fix for #718

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -62,7 +62,7 @@ function categorize_stmt(@nospecialize(stmt))
     return ismeth, haseval, isinclude, isnamespace, istoplevel
 end
 # Check for thunks that define functions (fixes #792)
-function defines_function(ci)
+function defines_function(@nospecialize(ci))
     isa(ci, CodeInfo) || return false
     if length(ci.code) == 1
         stmt = ci.code[1]

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -72,7 +72,7 @@ function process_source!(mod_exprs_sigs::ModuleExprsSigs, ex, filename, mod::Mod
                 if isa(a, LineNumberNode)
                     lnn = a
                 else
-                    pushex!(exprs_sigs, Expr(:block, lnn, a))
+                    pushex!(exprs_sigs, Expr(:toplevel, lnn, a))
                 end
             end
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1635,6 +1635,45 @@ const issue639report = []
         pop!(LOAD_PATH)
     end
 
+    do_test("Submodule in same file (#718)") && @testset "Submodule in same file (#718)" begin
+        testdir = newtestdir()
+        dn = joinpath(testdir, "TestPkg718", "src")
+        mkpath(dn)
+        write(joinpath(dn, "TestPkg718.jl"), """
+            module TestPkg718
+
+            module TestModule718
+                export _VARIABLE_UNASSIGNED
+                global _VARIABLE_UNASSIGNED = -84.0
+            end
+
+            using .TestModule718
+
+            end
+            """)
+        sleep(mtimedelay)
+        @eval using TestPkg718
+        sleep(mtimedelay)
+        @test TestPkg718._VARIABLE_UNASSIGNED == -84.0
+        write(joinpath(dn, "TestPkg718.jl"), """
+            module TestPkg718
+
+            module TestModule718
+                export _VARIABLE_UNASSIGNED
+                global _VARIABLE_UNASSIGNED = -83.0
+            end
+
+            using .TestModule718
+
+            end
+            """)
+        yry()
+        @test TestPkg718._VARIABLE_UNASSIGNED == -83.0
+
+        rm_precompile("TestPkg718")
+        pop!(LOAD_PATH)
+    end
+
     do_test("Timing (issue #341)") && @testset "Timing (issue #341)" begin
         testdir = newtestdir()
         dn = joinpath(testdir, "Timing", "src")


### PR DESCRIPTION
This adds a test for #718, and makes a change to Revise's parsing that will be necessary for the true fix, which will happen in JuliaInterpreter. Unfortunately this needs to be merged and tagged before that is safe to release. So the new test will fail, but I think we can live with that transiently.