### PR TITLE
Update limitations.md with REPL session

### DIFF
--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -77,6 +77,8 @@ julia> processFoo(FooStruct(3.5))
 [ Info: 3.5
 ```
 
+Here, note that we made two changes: we updated the "version number" of FooStruct when we changed something about its fields, and we also re-assigned FooStruct to alias the new version. We did not change the definition of any methods that have been typed AbstractFooStruct.
+
 This works as long as the new type name doesn't conflict with an existing name; within a session you need to change the name each time you change the definition.
 
 Once your development has converged on a solution, it's best to switch to the "permanent" name: in the example above, `FooStruct` is a non-constant global variable, and if used internally in a function there will be consequent performance penalties. Switching to the permanent name will force you to restart your session.

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -8,7 +8,7 @@ There are some kinds of changes that Revise (or often, Julia itself) cannot inco
 
 These kinds of changes require that you restart your Julia session.
 
-During early stages of development, it's quite common to want to change type definitions. You can work around Julia's/Revise's limitations by temporary renaming:
+During early stages of development, it's quite common to want to change type definitions. You can work around Julia's/Revise's limitations by temporary renaming. We'll illustrate this below, using `write` to be explicit about when updates to the file happen. But in ordinary usage, these are changes you'd likely make with your editor.
 
 ```julia
 julia> using Pkg, Revise

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -59,7 +59,7 @@ julia> write("src/MyPkg.jl","""
 
        abstract type AbstractFooStruct end
        struct FooStruct2 <: AbstractFooStruct # change version nuumber
-           bar::Float64 # changed type of the field
+           bar::Float64 # change type of the field
        end
        FooStruct = FooStruct2 # update alias reference
        function processFoo(foo::AbstractFooStruct)


### PR DESCRIPTION
Fix https://github.com/timholy/Revise.jl/issues/797

See Discourse thread:
https://discourse.julialang.org/t/revise-not-updating-functions/108391/12

Basically we replace the initial struct changing session with the following.
1. Use an abstract parent type for all struct versions and method definitions
2. Provide a full blown REPL session and example showing all steps
3. Explicitly use `write` to demonstrate editing steps.
4. Follow through with a Julia session restart
5. Demonstrate `isconst` on `FooStruct`.