### PR TITLE
fix codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,5 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         file: lcov.info
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true


### PR DESCRIPTION
https://github.com/timholy/Revise.jl/pull/800 broke codecov (see https://discourse.julialang.org/t/psa-new-version-of-codecov-action-requires-additional-setup/109857). To fix it @timholy you need to add a token named CODECOV_TOKEN to the repo.