### PR TITLE
Explicitly check if manifest paths are Strings

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -408,7 +408,7 @@ function manifest_paths!(pkgpaths::Dict, manifest_file::String)
         for entry in entries
             id = PkgId(UUID(entry["uuid"]::String), name)
             path = Base.explicit_manifest_entry_path(manifest_file, id, entry)
-            if path !== nothing
+            if path isa String
                 if isfile(path)
                     # Workaround for #802
                     path = dirname(dirname(path))


### PR DESCRIPTION
`Base.explicit_manifest_entry_path()` can return either a String, `missing`, or `nothing`, but previously `manifest_paths!()` was assuming the result was either a String or `nothing`.

Here's the stacktrace from when it failed for me:
```julia
julia> ┌ Error: Error watching manifest                                                                                                                                                                                                        
│   exception =                                                                                                                                                                                                                                
│    MethodError: no method matching joinpath(::Missing)                                                                                                                                                                                       
│                                                                                                                                                                                                                                              
│    Closest candidates are:                                                                                                                                                                                                                   
│      joinpath(::AbstractString...)                                                                                                                                                                                                           
│       @ Base path.jl:327
│      joinpath(::Union{Tuple, AbstractVector})
│       @ Base path.jl:305
│    
│    Stacktrace:
│     [1] stat(path::Missing)
│       @ Base.Filesystem ./stat.jl:193
│     [2] isfile(path::Missing)
│       @ Base.Filesystem ./stat.jl:461
│     [3] manifest_paths!(pkgpaths::Dict{Base.PkgId, String}, manifest_file::String)
│       @ Revise ~/.julia/packages/Revise/bAgL0/src/pkgs.jl:412
└ @ Revise ~/.julia/packages/Revise/bAgL0/src/pkgs.jl:493
```