### PR TITLE
Add test for Overlay Method Tables

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3762,6 +3762,36 @@ do_test("includet with mod arg (issue #689)") && @testset "includet with mod arg
     @test Driver.Codes.Common.foo == 2
 end
 
+do_test("Overlay Method Tables") && @testset "Overlay Method Tables" begin
+    # Issue #646
+    testdir = newtestdir()
+    file = joinpath(testdir, "overlaymt.jl")
+    write(file, """
+        Base.Experimental.@MethodTable(method_table)
+
+        foo_mt() = 1
+        Base.Experimental.@overlay Main.method_table foo_mt() = 2
+        """)
+    sleep(mtimedelay)
+    includet(file)
+    @test foo_mt() == 1
+    methods = Base._methods_by_ftype(Tuple{typeof(foo_mt)}, method_table, 1, Base.get_world_counter())
+    ci = Base.uncompressed_ir(methods[1].method)
+    @test ci.code[end] == Core.ReturnNode(2)
+    sleep(mtimedelay)
+    write(file, """
+        Base.Experimental.@MethodTable(method_table)
+
+        foo_mt() = 1
+        Base.Experimental.@overlay Main.method_table foo_mt() = 3
+        """)
+    sleep(mtimedelay)
+    @test foo_mt() == 1
+    methods = Base._methods_by_ftype(Tuple{typeof(foo_mt)}, method_table, 1, Base.get_world_counter())
+    ci = Base.uncompressed_ir(methods[1].method)
+    @test_broken ci.code[end] == Core.ReturnNode(3)
+end
+
 do_test("misc - coverage") && @testset "misc - coverage" begin
     @test Revise.ReviseEvalException("undef", UndefVarError(:foo)).loc isa String
     @test !Revise.throwto_repl(UndefVarError(:foo))


### PR DESCRIPTION
Adds the test for #646 (still broken).

Of note is that in the REPL this works fine:

```
julia> Base.Experimental.@MethodTable(method_table)
# 0 methods for callable object

julia> foo() = 1
foo (generic function with 1 method)

julia> Base.Experimental.@overlay Main.method_table foo() = 2

julia> methods = Base._methods_by_ftype(Tuple{typeof(foo)}, method_table, 1, Base.get_world_counter())
1-element Vector{Any}:
 Core.MethodMatch(Tuple{typeof(foo)}, svec(), foo() @ Main REPL[3]:1, true)

julia> display(Base.uncompressed_ir(methods[1].method))
CodeInfo(
1 ─     return 2
)

julia> Base.Experimental.@overlay Main.method_table foo() = 3

julia> methods = Base._methods_by_ftype(Tuple{typeof(foo)}, method_table, 1, Base.get_world_counter())
1-element Vector{Any}:
 Core.MethodMatch(Tuple{typeof(foo)}, svec(), foo() @ Main REPL[6]:1, true)

julia> display(Base.uncompressed_ir(methods[1].method))
CodeInfo(
1 ─     return 3
)
```
