### PR TITLE
Fix tests broken on 1.11

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1095,7 +1095,7 @@ const issue639report = []
         @test get_docstring(ds) == "f"
         @test ChangeDocstring.g() == 1
         ds = @doc(ChangeDocstring.g)
-        @test get_docstring(ds) == "No documentation found."
+        @test get_docstring(ds) in ("No documentation found.", "No documentation found for private symbol.")
         # Ordinary route
         write(joinpath(dn, "ChangeDocstring.jl"), """
             module ChangeDocstring
@@ -1135,7 +1135,7 @@ const issue639report = []
         sleep(mtimedelay)
         @test FirstDocstring.g() == 1
         ds = @doc(FirstDocstring.g)
-        @test get_docstring(ds) == "No documentation found."
+        @test get_docstring(ds) in ("No documentation found.", "No documentation found for private symbol.")
         write(joinpath(dn, "FirstDocstring.jl"), """
             module FirstDocstring
             "g" g() = 1


### PR DESCRIPTION
Almost all the real work of updating to 1.11 was in https://github.com/JuliaDebug/LoweredCodeUtils.jl/pull/108 and https://github.com/JuliaDebug/LoweredCodeUtils.jl/pull/109. But a warning now prints with different text, so accept both variants.