### PR TITLE
remove Pkg as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
@@ -34,6 +33,7 @@ IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 RoundingIntegers = "d5f540fe-1c90-5db3-b776-2e2f362d9394"
@@ -41,4 +41,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [targets]
-test = ["CatIndices", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]
+test = ["CatIndices", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Pkg", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1,6 +1,6 @@
 @eval Base.Experimental.@optlevel 1
 
-using FileWatching, REPL, Distributed, UUIDs, Pkg
+using FileWatching, REPL, Distributed, UUIDs
 import LibGit2
 using Base: PkgId
 using Base.Meta: isexpr
@@ -1307,11 +1307,6 @@ function __init__()
     # Set the lookup callbacks
     CodeTracking.method_lookup_callback[] = get_def
     CodeTracking.expressions_callback[] = get_expressions
-
-    # Register the active-project watcher
-    if isdefined(Pkg.Types, :active_project_watcher_thunks)
-        push!(Pkg.Types.active_project_watcher_thunks, active_project_watcher)
-    end
 
     # Watch the manifest file for changes
     mfile = manifest_file()


### PR DESCRIPTION
The only use (`Pkg.Types.active_project_watcher_thunks`) never existed.

Ref https://github.com/JuliaLang/Pkg.jl/pull/2744.