### PR TITLE
Extend loaded_precompiles fix to 1.11

### DIFF
--- a/src/loading.jl
+++ b/src/loading.jl
@@ -43,7 +43,7 @@ function parse_pkg_files(id::PkgId)
             @assert reqs !== nothing
             pkgdata.requirements = reqs
             for chi in includes
-                if VERSION >= v"1.12.0-DEV.764" && haskey(Base.loaded_precompiles, id => buildid)
+                if isdefined(Base, :loaded_precompiles) && haskey(Base.loaded_precompiles, id => buildid)
                     mod = Base.loaded_precompiles[id => buildid]
                 else
                     mod = Base.root_module(id)


### PR DESCRIPTION
The base commit got backported in rc. Should fix #832.