### PR TITLE
recheck file exists on deletions to deal with race condition with editor saving

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -682,11 +682,11 @@ function handle_deletions(pkgdata, file)
             filecontents = try_read(filename)
         end
     end
-    mexsnew = filecontents ? parse_source(filep, topmod, filecontents) : ModuleExprsSigs(topmod)
+    mexsnew = (filecontents !== nothing) ? parse_source(filep, topmod, filecontents) : ModuleExprsSigs(topmod)
     if mexsnew !== nothing
         delete_missing!(mexsold, mexsnew)
     end
-    if !filecontents
+    if filecontents === nothing
         @warn("$filep no longer exists, deleted all methods")
         deleteat!(pkgdata.fileinfos, idx)
         deleteat!(pkgdata.info.files, idx)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -660,6 +660,16 @@ function handle_deletions(pkgdata, file)
     end
     topmod = first(keys(mexsold))
     fileok = file_exists(String(filep)::String)
+    if !fileok
+        # necessary due to some editors (e.g. vim) doing a write process of: 1. rename file to backup, 2. write & fsync new file, 3. remove backup
+        sleep(0.1)
+        bak_exists = file_exists(String(filep) * "~") # vim backup file
+        fileok = file_exists(String(filep)::String)
+        if !fileok && bak_exists
+            sleep(0.5)
+            fileok = file_exists(String(filep)::String)
+        end
+    end
     mexsnew = fileok ? parse_source(filep, topmod) : ModuleExprsSigs(topmod)
     if mexsnew !== nothing
         delete_missing!(mexsold, mexsnew)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -9,6 +9,8 @@ If parsing `filename` fails, `nothing` is returned.
 """
 parse_source(filename, mod::Module; kwargs...) =
     parse_source!(ModuleExprsSigs(mod), filename, mod; kwargs...)
+parse_source(filename, mod::Module, src::AbstractString; kwargs...) =
+    parse_source!(ModuleExprsSigs(mod), src, filename, mod; kwargs...)
 
 """
     parse_source!(mexs::ModuleExprsSigs, filename, mod::Module)


### PR DESCRIPTION
This is somewhat hacky & only mostly works for me, it's still possible to trigger a failure with entr + repeated saving. I guess it'd be better to keep tracking deleted files in case they come back?