### PR TITLE
Add `force=true` kwarg to `revise(mod::Module)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.5.18"
+version = "3.6.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"


### PR DESCRIPTION
Fixes #839
Fixes #842

@staticfloat and/or @danielalcalde can you test whether this works for you? The behavior I think you're wanting is now `revise(mod; force=false)`.