### PR TITLE
Skip a problematic test on 1.6

### DIFF
--- a/test/sigtest.jl
+++ b/test/sigtest.jl
@@ -105,6 +105,7 @@ end
 basefiles = Set{String}()
 @time for (i, (mod, file)) in enumerate(Base._included_files)
     (endswith(file, "sysimg.jl") || endswith(file, "Base.jl")) && continue
+    Base.VERSION < v"1.7" && Sys.iswindows() && endswith(file, "RNGs.jl") && continue  # invalid redefinition of constant RandomDevice
     file = Revise.fixpath(file)
     push!(basefiles, reljpath(file))
     mexs = Revise.parse_source(file, mod)


### PR DESCRIPTION
On Windows, Julia 1.6, the signatures test fails with

```
Base signatures: Error During Test at D:\a\Revise.jl\Revise.jl\test\runtests.jl:3851
  Got exception outside of a @test
  LoadError: invalid redefinition of constant RandomDevice
  Stacktrace:
   [1] do_assignment!(frame::Frame, lhs::Any, rhs::Any)
     @ JuliaInterpreter C:\Users\runneradmin\.julia\packages\JuliaInterpreter\cxlKp\src\interpret.jl:352
  in expression starting at D:\a\Revise.jl\Revise.jl\test\sigtest.jl:106
```

Since this only happens on a soon-to-be-unsupported Julia release, let's just ignore the test.