### PR TITLE
Fix `juliadir` test on 1.12

### DIFF
--- a/test/juliadir.jl
+++ b/test/juliadir.jl
@@ -1,6 +1,6 @@
 using Revise, InteractiveUtils, Test
 
-@eval Revise juliadir = ARGS[1]
+@eval Revise const juliadir = ARGS[1]
 
 @test Revise.juliadir != Revise.basebuilddir
 @test Revise.juliadir != Revise.fallback_juliadir()


### PR DESCRIPTION
Overriding constants is technically forbidden, but allowed for interactive convenience. 1.12 tightened the rules and requires the `const` keyword for const redefine.