### PR TITLE
Adjust to upcoming change in world age semantics

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -24,6 +24,12 @@ else
 end
 
 yry() = (sleep(mtimedelay); revise(); sleep(mtimedelay))
+macro yry()
+    esc(quote
+        yry()
+        @latestworld
+    end)
+end
 
 function collectexprs(rex::Revise.RelocatableExpr)
     items = []


### PR DESCRIPTION
Upcoming base PR https://github.com/JuliaLang/julia/pull/56509 makes precise when exactly world age increments automatically at top-level. Packages are mostly not supposed to notice, but of course Revise is a bit patholgical in that it does basically expect asynchronous changes to have top level effects. After that PR, that requires an explicit opt-in. This PR makes the appropriate adjustments to the tests.