### PR TITLE
Fix "juliadir" test

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -178,13 +178,21 @@ function fallback_juliadir()
     normpath(candidate)
 end
 
+if VERSION >= v"1.8"
+Core.eval(@__MODULE__, :(global juliadir::String))
+else
+Core.eval(@__MODULE__, :(global juliadir  #= ::Any =#; nothing))
+end
+
 """
     Revise.juliadir
 
 Constant specifying full path to julia top-level source directory.
 This should be reliable even for local builds, cross-builds, and binary installs.
 """
-const juliadir = normpath(
+juliadir
+
+juliadir = normpath(
     if isdir(joinpath(basebuilddir, "base"))
         basebuilddir
     else

--- a/test/juliadir.jl
+++ b/test/juliadir.jl
@@ -1,11 +1,12 @@
 using Revise, InteractiveUtils, Test
 
-@eval Revise const juliadir = ARGS[1]
+@eval Revise juliadir = ARGS[1]
 
 @test Revise.juliadir != Revise.basebuilddir
 @test Revise.juliadir != Revise.fallback_juliadir()
 
-@show Revise.juliadir
-
 # https://github.com/timholy/Revise.jl/issues/697
-@test Revise.definition(@which(Float32(π))) isa Expr
+let def = Revise.definition(@which(Float32(π)))
+    @test isa(def, Expr)
+    @test Meta.isexpr(def, :macrocall)
+end


### PR DESCRIPTION
The test was ineffective because it was relying on binding replacement, which is undefined behavior on all versions of Julia (ironically it will not be in 1.12, but that change is not done yet). As a result, the redefinition of `juliadir` was not taking effect and the test was simply running with the old juliadir. Change `juliadir` to a (typed) global and update the test to make sure it's actually working.