### PR TITLE
Adjust to https://github.com/JuliaLang/julia/pull/56878

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1207,8 +1207,13 @@ function update_stacktrace_lineno!(trace)
             t, nrep = t
         end
         t = t::StackTraces.StackFrame
-        if t.linfo isa Core.MethodInstance
-            m = t.linfo.def
+        linfo = t.linfo
+        if linfo isa Core.CodeInstance
+            linfo = linfo.def
+            (isdefined(Core, :ABIOverride) && isa(linfo, Core.ABIOverride)) && (linfo = linfo.def)
+        end
+        if linfo isa Core.MethodInstance
+            m = linfo.def
             sigt = m.sig
             # Why not just call `whereis`? Because that forces tracking. This is being
             # clever by recognizing that these entries exist only if there have been updates.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2389,7 +2389,8 @@ end
         @test isequal(ex, Revise.RelocatableExpr(:(f(v::AbstractVector{<:Integer}) = 3)))
 
         st = try GetDef.bar(5.0) catch err stacktrace(catch_backtrace()) end
-        m = st[2].linfo.def
+        linfo = st[2].linfo
+        m = isa(linfo, Core.CodeInstance) ? linfo.def.def : linfo.def
         def = Revise.RelocatableExpr(definition(m))
         @test def == Revise.RelocatableExpr(:(foo(x::T, y::Integer=1; kw1="hello", kwargs...) where T<:Number = error("stop")))
 


### PR DESCRIPTION
The `linfo` field of `StackFrame` can now be a `CodeInstance`.