### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     tags: '*'
 jobs:
   test:
-    name: Install & test Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Test Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow_failure }}
     strategy:
@@ -21,20 +21,16 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
         allow_failure: [false]
         include:
           - version: 'nightly'
             os: ubuntu-latest
-            arch: x64
             allow_failure: true
     steps:
     - uses: actions/checkout@v4
     - uses: julia-actions/setup-julia@latest
       with:
         version: ${{ matrix.version }}
-        arch: ${{ matrix.arch }}
         show-versioninfo: ${{ matrix.version == 'nightly' }}
     - uses: julia-actions/cache@v2
     - uses: julia-actions/julia-buildpkg@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,6 @@ jobs:
     - uses: julia-actions/julia-processcoverage@latest
     - uses: codecov/codecov-action@v5
       with:
-        file: lcov.info
+        files: lcov.info
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - master
     tags: '*'
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     name: Test Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}


### PR DESCRIPTION
- Use default arch when installing via setup-julia, given forcing x64 on macos aarch64 runners means it uses rosetta
- update a deprecated arg
- add standard perms for julia-actions/cache https://github.com/julia-actions/cache/tree/v2.0.7?tab=readme-ov-file#usage