### PR TITLE
Make sigtest more robust

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -207,7 +207,7 @@ function add_require(sourcefile::String, modcaller::Module, idmod::String, modna
         fi = pkgdata.fileinfos[fileidx]
         # Tag the expr to ensure it is unique
         expr = Expr(:block, copy(expr))
-        push!(expr.args, :(__pkguuid__ = $idmod))
+        push!(expr.args, :(const __pkguuid__ = $idmod))
         # Add the expression to the fileinfo
         complex = true     # is this too complex to delay?
         if !fi.extracted[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3942,7 +3942,7 @@ include("non_jl_test.jl")
 do_test("Base signatures") && @testset "Base signatures" begin
     println("beginning signatures tests")
     # Using the extensive repository of code in Base as a testbed
-    include("sigtest.jl")
+    @test success(pipeline(`$(Base.julia_cmd()) sigtest.jl`, stderr=stderr))
 end
 
 # Run this test in a separate julia process, since it messes with projects, and we don't want to have to

--- a/test/switch_version.jl
+++ b/test/switch_version.jl
@@ -22,7 +22,8 @@ mktempdir() do thisdir
     # Back to toplevel
     @eval begin
         using PkgChange
-        @test_throws UndefVarError somemethod()   # not present in v1
+        @latestworld
+        @test_throws UndefVarError PkgChange.somemethod()   # not present in v1
         # From a different process, switch the active version of ExponentialUtilities
         v2_cmd = """using Pkg; Pkg.activate("."); Pkg.develop(path = joinpath("$(escape_string(dirname(@__FILE__)))", "pkgs", "PkgChange_v2"))"""
         t = @async run(pipeline(Cmd(`$(Base.julia_cmd()) -e $v2_cmd`; dir=$thisdir); stderr, stdout))
@@ -30,7 +31,7 @@ mktempdir() do thisdir
         wait(Revise.revision_event)
         revise()
         @latestworld
-        @test somemethod() === 1   # present in v2
+        @test PkgChange.somemethod() === 1   # present in v2
         # ...and then switch back (check that it's bidirectional and also to reset state)
         v1_cmd = """using Pkg; Pkg.activate("."); Pkg.develop(path = joinpath("$(escape_string(dirname(@__FILE__)))", "pkgs", "PkgChange_v1"))"""
         t = @async run(pipeline(Cmd(`$(Base.julia_cmd()) -e $v1_cmd`; dir=$thisdir); stderr, stdout))
@@ -38,6 +39,6 @@ mktempdir() do thisdir
         wait(Revise.revision_event)
         revise()
         @latestworld
-        @test_throws MethodError somemethod() # not present in v1
+        @test_throws MethodError PkgChange.somemethod() # not present in v1
     end
 end


### PR DESCRIPTION
With struct replacement enabled, the state of the process after the sigtest is somewhat problematic (e.g. references to IOContext will get the new world). Move it to a separate process and try to avoid world age increments so that this doesn't cause problems.