### PR TITLE
remove `CodeTracking.line_is_decl` usages

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -35,7 +35,7 @@ module Revise
 
 using OrderedCollections, CodeTracking, JuliaInterpreter, LoweredCodeUtils
 
-using CodeTracking: PkgFiles, basedir, srcfiles, line_is_decl, basepath
+using CodeTracking: PkgFiles, basedir, srcfiles, basepath
 using JuliaInterpreter: whichtt, is_doc_expr, step_expr!, finish_and_return!, get_return,
                         @lookup, moduleof, scopeof, pc_expr, is_quotenode_egal,
                         linetable, codelocs, LineTypes, isassign, isidentical

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -35,7 +35,7 @@ module Revise
 
 using OrderedCollections, CodeTracking, JuliaInterpreter, LoweredCodeUtils
 
-using CodeTracking: PkgFiles, basedir, srcfiles, basepath
+using CodeTracking: PkgFiles, basedir, srcfiles, line_is_decl, basepath
 using JuliaInterpreter: whichtt, is_doc_expr, step_expr!, finish_and_return!, get_return,
                         @lookup, moduleof, scopeof, pc_expr, is_quotenode_egal,
                         linetable, codelocs, LineTypes, isassign, isidentical

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -374,10 +374,12 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, fra
                     # Get the line number from the body
                     stmt3 = pc_expr(frame, pc3)::Expr
                     lnn = nothing
-                    sigcode = @lookup(frame, stmt3.args[2])::Core.SimpleVector
-                    lnn = sigcode[end]
-                    if !isa(lnn, LineNumberNode)
-                        lnn = nothing
+                    if line_is_decl
+                        sigcode = @lookup(frame, stmt3.args[2])::Core.SimpleVector
+                        lnn = sigcode[end]
+                        if !isa(lnn, LineNumberNode)
+                            lnn = nothing
+                        end
                     end
                     if lnn === nothing
                         bodycode = stmt3.args[end]

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -374,12 +374,10 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, fra
                     # Get the line number from the body
                     stmt3 = pc_expr(frame, pc3)::Expr
                     lnn = nothing
-                    if line_is_decl
-                        sigcode = @lookup(frame, stmt3.args[2])::Core.SimpleVector
-                        lnn = sigcode[end]
-                        if !isa(lnn, LineNumberNode)
-                            lnn = nothing
-                        end
+                    sigcode = @lookup(frame, stmt3.args[2])::Core.SimpleVector
+                    lnn = sigcode[end]
+                    if !isa(lnn, LineNumberNode)
+                        lnn = nothing
                     end
                     if lnn === nothing
                         bodycode = stmt3.args[end]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,8 @@ using Revise.OrderedCollections: OrderedSet
 using Test: collect_test_logs
 using Base.CoreLogging: Debug,Info
 
+using Revise.CodeTracking: line_is_decl
+
 # In addition to using this for the "More arg-modifying macros" test below,
 # this package is used on CI to test what happens when you have multiple
 # *.ji files for the package.
@@ -1587,7 +1589,8 @@ end
         io = IOBuffer()
         if isdefined(Base, :methodloc_callback)
             print(io, methods(triggered))
-            @test occursin(filename * ":1", String(take!(io)))
+            mline = line_is_decl ? 1 : 2
+            @test occursin(filename * ":$mline", String(take!(io)))
         end
         write(filename, """
             # A comment to change the line numbers
@@ -1622,7 +1625,8 @@ end
         @test occursin(targetstr, String(take!(io)))
         if isdefined(Base, :methodloc_callback)
             print(io, methods(triggered))
-            @test occursin(basename(filename * ":2"), String(take!(io)))
+            mline = line_is_decl ? 2 : 3
+            @test occursin(basename(filename * ":$mline"), String(take!(io)))
         end
 
         push!(to_remove, filename)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,6 @@ using Revise.OrderedCollections: OrderedSet
 using Test: collect_test_logs
 using Base.CoreLogging: Debug,Info
 
-using Revise.CodeTracking: line_is_decl
-
 # In addition to using this for the "More arg-modifying macros" test below,
 # this package is used on CI to test what happens when you have multiple
 # *.ji files for the package.
@@ -1589,8 +1587,7 @@ end
         io = IOBuffer()
         if isdefined(Base, :methodloc_callback)
             print(io, methods(triggered))
-            mline = line_is_decl ? 1 : 2
-            @test occursin(filename * ":$mline", String(take!(io)))
+            @test occursin(filename * ":1", String(take!(io)))
         end
         write(filename, """
             # A comment to change the line numbers
@@ -1625,8 +1622,7 @@ end
         @test occursin(targetstr, String(take!(io)))
         if isdefined(Base, :methodloc_callback)
             print(io, methods(triggered))
-            mline = line_is_decl ? 2 : 3
-            @test occursin(basename(filename * ":$mline"), String(take!(io)))
+            @test occursin(basename(filename * ":2"), String(take!(io)))
         end
 
         push!(to_remove, filename)


### PR DESCRIPTION
This variable is always `true` on recent versions