### PR TITLE
Get rid of two precompiles from trivial Julia execution

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -73,6 +73,8 @@ function _precompile_()
     if isdefined(Revise, :filter_valid_cachefiles)
         @warnpcfail precompile(Tuple{typeof(filter_valid_cachefiles), String, Vector{String}})
     end
+    @warnpcfail precompile(Tuple{typeof(Revise.iswritable), String})
+    @warnpcfail precompile(Tuple{typeof(Revise.active_repl_backend_available)})
     @warnpcfail precompile(Tuple{typeof(pkg_fileinfo), PkgId})
     @warnpcfail precompile(Tuple{typeof(push!), WatchList, Pair{String,PkgId}})
     @warnpcfail precompile(Tuple{typeof(pushex!), ExprsSigs, Expr})


### PR DESCRIPTION
With only using Revise in the startup.jl and this commit, there are two precompiles less with
`julia --trace-compile=stderr -ie "exit()"`

This partially addresses #900.