### PR TITLE
remove no-longer necessary `moduledeps` data structure

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -22,7 +22,6 @@ const MethodInfo = IdDict{Type,LineNumberNode}
 add_signature!(methodinfo, @nospecialize(sig), ln) = push!(methodinfo, sig=>ln)
 push_expr!(methodinfo, mod::Module, ex::Expr) = methodinfo
 pop_expr!(methodinfo) = methodinfo
-add_dependencies!(methodinfo, be::CodeEdges, src, isrequired) = methodinfo
 add_includes!(methodinfo, mod::Module, filename) = methodinfo
 
 function is_some_include(@nospecialize(f))
@@ -53,7 +52,6 @@ function is_defaultctors(@nospecialize(f))
     end
     return false
 end
-
 
 # This is not generally used, see `is_method_or_eval` instead
 function hastrackedexpr(@nospecialize(stmt), code)
@@ -186,7 +184,6 @@ function minimal_evaluation!(@nospecialize(predicate), methodinfo, mod::Module, 
     lines_required!(isrequired, src, edges;)
                     # norequire=mode===:sigs ? LoweredCodeUtils.exclude_named_typedefs(src, edges) : ())
     # LoweredCodeUtils.print_with_code(stdout, src, isrequired)
-    add_dependencies!(methodinfo, edges, src, isrequired)
     return isrequired, evalassign
 end
 @noinline minimal_evaluation!(@nospecialize(predicate), methodinfo, frame::Frame, mode::Symbol) =

--- a/src/types.jl
+++ b/src/types.jl
@@ -17,8 +17,6 @@ end
 
 const DocExprs = Dict{Module,Vector{Expr}}
 const ExprsSigs = OrderedDict{RelocatableExpr,Union{Nothing,Vector{Any}}}
-const DepDictVals = Tuple{Module,RelocatableExpr}
-const DepDict = Dict{Symbol,Set{DepDictVals}}
 
 function Base.show(io::IO, exsigs::ExprsSigs)
     compact = get(io, :compact, false)

--- a/test/backedges.jl
+++ b/test/backedges.jl
@@ -42,12 +42,9 @@ do_test("Backedges") && @testset "Backedges" begin
     end
     """
     mexs = Revise.parse_source!(Revise.ModuleExprsSigs(BackEdgesTest), src, "backedges_test.jl", BackEdgesTest)
-    Revise.moduledeps[BackEdgesTest] = Revise.DepDict()
     Revise.instantiate_sigs!(mexs)
     @test isempty(methods(BackEdgesTest.getdiameter))
     @test !isdefined(BackEdgesTest, :planetdiameters)
-    @test length(Revise.moduledeps[BackEdgesTest]) == 1
-    @test Revise.moduledeps[BackEdgesTest][:flag] == Set([(BackEdgesTest, first(Iterators.drop(mexs[BackEdgesTest], 1))[1])])
 
     # issue #399
     src = """


### PR DESCRIPTION
This data structure was added in 32f8727b4859f114b14ab00ab30ecaa3a84da37a, but its functionality has since been provided by LoweredCodeUtils and is no longer needed. This removes all code related to `moduledeps` and clean up.