### PR TITLE
remove the interface to support non .jl files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.7.6"
+version = "3.8.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -155,12 +155,12 @@ Revise.init_worker
 
 ## Teaching Revise about non-julia source codes
 Revise can be made to work for transpilers from non-Julia languages to Julia with a little effort.
-For example, if you wrote a transpiler from C to Julia, you can define a `struct CFile`
-which overrides enough of the common `String` methods (`abspath`,`isabspath`, `joinpath`, `normpath`,`isfile`,`findfirst`, and `String`),
-it will be supported by Revise if you define a method like
+For example, if you have written a C-to-Julia transpiler, you can support `includet("path/to/file.c")`
+by simply registering a function to parse `.c` files in `Revise.parsers`:
 ```julia
-function Revise.parse_source!(mod_exprs_sigs::Revise.ModuleExprsSigs, file::CFile, mod::Module; kwargs...)
-    ex = # julia Expr returned from running transpiler
-    Revise.process_source!(mod_exprs_sigs, ex, file, mod; kwargs...)
+Revise.parsers[".c"] = function (filename::String)
+    text = read(filename, String)
+    ex = ... # Julia Expr returned from running the transpiler
+    return ex
 end
 ```

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -152,15 +152,3 @@ Revise.git_repo
 ```@docs
 Revise.init_worker
 ```
-
-## Teaching Revise about non-julia source codes
-Revise can be made to work for transpilers from non-Julia languages to Julia with a little effort.
-For example, if you have written a C-to-Julia transpiler, you can support `includet("path/to/file.c")`
-by simply registering a function to parse `.c` files in `Revise.parsers`:
-```julia
-Revise.parsers[".c"] = function (filename::String)
-    text = read(filename, String)
-    ex = ... # Julia Expr returned from running the transpiler
-    return ex
-end
-```

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -30,8 +30,6 @@ Global variable, maps callback keys to user hooks.
 """
 const user_callbacks_by_key = Dict{Any, Any}()
 
-
-
 """
     key = Revise.add_callback(f, files, modules=nothing; key=gensym())
 

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -891,7 +891,7 @@ it defaults to `Main`.
 
 If this produces many errors, check that you specified `mod` correctly.
 """
-function track(mod::Module, file; mode=:sigs, kwargs...)
+function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
     isfile(file) || error(file, " is not a file")
     # Determine whether we're already tracking this file
     id = Base.moduleroot(mod) == Main ? PkgId(mod, string(mod)) : PkgId(mod)  # see #689 for `Main`
@@ -935,13 +935,13 @@ function track(mod::Module, file; mode=:sigs, kwargs...)
     return nothing
 end
 
-function track(file; kwargs...)
+function track(file::AbstractString; kwargs...)
     startswith(file, juliadir) && error("use Revise.track(Base) or Revise.track(<stdlib module>)")
     track(Main, file; kwargs...)
 end
 
 """
-    includet(filename)
+    includet(filename::AbstractString)
 
 Load `filename` and track future changes. `includet` is intended for quick "user scripts"; larger or more
 established projects are encouraged to put the code in one or more packages loaded with `using`
@@ -1001,7 +1001,7 @@ try fixing it with something like `push!(LOAD_PATH, "/path/to/my/private/repos")
 they will not be automatically tracked.
 (Call [`Revise.track`](@ref) manually on each file, if you've already `included`d all the code you need.)
 """
-function includet(mod::Module, file)
+function includet(mod::Module, file::AbstractString)
     prev = Base.source_path(nothing)
     file = if prev === nothing
         abspath(file)
@@ -1033,7 +1033,7 @@ function includet(mod::Module, file)
     end
     return nothing
 end
-includet(file) = includet(Main, file)
+includet(file::AbstractString) = includet(Main, file)
 
 """
     Revise.silence(pkg)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -537,13 +537,13 @@ end
 init_watching(files) = init_watching(pkgdatas[NOPACKAGE], files)
 
 """
-    revise_dir_queued(dirname)
+    revise_dir_queued(dirname::AbstractString)
 
 Wait for one or more of the files registered in `Revise.watched_files[dirname]` to be
 modified, and then queue the corresponding files on [`Revise.revision_queue`](@ref).
 This is generally called via a [`Revise.TaskThunk`](@ref).
 """
-@noinline function revise_dir_queued(dirname)
+@noinline function revise_dir_queued(dirname::AbstractString)
     @assert isabspath(dirname)
     if !isdir(dirname)
         sleep(0.1)   # in case git has done a delete/replace cycle

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -390,7 +390,7 @@ end
 
 # Much of this is adapted from base/loading.jl
 
-function manifest_file(project_file)
+function manifest_file(project_file = Base.active_project())
     if project_file isa String && isfile(project_file)
         mfile = Base.project_file_manifest_path(project_file)
         if mfile isa String
@@ -399,7 +399,6 @@ function manifest_file(project_file)
     end
     return nothing
 end
-manifest_file() = manifest_file(Base.active_project())
 
 function manifest_paths!(pkgpaths::Dict, manifest_file::String)
     d = if isdefined(Base, :get_deps) # `get_deps` is present in versions that support new manifest formats
@@ -427,7 +426,7 @@ end
 manifest_paths(manifest_file::String) =
     manifest_paths!(Dict{PkgId,String}(), manifest_file)
 
-function watch_manifest(mfile)
+function watch_manifest(mfile::String)
     while true
         try
             wait_changed(mfile)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -14,7 +14,7 @@ end
 
 const vstring = "v$(VERSION.major).$(VERSION.minor)"
 
-function inpath(path, dirs)
+function inpath(path::AbstractString, dirs::Vector{String})
     spath = splitpath(path)
     idx = findfirst(isequal(first(dirs)), spath)
     idx === nothing && return false
@@ -29,7 +29,7 @@ function inpath(path, dirs)
     return true
 end
 
-function _track(id, modname; modified_files=revision_queue)
+function _track(id::PkgId, modname::Symbol; modified_files=revision_queue)
     haskey(pkgdatas, id) && return nothing  # already tracked
     isbase = modname === :Base
     isstdlib = !isbase && modname ∈ stdlib_names
@@ -37,7 +37,7 @@ function _track(id, modname; modified_files=revision_queue)
         # Test whether we know where to find the files
         if isbase
             srcdir = fixpath(joinpath(juliadir, "base"))
-            dirs = ["base"]
+            dirs = String["base"]
         else
             stdlibv = joinpath("stdlib", vstring, String(modname))
             srcdir = fixpath(joinpath(juliadir, stdlibv))
@@ -48,7 +48,7 @@ function _track(id, modname; modified_files=revision_queue)
                 # This can happen for Pkg, since it's developed out-of-tree
                 srcdir = joinpath(juliadir, "usr", "share", "julia", stdlibv)  # omit fixpath deliberately
             end
-            dirs = ["stdlib", String(modname)]
+            dirs = String["stdlib", String(modname)]
         end
         if !isdir(srcdir)
             @error "unable to find path containing source for $modname, tracking is not possible"

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -73,7 +73,7 @@ function Base.iterate(iter::LineSkippingIterator, i=0)
     return (iter.args[i], i)
 end
 
-function skip_to_nonline(args, i)
+function skip_to_nonline(args::Vector{Any}, i::Int)
     while true
         i > length(args) && return i
         ex = args[i]

--- a/src/types.jl
+++ b/src/types.jl
@@ -145,16 +145,14 @@ Base.PkgId(pkgdata::PkgData) = PkgId(pkgdata.info)
 CodeTracking.basedir(pkgdata::PkgData) = basedir(pkgdata.info)
 CodeTracking.srcfiles(pkgdata::PkgData) = srcfiles(pkgdata.info)
 
-is_same_file(a, b) = String(a) == String(b)
-
-function fileindex(info, file)
+function fileindex(info::PkgData, file::AbstractString)
     for (i, f) in enumerate(srcfiles(info))
-        is_same_file(f, file) && return i
+        String(f) == String(file) && return i
     end
     return nothing
 end
 
-function hasfile(info, file)
+function hasfile(info::PkgData, file::AbstractString)
     if isabspath(file)
         file = relpath(file, info)
     end
@@ -168,7 +166,7 @@ function fileinfo(pkgdata::PkgData, file::String)
 end
 fileinfo(pkgdata::PkgData, i::Int) = pkgdata.fileinfos[i]
 
-function Base.push!(pkgdata::PkgData, pr::Pair{<:Any,FileInfo})
+function Base.push!(pkgdata::PkgData, pr::Pair{<:AbstractString,FileInfo})
     push!(srcfiles(pkgdata), pr.first)
     push!(pkgdata.fileinfos, pr.second)
     return pkgdata

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-relpath_safe(path, startpath) = isempty(startpath) ? path : relpath(path, startpath)
+relpath_safe(path::AbstractString, startpath::AbstractString) = isempty(startpath) ? path : relpath(path, startpath)
 
 function Base.relpath(filename::AbstractString, pkgdata::PkgData)
     if isabspath(filename)
@@ -33,7 +33,7 @@ function unique_dirs(iter)
     return udirs
 end
 
-function file_exists(filename)
+function file_exists(filename::AbstractString)
     filename = normpath(filename)
     isfile(filename) && return true
     alt = get(cache_file_key, filename, nothing)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,7 +87,7 @@ function unwrap(ex::Expr)
 end
 unwrap(rex::RelocatableExpr) = RelocatableExpr(unwrap(rex.ex))
 
-istrivial(a) = a === nothing || isa(a, LineNumberNode)
+istrivial(@nospecialize a) = a === nothing || isa(a, LineNumberNode)
 
 function unwrap_where(ex::Expr)
     while isexpr(ex, :where)

--- a/test/non_jl_test.jl
+++ b/test/non_jl_test.jl
@@ -4,21 +4,9 @@
 using Revise
 using Test
 
-struct MyFile
-    file::String
-end
-Base.relpath(file::MyFile, args...) = MyFile(Base.relpath(file.file, args...))
-Base.abspath(file::MyFile) = MyFile(Base.abspath(file.file))
-Base.isabspath(file::MyFile) = Base.isabspath(file.file)
-Base.joinpath(str::String, file::MyFile) = MyFile(Base.joinpath(str, file.file))
-Base.normpath(file::MyFile) = MyFile(Base.normpath(file.file))
-Base.isfile(file::MyFile) = Base.isfile(file.file)
-Base.findfirst(str::String, file::MyFile) = Base.findfirst(str, file.file)
-Base.String(file::MyFile) = file.file
-
-function make_module(file::MyFile)
+Revise.parsers[".program"] = function (filename::AbstractString)
     exprs = []
-    for line in eachline(file.file)
+    for line in eachline(filename)
        val, name = split(line, '=')
        push!(exprs, :(function $(Symbol(name))() $val end))
     end
@@ -27,23 +15,12 @@ function make_module(file::MyFile)
     end), :(using .fake_lang))
 end
 
-function Base.include(mod::Module, file::MyFile)
-    Core.eval(mod, make_module(file))
-end
-Base.include(file::MyFile) = Base.include(Core.Main, file)
-
-function Revise.parse_source!(mod_exprs_sigs::Revise.ModuleExprsSigs, file::MyFile, mod::Module; kwargs...)
-    ex = make_module(file)
-    Revise.process_source!(mod_exprs_sigs, ex, file, mod; kwargs...)
-end
-
 @testset "non-jl revisions" begin
     path = joinpath(@__DIR__, "test.program")
     try
         cp(joinpath(@__DIR__, "fake_lang", "test.program"), path, force=true)
         sleep(mtimedelay)
-        m=MyFile(path)
-        includet(m)
+        includet(path)
         @yry()    # comes from test/common.jl
         @test fake_lang.y() == "2"
         @test fake_lang.x() == "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3931,7 +3931,7 @@ end
 
 include("backedges.jl")
 
-include("non_jl_test.jl")
+# include("non_jl_test.jl")
 
 do_test("Base signatures") && @testset "Base signatures" begin
     println("beginning signatures tests")


### PR DESCRIPTION
The interface added in timholy/Revise.jl#680 for supporting non-.jl files assumes usages of custom struct, which requires overloading functions like `abspath` and is therefore quite cumbersome. Worse still, that makes it harder to refactor Revise code base, since now we need to think about the possibility of arbitrary types in places that originally needed to handle `AbstractString`.

This commit provides a simpler interface: support custom files by registering parsers per file extension in
`Revise.parsers::Dict{String,Any}`.
The greatly simplified `non_jl_test.jl` demonstrates how much more straightforward this approach is.
Of course, a potential downside is that if multiple packages register different parsers for the same extension, conflicts could arise, but since this feature is experimental, I believe we don’t need to account for that scenario yet.

/cc @Keno @oscardssmith Are you fine with this change? I'm currently working on some structural refactoring on Revise code base to support LS usecase, and I'd like to clean up the code base if possible before making massive changes on that.