### PR TITLE
Add PCRE2_jll and Zlib_jll as known stdlibs

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -199,9 +199,7 @@ const stdlib_names = Set([
     :Serialization, :SHA, :SharedArrays, :Sockets, :SparseArrays,
     :Statistics, :SuiteSparse, :Test, :Unicode, :UUIDs,
     :TOML, :Artifacts, :LibCURL_jll, :LibCURL, :MozillaCACerts_jll,
-    :Downloads, :Tar, :ArgTools, :NetworkOptions,
-    # :PCRE2_jll, :Zlib_jll
-])
+    :Downloads, :Tar, :ArgTools, :NetworkOptions, :PCRE2_jll, :Zlib_jll])
 
 # This replacement is needed because the path written during compilation differs from
 # the git source path


### PR DESCRIPTION
Revise's list of stdlibs is incomplete. This is currently a blocker for https://github.com/JuliaLang/julia/pull/58731: This PR updates LibGit2_jll to a new version, and this version has both PCRE2_jll and Zlib_jll as dependencies. Revise does not know about these two stdlibs, and this makes Julia's CI self tests fail.

This is a pared-down version of https://github.com/timholy/Revise.jl/pull/929. That other PR still may or may not make sense.

After this PR is merged we will need to update the version of Revise used by Julia's CI tests.