### PR TITLE
Use `invokelatest` when printing errors after `includet`

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1019,7 +1019,7 @@ function includet(mod::Module, file::AbstractString)
         end
         if isa(err, ReviseEvalException)
             printstyled(stderr, "ERROR: "; color=Base.error_color());
-            showerror(stderr, err; blame_revise=false)
+            invokelatest(showerror, stderr, err; blame_revise=false)
             println(stderr, "\nin expression starting at ", err.loc)
         else
             throw(err)


### PR DESCRIPTION
Matches the behavior in the REPL. Useful in general in case included code is required for proper printing and will also be required in the tests after https://github.com/JuliaLang/julia/pull/58976.