### PR TITLE
Track Core.Compiler under a separate PkgId

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -7,7 +7,9 @@ Track updates to the code in Julia's `base` directory, `base/compiler`, or one o
 standard libraries.
 """
 function track(mod::Module; modified_files=revision_queue)
-    id = PkgId(mod)
+    id = Base.moduleroot(mod) == Core.Compiler ?
+        PkgId(mod, "Core.Compiler") :
+        PkgId(mod)
     modname = nameof(mod)
     return _track(id, modname; modified_files=modified_files)
 end


### PR DESCRIPTION
It shares a UUID with the Compiler stdlib (which depending on version may or may not delegate to Core.Compiler). I think this should work because in the non-delegation case, the Compiler stdlib doesn't actually load any files and in the delegation files they are totally separate, but let's keep an eye on any Revise weirdness around the Compilers.

Fixes #935