### PR TITLE
separate `RelocatableExpr` into a subpackage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,7 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
 version = "3.8.0"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -10,12 +11,16 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+RelocatableExprs = "d8335a89-6200-4039-b235-f3a516e6e8f0"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [weakdeps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[sources]
+RelocatableExprs = {path = "RelocatableExprs"}
 
 [extensions]
 DistributedExt = "Distributed"
@@ -26,7 +31,6 @@ Distributed = "1"
 JuliaInterpreter = "0.10"
 LoweredCodeUtils = "3.3"
 OrderedCollections = "1"
-# Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94
 Requires = "~1.0, ^1.1.1"
 julia = "1.10"
 

--- a/RelocatableExprs/Project.toml
+++ b/RelocatableExprs/Project.toml
@@ -1,0 +1,10 @@
+name = "RelocatableExprs"
+uuid = "d8335a89-6200-4039-b235-f3a516e6e8f0"
+version = "0.1.0"
+authors = ["Tim Holy <tim.holy@gmail.com>", "Shuhei Kadowaki <aviatesk@gmail.com>"]
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/RelocatableExprs/test/runtests.jl
+++ b/RelocatableExprs/test/runtests.jl
@@ -1,0 +1,45 @@
+using Test
+using RelocatableExprs
+
+@testset "RelocatableExprs" begin
+    @testset "Equality and hashing" begin
+        # issue #233
+        @test  isequal(RelocatableExpr(:(x = 1)), RelocatableExpr(:(x = 1)))
+        @test !isequal(RelocatableExpr(:(x = 1)), RelocatableExpr(:(x = 1.0)))
+        @test hash(RelocatableExpr(:(x = 1))) == hash(RelocatableExpr(:(x = 1)))
+        @test hash(RelocatableExpr(:(x = 1))) != hash(RelocatableExpr(:(x = 1.0)))
+        @test hash(RelocatableExpr(:(x = 1))) != hash(RelocatableExpr(:(x = 2)))
+    end
+
+    function collectexprs(rex::RelocatableExpr)
+        items = []
+        for item in LineSkippingIterator(rex.ex.args)
+            push!(items, isa(item, Expr) ? RelocatableExpr(item) : item)
+        end
+        items
+    end
+
+    @testset "LineSkipping" begin
+        rex = RelocatableExpr(quote
+                                f(x) = x^2
+                                g(x) = sin(x)
+                            end)
+        @test length(rex.ex.args) == 4  # including the line number expressions
+        exs = collectexprs(rex)
+        @test length(exs) == 2
+        @test isequal(exs[1], RelocatableExpr(:(f(x) = x^2)))
+        @test hash(exs[1]) == hash(RelocatableExpr(:(f(x) = x^2)))
+        @test !isequal(exs[2], RelocatableExpr(:(f(x) = x^2)))
+        @test isequal(exs[2], RelocatableExpr(:(g(x) = sin(x))))
+        @test !isequal(exs[1], RelocatableExpr(:(g(x) = sin(x))))
+        @test string(rex) == """
+            quote
+                f(x) = begin
+                        x ^ 2
+                    end
+                g(x) = begin
+                        sin(x)
+                    end
+            end"""
+    end
+end

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -104,7 +104,7 @@ flavors:
 
 - log entries with message `"Eval"` signify a call to `eval`; for these events,
   keyword `:deltainfo` has value `(mod, expr)` where `mod` is the module of evaluation
-  and `expr` is a [`Revise.RelocatableExpr`](@ref) containing the expression
+  and `expr` is a [`RelocatableExprs.RelocatableExpr`](@ref) containing the expression
   that was evaluated.
 - log entries with message `"DeleteMethod"` signify a method deletion; for these events,
   keyword `:deltainfo` has value `(sigt, methsummary)` where `sigt` is the signature of the

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -45,7 +45,6 @@ Revise.user_callbacks_by_key
 ## Types
 
 ```@docs
-Revise.RelocatableExpr
 Revise.ModuleExprsSigs
 Revise.FileInfo
 Revise.PkgData

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -121,7 +121,7 @@ end</code></pre></p>
 ```
 
 This represents the *definition* of a method.
-Definitions are stored as expressions, using a [`Revise.RelocatableExpr`](@ref).
+Definitions are stored as expressions, using a [`RelocatableExprs.RelocatableExpr`](@ref).
 The highlighted portion is the *signature-expression*, specifying the name, argument names
 and their types, and (if applicable) type-parameters of the method.
 
@@ -338,7 +338,7 @@ This is just a summary; to see the actual `def=>sigts` map, do the following:
 
 ```julia
 julia> pkgdata.fileinfos[2].modexsigs[Items]
-OrderedCollections.OrderedDict{Revise.RelocatableExpr,Union{Nothing, Array{Any,1}}} with 2 entries:
+OrderedCollections.OrderedDict{RelocatableExprs.RelocatableExpr,Union{Nothing, Array{Any,1}}} with 2 entries:
   :(indent(::UInt16) = begin…                       => Any[Tuple{typeof(indent),UInt16}]
   :(indent(::UInt8) = begin…                        => Any[Tuple{typeof(indent),UInt8}]
 ```

--- a/test/common.jl
+++ b/test/common.jl
@@ -42,14 +42,6 @@ macro yry()
     end)
 end
 
-function collectexprs(rex::Revise.RelocatableExpr)
-    items = []
-    for item in Revise.LineSkippingIterator(rex.ex.args)
-        push!(items, isa(item, Expr) ? Revise.RelocatableExpr(item) : item)
-    end
-    items
-end
-
 function get_docstring(obj)
     while !isa(obj, AbstractString)
         fn = fieldnames(typeof(obj))


### PR DESCRIPTION
I want to use the `RelocatableExpr` definition in a new language server project, so we are separating it as a subpackage of Revise. There are no functional changes when using Revise.