### PR TITLE
Preliminary support for `include(mapexpr, file)`

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/CodeTracking.jl#parametrize-by-mt https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
+      - run: cd docs && julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/CodeTracking.jl#parametrize-by-mt https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/CodeTracking.jl#parametrize-by-mt https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
-      - run: cd docs && julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/CodeTracking.jl#parametrize-by-mt https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
+      - run: julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/timholy/CodeTracking.jl#master https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
+      - run: cd docs && julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/timholy/CodeTracking.jl#master https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         version: ${{ matrix.version }}
         show-versioninfo: ${{ matrix.version == 'nightly' }}
     - uses: julia-actions/cache@v2
+    - run: julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/CodeTracking.jl#parametrize-by-mt https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
     - uses: julia-actions/julia-buildpkg@latest
     # Revise's tests need significant customization
     # Populate the precompile cache with an extraneous file, to catch issues like in #460

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         version: ${{ matrix.version }}
         show-versioninfo: ${{ matrix.version == 'nightly' }}
     - uses: julia-actions/cache@v2
-    - run: julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/timholy/CodeTracking.jl#master https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
+    - run: julia --project -e 'using Pkg; using Pkg; Pkg.add([PackageSpec(; url="https://github.com/serenity4/JuliaInterpreter.jl", rev="codetracking-v2"), PackageSpec(; name = "CodeTracking", rev="master"), PackageSpec(; url = "https://github.com/serenity4/LoweredCodeUtils.jl", rev = "support-external-methodtables")])'
     - uses: julia-actions/julia-buildpkg@latest
     # Revise's tests need significant customization
     # Populate the precompile cache with an extraneous file, to catch issues like in #460
@@ -81,7 +81,7 @@ jobs:
         # We also need to pick up the Git tests, but for that we need to `dev` the package
         echo "Git tests"
         julia --code-coverage=user -e '
-          using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/timholy/CodeTracking.jl#master https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"
+          using Pkg; using Pkg; using Pkg; Pkg.add([PackageSpec(; url="https://github.com/serenity4/JuliaInterpreter.jl", rev="codetracking-v2"), PackageSpec(; name = "CodeTracking", rev="master"), PackageSpec(; url = "https://github.com/serenity4/LoweredCodeUtils.jl", rev = "support-external-methodtables")])
           using Pkg; Pkg.develop(PackageSpec(path="."))
           include(joinpath("test", "runtests.jl"))
         ' "Git"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         version: ${{ matrix.version }}
         show-versioninfo: ${{ matrix.version == 'nightly' }}
     - uses: julia-actions/cache@v2
-    - run: julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/CodeTracking.jl#parametrize-by-mt https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
+    - run: julia --project -e 'using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/timholy/CodeTracking.jl#master https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"'
     - uses: julia-actions/julia-buildpkg@latest
     # Revise's tests need significant customization
     # Populate the precompile cache with an extraneous file, to catch issues like in #460
@@ -81,7 +81,7 @@ jobs:
         # We also need to pick up the Git tests, but for that we need to `dev` the package
         echo "Git tests"
         julia --code-coverage=user -e '
-          using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/CodeTracking.jl#parametrize-by-mt https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"
+          using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/timholy/CodeTracking.jl#master https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"
           using Pkg; Pkg.develop(PackageSpec(path="."))
           include(joinpath("test", "runtests.jl"))
         ' "Git"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         # We also need to pick up the Git tests, but for that we need to `dev` the package
         echo "Git tests"
         julia --code-coverage=user -e '
+          using Pkg; pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/CodeTracking.jl#parametrize-by-mt https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables"
           using Pkg; Pkg.develop(PackageSpec(path="."))
           include(joinpath("test", "runtests.jl"))
         ' "Git"

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 This file describes only major changes, and does not include bug fixes,
 cleanups, or minor enhancements.
 
+## Revise 3.8
+
+* Methods defined on external method tables via `Base.Experimental.@overlay` can now be correctly revised ([#904]).
+
 ## Revise 3.3
 
 * Upgrade to JuliaInterpreter 0.9 and drop support for Julia prior to 1.6 (the new LTS).
@@ -151,3 +155,4 @@ New features:
 [#243]: https://github.com/timholy/Revise.jl/pull/243
 [#245]: https://github.com/timholy/Revise.jl/pull/245
 [#278]: https://github.com/timholy/Revise.jl/pull/278
+[#904]: https://github.com/timholy/Revise.jl/pull/904

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ DistributedExt = "Distributed"
 [compat]
 CodeTracking = "2"
 Distributed = "1"
-JuliaInterpreter = "0.9"
+JuliaInterpreter = "0.10"
 LoweredCodeUtils = "3.2"
 OrderedCollections = "1"
 # Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DistributedExt = "Distributed"
 
 [compat]
-CodeTracking = "1.2"
+CodeTracking = "2"
 Distributed = "1"
 JuliaInterpreter = "0.9"
 LoweredCodeUtils = "3.2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.7.6"
+version = "3.8.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -159,13 +159,13 @@ julia> rlogger.logs
           #= /tmp/revisetest.jl:9 =#
           x ^ 4
       end))))
- Revise.LogRecord(Debug, LineOffset, Action, Revise_fb38a7f7, "/home/tim/.julia/dev/Revise/src/Revise.jl", 296, (time=1.557996459331061e9, deltainfo=(Any[Tuple{typeof(mult2),Any}], :(#= /tmp/revisetest.jl:11 =#) => :(#= /tmp/revisetest.jl:13 =#))))
+ Revise.LogRecord(Debug, LineOffset, Action, Revise_fb38a7f7, "/home/tim/.julia/dev/Revise/src/Revise.jl", 296, (time=1.557996459331061e9, deltainfo=(Pair{Union{Nothing, MethodTable}, Type}[nothing => Tuple{typeof(mult2),Any}], :(#= /tmp/revisetest.jl:11 =#) => :(#= /tmp/revisetest.jl:13 =#))))
  Revise.LogRecord(Debug, Eval, Action, Revise_9147188b, "/home/tim/.julia/dev/Revise/src/Revise.jl", 276, (time=1.557996459391182e9, deltainfo=(Main.ReviseTest.Internal, :(mult3(x) = begin
           #= /tmp/revisetest.jl:14 =#
           3x
       end))))
- Revise.LogRecord(Debug, LineOffset, Action, Revise_fb38a7f7, "/home/tim/.julia/dev/Revise/src/Revise.jl", 296, (time=1.557996459391642e9, deltainfo=(Any[Tuple{typeof(unchanged),Any}], :(#= /tmp/revisetest.jl:18 =#) => :(#= /tmp/revisetest.jl:19 =#))))
- Revise.LogRecord(Debug, LineOffset, Action, Revise_fb38a7f7, "/home/tim/.julia/dev/Revise/src/Revise.jl", 296, (time=1.557996459391695e9, deltainfo=(Any[Tuple{typeof(unchanged2),Any}], :(#= /tmp/revisetest.jl:20 =#) => :(#= /tmp/revisetest.jl:21 =#))))
+ Revise.LogRecord(Debug, LineOffset, Action, Revise_fb38a7f7, "/home/tim/.julia/dev/Revise/src/Revise.jl", 296, (time=1.557996459391642e9, deltainfo=(Pair{Union{Nothing, MethodTable}, Type}[nothing => Tuple{typeof(unchanged),Any}], :(#= /tmp/revisetest.jl:18 =#) => :(#= /tmp/revisetest.jl:19 =#))))
+ Revise.LogRecord(Debug, LineOffset, Action, Revise_fb38a7f7, "/home/tim/.julia/dev/Revise/src/Revise.jl", 296, (time=1.557996459391695e9, deltainfo=(Pair{Union{Nothing, MethodTable}, Type}[nothing => Tuple{typeof(unchanged2),Any}], :(#= /tmp/revisetest.jl:20 =#) => :(#= /tmp/revisetest.jl:21 =#))))
 ```
 
 You can see that Revise started by deleting three methods, followed by evaluating three new versions of those methods. Interspersed are various changes to the line numbering.

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -137,6 +137,7 @@ Tuple{typeof(print_item),IO,Any,Integer,String}     # print_item(io, item, 2, " 
 ```
 
 In Revise's internal code, a definition is often represented with a variable `def`, and a signature-type with `sigt`.
+The method table for which the method was defined is also represented, to form a `mt_sigt` pair.
 Recent versions of Revise do not make extensive use of signature expressions.
 
 ### Computing signatures

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -35,7 +35,7 @@ module Revise
 
 using OrderedCollections, CodeTracking, JuliaInterpreter, LoweredCodeUtils
 
-using CodeTracking: PkgFiles, basedir, srcfiles, basepath, MethodInfoKey
+using CodeTracking: PkgFiles, MethodInfoKey, MapExprFile, basedir, srcfiles, basepath
 using JuliaInterpreter: Compiled, Frame, Interpreter, LineTypes, RecursiveInterpreter
 using JuliaInterpreter: codelocs, finish_and_return!, get_return, is_doc_expr, isassign,
                         isidentical, is_quotenode_egal, linetable, lookup, moduleof,

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -35,7 +35,7 @@ module Revise
 
 using OrderedCollections, CodeTracking, JuliaInterpreter, LoweredCodeUtils
 
-using CodeTracking: PkgFiles, basedir, srcfiles, basepath
+using CodeTracking: PkgFiles, basedir, srcfiles, basepath, MethodInfoKey
 using JuliaInterpreter: whichtt, is_doc_expr, step_expr!, finish_and_return!, get_return,
                         @lookup, moduleof, scopeof, pc_expr, is_quotenode_egal,
                         linetable, codelocs, LineTypes, isassign, isidentical

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -21,7 +21,7 @@ const user_callbacks_queue = Set{Any}()
 Global variable, maps files (identified by their absolute path) to the set of
 callback keys registered for them.
 """
-const user_callbacks_by_file = Dict{String, Set{Any}}()
+const user_callbacks_by_file = Dict{Union{String, MapExprFile}, Set{Any}}()
 
 """
     Revise.user_callbacks_by_key

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -495,7 +495,12 @@ function _methods_by_execution!(interp::Interpreter, methodinfo, frame::Frame, i
                     if length(stmt.args) == 2
                         add_includes!(methodinfo, mod, lookup(interp, frame, stmt.args[2]))
                     elseif length(stmt.args) == 3
-                        add_includes!(methodinfo, lookup(interp, frame, stmt.args[2]), lookup(interp, frame, stmt.args[3]))
+                        mod_or_mapexpr = lookup(interp, frame, stmt.args[2])
+                        if isa(mod_or_mapexpr, Module)
+                            add_includes!(methodinfo, mod_or_mapexpr, lookup(interp, frame, stmt.args[3]))
+                        else
+                            add_includes!(methodinfo, mod, MapExprFile(mod_or_mapexpr, lookup(interp, frame, stmt.args[3])))
+                        end
                     else
                         error("Bad call to Core.include")
                     end
@@ -509,7 +514,7 @@ function _methods_by_execution!(interp::Interpreter, methodinfo, frame::Frame, i
                         if isa(mod_or_mapexpr, Module)
                             add_includes!(methodinfo, mod_or_mapexpr, lookup(interp, frame, stmt.args[3]))
                         else
-                            error("include(mapexpr, path) is not supported") # TODO (issue #634)
+                            add_includes!(methodinfo, mod, MapExprFile(mod_or_mapexpr, lookup(interp, frame, stmt.args[3])))
                         end
                     end
                     assign_this!(frame, nothing)  # FIXME: the file might return something different from `nothing`

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -16,7 +16,7 @@ end
 # This defines the API needed to store signatures using methods_by_execution!
 # This default version is simple and only used for testing purposes.
 # The "real" one is CodeTrackingMethodInfo in Revise.jl.
-const MethodInfo = IdDict{Pair{<:Union{Nothing, MethodTable},<:Type},LineNumberNode}
+const MethodInfo = IdDict{MethodInfoKey,LineNumberNode}
 add_signature!(methodinfo::MethodInfo, @nospecialize(sig), ln) = push!(methodinfo, sig=>ln)
 push_expr!(methodinfo::MethodInfo, mod::Module, ex::Expr) = methodinfo
 pop_expr!(methodinfo::MethodInfo) = methodinfo
@@ -320,7 +320,7 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, fra
     mod = moduleof(frame)
     # Hoist this lookup for performance. Don't throw even when `mod` is a baremodule:
     modinclude = isdefined(mod, :include) ? getfield(mod, :include) : nothing
-    signatures = []  # temporary for method signature storage
+    signatures = MethodInfoKey[]  # temporary for method signature storage
     pc = frame.pc
     while true
         JuliaInterpreter.is_leaf(frame) || (@warn("not a leaf"); break)

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -16,7 +16,7 @@ end
 # This defines the API needed to store signatures using methods_by_execution!
 # This default version is simple and only used for testing purposes.
 # The "real" one is CodeTrackingMethodInfo in Revise.jl.
-const MethodInfo = IdDict{Type,LineNumberNode}
+const MethodInfo = IdDict{Pair{<:Union{Nothing, MethodTable},<:Type},LineNumberNode}
 add_signature!(methodinfo::MethodInfo, @nospecialize(sig), ln) = push!(methodinfo, sig=>ln)
 push_expr!(methodinfo::MethodInfo, mod::Module, ex::Expr) = methodinfo
 pop_expr!(methodinfo::MethodInfo) = methodinfo
@@ -464,13 +464,13 @@ function methods_by_execution!(@nospecialize(recurse), methodinfo, docexprs, fra
                         uT = Base.unwrap_unionall(T)::DataType
                         ft = uT.types
                         sig1 = Tuple{Base.rewrap_unionall(Type{uT}, T), Any[Any for i in 1:length(ft)]...}
-                        push!(signatures, sig1)
+                        push!(signatures, nothing => sig1)
                         sig2 = Base.rewrap_unionall(Tuple{Type{T}, ft...}, T)
                         while T isa UnionAll
                             sig2 isa UnionAll || (sig2 = sig1; break) # sig2 doesn't define all parameters, so drop it
                             T = T.body
                         end
-                        sig1 == sig2 || push!(signatures, sig2)
+                        sig1 == sig2 || push!(signatures, nothing => sig2)
                         for sig in signatures
                             add_signature!(methodinfo, sig, lnn)
                         end

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -15,7 +15,7 @@ end
 
 # This defines the API needed to store signatures using methods_by_execution!
 # This default version is simple and only used for testing purposes.
-# The "real" one is CodeTrackingMethodInfo in Revise.jl.
+# The "real" one is CodeTrackingMethodInfo in packagedef.jl.
 const MethodInfo = IdDict{MethodInfoKey,LineNumberNode}
 add_signature!(methodinfo::MethodInfo, @nospecialize(sig), ln) = push!(methodinfo, sig=>ln)
 push_expr!(methodinfo::MethodInfo, mod::Module, ex::Expr) = methodinfo

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -43,6 +43,21 @@ function parse_source!(mod_exprs_sigs::ModuleExprsSigs, src::AbstractString, fil
     end
 end
 
+function parse_source!(mod_exprs_sigs::ModuleExprsSigs, src::AbstractString, mapfile::MapExprFile, mod::Module; kwargs...)
+    if startswith(src, "# REVISE: DO NOT PARSE")
+        return DoNotParse()
+    end
+    (; mapexpr, filename) = mapfile
+    ex = Base.parse_input_line(src; filename)
+    if ex === nothing
+        return mod_exprs_sigs
+    elseif ex isa Expr
+        return process_ex!(mod_exprs_sigs, mapexpr(ex), filename, mod; kwargs...)
+    else # literals
+        return nothing
+    end
+end
+
 function process_ex!(mod_exprs_sigs::ModuleExprsSigs, ex::Expr, filename::AbstractString, mod::Module; mode::Symbol=:sigs)
     if isexpr(ex, :error) || isexpr(ex, :incomplete)
         return eval(ex)

--- a/src/types.jl
+++ b/src/types.jl
@@ -150,7 +150,11 @@ CodeTracking.srcfiles(pkgdata::PkgData) = srcfiles(pkgdata.info)
 
 function fileindex(info::PkgData, file::AbstractString)
     for (i, f) in enumerate(srcfiles(info))
-        String(f) == String(file) && return i
+        f == file && return i
+        # FIXME: what if the file gets included twice with different mapexprs?
+        if isa(f, MapExprFile) && !isa(file, MapExprFile)
+            f.filename == file && return i
+        end
     end
     return nothing
 end
@@ -162,7 +166,7 @@ function hasfile(info::PkgData, file::AbstractString)
     fileindex(info, file) !== nothing
 end
 
-function fileinfo(pkgdata::PkgData, file::String)
+function fileinfo(pkgdata::PkgData, file::Union{String, MapExprFile})
     i = fileindex(pkgdata, file)
     i === nothing && error("file ", file, " not found")
     return pkgdata.fileinfos[i]

--- a/src/types.jl
+++ b/src/types.jl
@@ -16,7 +16,7 @@ mutable struct WatchList
 end
 
 const DocExprs = Dict{Module,Vector{Expr}}
-const ExprsSigs = OrderedDict{RelocatableExpr,Union{Nothing,Vector{Any}}}
+const ExprsSigs = OrderedDict{RelocatableExpr,Union{Nothing,Vector{Pair{Union{Nothing, MethodTable}, Type}}}}
 const DepDictVals = Tuple{Module,RelocatableExpr}
 const DepDict = Dict{Symbol,Set{DepDictVals}}
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -24,9 +24,9 @@ function Base.show(io::IO, exsigs::ExprsSigs)
     compact = get(io, :compact, false)
     if compact
         n = 0
-        for (rex, sigs) in exsigs
-            sigs === nothing && continue
-            n += length(sigs)
+        for (rex, mt_sigs) in exsigs
+            mt_sigs === nothing && continue
+            n += length(mt_sigs)
         end
         print(io, "ExprsSigs(<$(length(exsigs)) expressions>, <$n signatures>)")
     else
@@ -42,11 +42,11 @@ end
     ModuleExprsSigs
 
 For a particular source file, the corresponding `ModuleExprsSigs` is a mapping
-`mod=>exprs=>sigs` of the expressions `exprs` found in `mod` and the signatures `sigs`
+`mod=>exprs=>mt_sigs` of the expressions `exprs` found in `mod` and the method table/signature pairs `mt_sigs`
 that arise from them. Specifically, if `mes` is a `ModuleExprsSigs`, then `mes[mod][ex]`
-is a list of signatures that result from evaluating `ex` in `mod`. It is possible that
+is a list of method table/signature pairs that result from evaluating `ex` in `mod`. It is possible that
 this returns `nothing`, which can mean either that `ex` does not define any methods
-or that the signatures have not yet been cached.
+or that the method table/signature pairs have not yet been cached.
 
 The first `mod` key is guaranteed to be the module into which this file was `include`d.
 
@@ -186,10 +186,10 @@ function Base.show(io::IO, pkgdata::PkgData)
         for fi in pkgdata.fileinfos
             thisnexs, thisnsigs = 0, 0
             for (mod, exsigs) in fi.modexsigs
-                for (rex, sigs) in exsigs
+                for (rex, mt_sigs) in exsigs
                     thisnexs += 1
-                    sigs === nothing && continue
-                    thisnsigs += length(sigs)
+                    mt_sigs === nothing && continue
+                    thisnsigs += length(mt_sigs)
                 end
             end
             nexs += thisnexs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 # REVISE: DO NOT PARSE   # For people with JULIA_REVISE_INCLUDE=1
 using Revise
 using Revise.CodeTracking
+using Revise.CodeTracking: MethodInfoKey
 using Revise.JuliaInterpreter
 using Test
 
@@ -1408,7 +1409,7 @@ end
             """)
         @yry()
         @test MacroSigs.blah() == 1
-        @test haskey(CodeTracking.method_info, CodeTracking.method_info_key(@which MacroSigs.blah()))
+        @test haskey(CodeTracking.method_info, MethodInfoKey(@which MacroSigs.blah()))
         rm_precompile("MacroSigs")
 
         # Issue #568 (a macro *execution* bug)
@@ -2945,7 +2946,7 @@ end
     do_test("Recipes") && @testset "Recipes" begin
         # https://github.com/JunoLab/Juno.jl/issues/257#issuecomment-473856452
         meth = @which gcd(10, 20)
-        sigs = signatures_at(Base.find_source_file(String(meth.file)), meth.line)  # this should track Base
+        signatures_at(Base.find_source_file(String(meth.file)), meth.line)  # this should track Base
 
         # Tracking Base
         # issue #250

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,7 +266,7 @@ end
         @test length(dvs) == 3
         (def, val) = dvs[1]
         @test isequal(Revise.unwrap(def), Revise.RelocatableExpr(:(square(x) = x^2)))
-        @test val == [Tuple{typeof(ReviseTest.square),Any}]
+        @test val == [nothing => Tuple{typeof(ReviseTest.square),Any}]
         @test Revise.firstline(Revise.unwrap(def)).line == 5
         m = @which ReviseTest.square(1)
         @test m.line == 5
@@ -274,14 +274,14 @@ end
         @test Revise.RelocatableExpr(definition(m)) == Revise.unwrap(def)
         (def, val) = dvs[2]
         @test isequal(Revise.unwrap(def), Revise.RelocatableExpr(:(cube(x) = x^3)))
-        @test val == [Tuple{typeof(ReviseTest.cube),Any}]
+        @test val == [nothing => Tuple{typeof(ReviseTest.cube),Any}]
         m = @which ReviseTest.cube(1)
         @test m.line == 7
         @test whereis(m) == (tmpfile, 7)
         @test Revise.RelocatableExpr(definition(m)) == Revise.unwrap(def)
         (def, val) = dvs[3]
         @test isequal(Revise.unwrap(def), Revise.RelocatableExpr(:(fourth(x) = x^4)))
-        @test val == [Tuple{typeof(ReviseTest.fourth),Any}]
+        @test val == [nothing => Tuple{typeof(ReviseTest.fourth),Any}]
         m = @which ReviseTest.fourth(1)
         @test m.line == 9
         @test whereis(m) == (tmpfile, 9)
@@ -291,7 +291,7 @@ end
         @test length(dvs) == 5
         (def, val) = dvs[1]
         @test isequal(Revise.unwrap(def),  Revise.RelocatableExpr(:(mult2(x) = 2*x)))
-        @test val == [Tuple{typeof(ReviseTest.Internal.mult2),Any}]
+        @test val == [nothing => Tuple{typeof(ReviseTest.Internal.mult2),Any}]
         @test Revise.firstline(Revise.unwrap(def)).line == 13
         m = @which ReviseTest.Internal.mult2(1)
         @test m.line == 11
@@ -299,7 +299,7 @@ end
         @test Revise.RelocatableExpr(definition(m)) == Revise.unwrap(def)
         (def, val) = dvs[2]
         @test isequal(Revise.unwrap(def), Revise.RelocatableExpr(:(mult3(x) = 3*x)))
-        @test val == [Tuple{typeof(ReviseTest.Internal.mult3),Any}]
+        @test val == [nothing => Tuple{typeof(ReviseTest.Internal.mult3),Any}]
         m = @which ReviseTest.Internal.mult3(1)
         @test m.line == 14
         @test whereis(m) == (tmpfile, 14)
@@ -327,10 +327,10 @@ end
         cmpdiff(logs[4], "Eval"; deltainfo=(ReviseTest, :(cube(x) = x^3)))
         cmpdiff(logs[5], "Eval"; deltainfo=(ReviseTest, :(fourth(x) = x^4)))
         stmpfile = Symbol(tmpfile)
-        cmpdiff(logs[6], "LineOffset"; deltainfo=(Any[Tuple{typeof(ReviseTest.Internal.mult2),Any}], LineNumberNode(11,stmpfile)=>LineNumberNode(13,stmpfile)))
+        cmpdiff(logs[6], "LineOffset"; deltainfo=(Any[nothing => Tuple{typeof(ReviseTest.Internal.mult2),Any}], LineNumberNode(11,stmpfile)=>LineNumberNode(13,stmpfile)))
         cmpdiff(logs[7], "Eval"; deltainfo=(ReviseTest.Internal, :(mult3(x) = 3*x)))
-        cmpdiff(logs[8], "LineOffset"; deltainfo=(Any[Tuple{typeof(ReviseTest.Internal.unchanged),Any}], LineNumberNode(18,stmpfile)=>LineNumberNode(19,stmpfile)))
-        cmpdiff(logs[9], "LineOffset"; deltainfo=(Any[Tuple{typeof(ReviseTest.Internal.unchanged2),Any}], LineNumberNode(20,stmpfile)=>LineNumberNode(21,stmpfile)))
+        cmpdiff(logs[8], "LineOffset"; deltainfo=(Any[nothing => Tuple{typeof(ReviseTest.Internal.unchanged),Any}], LineNumberNode(18,stmpfile)=>LineNumberNode(19,stmpfile)))
+        cmpdiff(logs[9], "LineOffset"; deltainfo=(Any[nothing => Tuple{typeof(ReviseTest.Internal.unchanged2),Any}], LineNumberNode(20,stmpfile)=>LineNumberNode(21,stmpfile)))
         @test length(Revise.actions(rlogger)) == 6  # by default LineOffset is skipped
         @test length(Revise.actions(rlogger; line=true)) == 9
         @test_broken length(Revise.diffs(rlogger)) == 2
@@ -503,8 +503,8 @@ end
                 m3 = first(methods(eval(fn3)))
                 m3file = joinpath(dn, "subdir", "file3.jl")
                 @test whereis(m3) == (m3file, 1)
-                @test signatures_at(m3file, 1) == [m3.sig]
-                @test signatures_at(eval(Symbol(modname)), joinpath("src", "subdir", "file3.jl"), 1) == [m3.sig]
+                @test signatures_at(m3file, 1) == [nothing => m3.sig]
+                @test signatures_at(eval(Symbol(modname)), joinpath("src", "subdir", "file3.jl"), 1) == [nothing => m3.sig]
 
                 id = Base.PkgId(eval(Symbol(modname)))   # for testing #596
                 pkgdata = Revise.pkgdatas[id]
@@ -1398,7 +1398,7 @@ end
             """)
         @yry()
         @test MacroSigs.blah() == 1
-        @test haskey(CodeTracking.method_info, (@which MacroSigs.blah()).sig)
+        @test haskey(CodeTracking.method_info, CodeTracking.method_info_key(@which MacroSigs.blah()))
         rm_precompile("MacroSigs")
 
         # Issue #568 (a macro *execution* bug)
@@ -1896,8 +1896,8 @@ end
         ex2 = :(methspecificity(x::Integer) = 2)
         Core.eval(ReviseTestPrivate, ex1)
         Core.eval(ReviseTestPrivate, ex2)
-        exsig1 = Revise.RelocatableExpr(ex1)=>[Tuple{typeof(ReviseTestPrivate.methspecificity),Int}]
-        exsig2 = Revise.RelocatableExpr(ex2)=>[Tuple{typeof(ReviseTestPrivate.methspecificity),Integer}]
+        exsig1 = Revise.RelocatableExpr(ex1) => [nothing => Tuple{typeof(ReviseTestPrivate.methspecificity),Int}]
+        exsig2 = Revise.RelocatableExpr(ex2) => [nothing => Tuple{typeof(ReviseTestPrivate.methspecificity),Integer}]
         f_old, f_new = Revise.ExprsSigs(exsig1, exsig2), Revise.ExprsSigs(exsig2)
         Revise.delete_missing!(f_old, f_new)
         m = @which ReviseTestPrivate.methspecificity(1)
@@ -3084,6 +3084,87 @@ end
         @test B670.x == 6
         @test B670.y == 7
         rm_precompile("B670")
+    end
+
+    do_test("External method tables") && @testset "External method tables" begin
+        function retval(m)
+            src = Base.uncompressed_ast(m)
+            node = src.code[1]::Core.ReturnNode
+            node.val
+        end
+
+        testdir = newtestdir()
+
+        unique_name(base) = Symbol(replace(lstrip(String(gensym(base)), '#'), '#' => '_'))
+        first_revision(name) = """
+            module $name
+
+            Base.Experimental.@MethodTable(method_table)
+
+            foo() = 1
+            Base.Experimental.@overlay method_table foo() = 2
+
+            bar() = foo()
+
+            end
+            """
+        second_revision(name) = """
+            module $name
+
+            Base.Experimental.@MethodTable(method_table)
+
+            foo() = 1
+            Base.Experimental.@overlay method_table foo() = 3
+
+            bar() = foo() + 1
+
+            end
+            """
+
+        name = unique_name(:ExternalMT)
+        dn = joinpath(testdir, "$name", "src")
+        mkpath(dn)
+        write(joinpath(dn, "$name.jl"), first_revision(name))
+        sleep(mtimedelay)
+        @eval import $name
+        ExternalMT = @eval $name
+        foo, bar, mt = ExternalMT.foo, ExternalMT.bar, ExternalMT.method_table
+        sleep(mtimedelay)
+        @test foo() == 1
+        @test bar() == 1
+        (; ms) = Base.MethodList(mt)
+        @test retval(first(ms)) == 2
+        write(joinpath(dn, "$name.jl"), second_revision(name))
+        sleep(mtimedelay)
+        @yry()
+        @test foo() == 1
+        @test bar() == 2
+        (; ms) = Base.MethodList(mt)
+        @test retval(first(ms)) == 3
+
+        file = tempname() * ".jl"
+        name = unique_name(:ExternalMT_includet)
+        write(file, first_revision(name))
+        sleep(mtimedelay)
+        Revise.track(@__MODULE__(), file; mode=:includet)
+        sleep(mtimedelay)
+        @eval import .$name
+        ExternalMT = @eval $name
+        foo, bar, mt = ExternalMT.foo, ExternalMT.bar, ExternalMT.method_table
+        sleep(mtimedelay)
+        @test foo() == 1
+        @test bar() == 1
+        (; ms) = Base.MethodList(mt)
+        @test retval(first(ms)) == 2
+        rm(file)
+        sleep(mtimedelay)
+        write(file, second_revision(name))
+        sleep(mtimedelay)
+        @yry()
+        @test foo() == 1
+        @test bar() == 2
+        (; ms) = Base.MethodList(mt)
+        @test retval(first(ms)) == 3
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3171,15 +3171,16 @@ end
         end
 
         function test_second_revision(mod::Module)
+            current_world_age = isdefined(Base, :tls_world_age) ? Base.tls_world_age() : Base.get_world_counter()
             @test mod.foo() == 1
             @test mod.bar() == 2
             @test isempty(methods(mod.baz))
             (; ms) = Base.MethodList(mod.method_table)
             @test length(ms) == 8 # cos/sin/sincos x2 + print/show
-            @test count(x -> x.deleted_world < Base.tls_world_age(), ms) == 4 # deleted cos/sin/sincos/show
+            @test count(x -> x.deleted_world < current_world_age, ms) == 4 # deleted cos/sin/sincos/show
             (; ms) = Base.MethodList(mod.method_table_2)
             @test length(ms) == 2 # foo x2
-            @test count(x -> x.deleted_world < Base.tls_world_age(), ms) == 1 # deleted foo
+            @test count(x -> x.deleted_world < current_world_age, ms) == 1 # deleted foo
             @test retval(first(ms)) == 3
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3165,10 +3165,10 @@ const issue639report = []
             @test isempty(methods(mod.baz))
             (; ms) = Base.MethodList(mod.method_table)
             @test length(ms) == 8 # cos/sin/sincos x2 + print/show
-            @test count(x -> x.deleted_world < current_world_age, ms) == 4 # deleted cos/sin/sincos/show
+            VERSION < v"1.12-" && @test count(x -> x.deleted_world < current_world_age, ms) == 4 # deleted cos/sin/sincos/show
             (; ms) = Base.MethodList(mod.method_table_2)
             @test length(ms) == 2 # foo x2
-            @test count(x -> x.deleted_world < current_world_age, ms) == 1 # deleted foo
+            VERSION < v"1.12-" && @test count(x -> x.deleted_world < current_world_age, ms) == 1 # deleted foo
             @test retval(first(ms)) == 3
         end
 

--- a/test/sigtest.jl
+++ b/test/sigtest.jl
@@ -88,8 +88,8 @@ module Lowering end
             end
         end
     end
-    sigs, _ = Revise.eval_with_signatures(Lowering, ex)
-    @test length(sigs) >= 2
+    mt_sigs, _ = Revise.eval_with_signatures(Lowering, ex)
+    @test length(mt_sigs) >= 2
 end
 
 try # Suppress world age increments, since the instantiation messes with base


### PR DESCRIPTION
In conjunction with [`CodeTracking.MapExprFile`](https://github.com/timholy/CodeTracking.jl/pull/144), this allows Revise to track
changes in files that are included with `include(mapexpr, file)`. This
PR supports the implementation of revisions for such files, properly
applying the `mapexpr` transformation to the included file's
expressions.

What's missing:
- Revise can't correctly populate the internal data structures needed to
  initiate `mapexpr` without help. The problem is that Revise only
  parses files that get edited, but discovering that `file2.jl` gets
  included from `file1.jl` via a `mapexpr` requires parsing `file1.jl`,
  which may not have been edited and therefore never scanned via Revise.
  The right way to fix this is in Julia itself, writing additional info
  to the package cache header. This will not land before Julia 1.13.
- `include(mapexpr, file)` is well-suited to include the same file more
  than once with different `mapexpr`s. While it hasn't been tested, this
  seems unlikely to work for now, and the anticipated problems stem all
  the way back to Julia itself (again, issues that should be fixed in
  the package cache header).

Package authors who want to use this in their packages can add a call to
`Revise.parseall(@__MODULE__)` in their `__init__` function to
ensure that the `mapexpr` files are parsed and tracked by Revise.

Fixes #820, #634

Note this is built on #904 so the diff will be confusing unless you look at only the final commit.