### PR TITLE
Fix intermittent Base CI failure due to misdetected juliadir

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -176,11 +176,20 @@ It's used to track non-precompiled packages and, optionally, user scripts (see d
 const included_files = Tuple{Module,String}[]  # (module, filename)
 
 """
+    expected_juliadir()
+
+This is the path where we ordinarily expect to find a copy of the julia source files,
+as well as the source cache. For `juliadir` we additionally search some fallback
+locations to handle various corrupt and incomplete installations.
+"""
+expected_juliadir() = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia")
+
+"""
     Revise.basesrccache
 
 Full path to the running Julia's cache of source code defining `Base`.
 """
-const basesrccache = normpath(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "base.cache"))
+const basesrccache = normpath(joinpath(expected_juliadir(), "base.cache"))
 
 """
     Revise.basebuilddir
@@ -193,8 +202,7 @@ const basebuilddir = begin
     dirname(dirname(sysimg))
 end
 
-function fallback_juliadir()
-    candidate = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia")
+function fallback_juliadir(candidate = expected_juliadir())
     if !isdir(joinpath(candidate, "base"))
         while true
             trydir = joinpath(candidate, "base")
@@ -212,18 +220,31 @@ function fallback_juliadir()
     normpath(candidate)
 end
 
+function find_juliadir()
+    candidate = expected_juliadir()
+    isdir(candidate) && return normpath(candidate)
+    # Couldn't find julia dir in the expected place.
+    # Let's look in the source build also - it's possible that the Makefile didn't
+    # set up the symlinks.
+    # N.B.: We need to make sure here that the julia we're running is actually
+    # the one being built. It's very common on buildbots that the original build
+    # dir exists, but is a different julia that is currently being built.
+    if Sys.BINDIR == joinpath(basebuilddir, "usr", "bin")
+        return normpath(basebuilddir)
+    end
+
+    @warn "Unable to find julia source directory in the expected places.\n
+           Looking in fallback locations. If this happens on a non-development build, please file an issue."
+    return fallback_juliadir(candidate)
+end
+
 """
     Revise.juliadir
 
 Constant specifying full path to julia top-level source directory.
 This should be reliable even for local builds, cross-builds, and binary installs.
 """
-global juliadir::String =
-    if isdir(joinpath(basebuilddir, "base"))
-        basebuilddir
-    else
-        fallback_juliadir()  # Binaries probably end up here. We fall back on Sys.BINDIR
-    end |> normpath
+global juliadir::String = find_juliadir()
 
 const cache_file_key = Dict{String,String}() # corrected=>uncorrected filenames
 const src_file_key   = Dict{String,String}() # uncorrected=>corrected filenames


### PR DESCRIPTION
We have an intermittent Revise test failure in Julia base CI, e.g. https://buildkite.com/organizations/julialang/pipelines/julia-master/builds/49637/jobs/0198728e-c6d1-4db8-8dd8-84eb87f72c6d/log
```
7-element Vector{Tuple{String, String}}:
 ("/cache/build/builder-amdci5-3/julialang/julia-master/base/./build_h.jl", "/cache/build/builder-amdci5-3/julialang/julia-master/base/build_h.jl")
 ("/cache/build/builder-amdci5-3/julialang/julia-master/base/./version_git.jl", "/cache/build/builder-amdci5-3/julialang/julia-master/base/version_git.jl")
 ("/cache/build/builder-amdci5-3/julialang/julia-master/base/./pcre_h.jl", "/cache/build/builder-amdci5-3/julialang/julia-master/base/pcre_h.jl")
 ("/cache/build/builder-amdci5-3/julialang/julia-master/base/./errno_h.jl", "/cache/build/builder-amdci5-3/julialang/julia-master/base/errno_h.jl")
 ("/cache/build/builder-amdci5-3/julialang/julia-master/base/./uv_constants.jl", "/cache/build/builder-amdci5-3/julialang/julia-master/base/uv_constants.jl")
 ("/cache/build/builder-amdci5-3/julialang/julia-master/base/./file_constants.jl", "/cache/build/builder-amdci5-3/julialang/julia-master/base/file_constants.jl")
 ("/cache/build/builder-amdci5-3/julialang/julia-master/base/features_h.jl", "/cache/build/builder-amdci5-3/julialang/julia-master/base/features_h.jl")
```

The apparent cause is that the Revise test job runs on the same node that built the original binary. Upon further investigation, that cause is apparent - when setting `juliadir`, we only check whether the original build dir exists, not whether it actually belongs to the julia executable we're testing. On the buildbots, they will happily accept the next build job, causing the path to exist again (in the same location), but actually we're not testing a source build. Fix this by always trying to use the canonical build directory (which should be created by the build system), even in a source build. If it doesn't exist (e.g. because the build systme ran incompletely), we try to fallback to the original directory. If an only if `Sys.BINDIR` points to where it would in an ordinary source build. Lastly we fall back to the ascending search procedure, though I'm a bit skeptical about it, since it could easily find the wrong installation. I added a warning for users to let us know if they encounter this frequently.