### PR TITLE
Force revise() after Revise.track

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1,14 +1,14 @@
 """
-    Revise.track(Base; revise_throw::Bool=false)
-    Revise.track(Core.Compiler; revise_throw::Bool=false)
-    Revise.track(stdlib; revise_throw::Bool=false)
+    Revise.track(Base; revise_throw::Bool=!isinteractive())
+    Revise.track(Core.Compiler; revise_throw::Bool=!isinteractive())
+    Revise.track(stdlib; revise_throw::Bool=!isinteractive())
 
 Track updates to the code in Julia's `base` directory, `base/compiler`, or one of its
 standard libraries. Calls `revise()` after tracking to ensure that any changes
 detected during tracking are applied immediately. Optionally, if `revise_throw` is
 `true`, `revise()` will throw if any exceptions are encountered while revising.
 """
-function track(mod::Module; modified_files=revision_queue, revise_throw::Bool=false)
+function track(mod::Module; modified_files=revision_queue, revise_throw::Bool=!isinteractive())
     id = Base.moduleroot(mod) == Core.Compiler ?
         PkgId(mod, "Core.Compiler") :
         PkgId(mod)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -11,7 +11,9 @@ function track(mod::Module; modified_files=revision_queue)
         PkgId(mod, "Core.Compiler") :
         PkgId(mod)
     modname = nameof(mod)
-    return _track(id, modname; modified_files=modified_files)
+    ret = _track(id, modname; modified_files=modified_files)
+    revise() # force revision so following calls in the same block work
+    return ret
 end
 
 const vstring = "v$(VERSION.major).$(VERSION.minor)"

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1,19 +1,20 @@
 """
-    Revise.track(Base)
-    Revise.track(Core.Compiler)
-    Revise.track(stdlib)
+    Revise.track(Base; revise_throw::Bool=false)
+    Revise.track(Core.Compiler; revise_throw::Bool=false)
+    Revise.track(stdlib; revise_throw::Bool=false)
 
 Track updates to the code in Julia's `base` directory, `base/compiler`, or one of its
 standard libraries. Calls `revise()` after tracking to ensure that any changes
-detected during tracking are applied immediately.
+detected during tracking are applied immediately. Optionally, if `revise_throw` is
+`true`, `revise()` will throw if any exceptions are encountered while revising.
 """
-function track(mod::Module; modified_files=revision_queue)
+function track(mod::Module; modified_files=revision_queue, revise_throw::Bool=false)
     id = Base.moduleroot(mod) == Core.Compiler ?
         PkgId(mod, "Core.Compiler") :
         PkgId(mod)
     modname = nameof(mod)
     ret = _track(id, modname; modified_files=modified_files)
-    revise() # force revision so following calls in the same block work
+    revise(; throw=revise_throw) # force revision so following calls in the same block work
     return ret
 end
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -4,7 +4,8 @@
     Revise.track(stdlib)
 
 Track updates to the code in Julia's `base` directory, `base/compiler`, or one of its
-standard libraries.
+standard libraries. Calls `revise()` after tracking to ensure that any changes
+detected during tracking are applied immediately.
 """
 function track(mod::Module; modified_files=revision_queue)
     id = Base.moduleroot(mod) == Core.Compiler ?


### PR DESCRIPTION
Fixes
```
% ./julia -E 'using Revise; Revise.track(Base); Base.Threads.foo()' 
ERROR: UndefVarError: `foo` not defined in `Base.Threads`
```

PR
```
% ./julia -E 'using Revise; Revise.track(Base); Base.Threads.foo()'
1
```