### PR TITLE
implement basic extension system for `pkgdatas`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.10.0"
+version = "3.11.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -17,6 +17,7 @@ Revise.tracking_Main_includes
 
 ```@docs
 Revise.juliadir
+Revise.expected_juliadir
 Revise.basesrccache
 Revise.basebuilddir
 ```
@@ -152,4 +153,13 @@ Revise.git_repo
 
 ```@docs
 Revise.init_worker
+```
+
+## Extension system
+
+```@docs
+Revise.SigInfo
+Revise.ExtendedData
+Revise.get_extended_data
+Revise.replace_extended_data
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -256,7 +256,7 @@ const issue639report = []
         @test length(dvs) == 3
         (def, val) = dvs[1]
         @test isequal(Revise.unwrap(def), Revise.RelocatableExpr(:(square(x) = x^2)))
-        @test val == [nothing => Tuple{typeof(ReviseTest.square),Any}]
+        @test val == [Revise.SigInfo(nothing, Tuple{typeof(ReviseTest.square),Any})]
         @test Revise.firstline(Revise.unwrap(def)).line == 5
         m = @which ReviseTest.square(1)
         @test m.line == 5
@@ -264,14 +264,14 @@ const issue639report = []
         @test Revise.RelocatableExpr(definition(m)) == Revise.unwrap(def)
         (def, val) = dvs[2]
         @test isequal(Revise.unwrap(def), Revise.RelocatableExpr(:(cube(x) = x^3)))
-        @test val == [nothing => Tuple{typeof(ReviseTest.cube),Any}]
+        @test val == [Revise.SigInfo(nothing, Tuple{typeof(ReviseTest.cube),Any})]
         m = @which ReviseTest.cube(1)
         @test m.line == 7
         @test whereis(m) == (tmpfile, 7)
         @test Revise.RelocatableExpr(definition(m)) == Revise.unwrap(def)
         (def, val) = dvs[3]
         @test isequal(Revise.unwrap(def), Revise.RelocatableExpr(:(fourth(x) = x^4)))
-        @test val == [nothing => Tuple{typeof(ReviseTest.fourth),Any}]
+        @test val == [Revise.SigInfo(nothing, Tuple{typeof(ReviseTest.fourth),Any})]
         m = @which ReviseTest.fourth(1)
         @test m.line == 9
         @test whereis(m) == (tmpfile, 9)
@@ -281,7 +281,7 @@ const issue639report = []
         @test length(dvs) == 5
         (def, val) = dvs[1]
         @test isequal(Revise.unwrap(def),  Revise.RelocatableExpr(:(mult2(x) = 2*x)))
-        @test val == [nothing => Tuple{typeof(ReviseTest.Internal.mult2),Any}]
+        @test val == [Revise.SigInfo(nothing, Tuple{typeof(ReviseTest.Internal.mult2),Any})]
         @test Revise.firstline(Revise.unwrap(def)).line == 13
         m = @which ReviseTest.Internal.mult2(1)
         @test m.line == 11
@@ -289,7 +289,7 @@ const issue639report = []
         @test Revise.RelocatableExpr(definition(m)) == Revise.unwrap(def)
         (def, val) = dvs[2]
         @test isequal(Revise.unwrap(def), Revise.RelocatableExpr(:(mult3(x) = 3*x)))
-        @test val == [nothing => Tuple{typeof(ReviseTest.Internal.mult3),Any}]
+        @test val == [Revise.SigInfo(nothing, Tuple{typeof(ReviseTest.Internal.mult3),Any})]
         m = @which ReviseTest.Internal.mult3(1)
         @test m.line == 14
         @test whereis(m) == (tmpfile, 14)
@@ -317,10 +317,10 @@ const issue639report = []
         cmpdiff(logs[4], "Eval"; deltainfo=(ReviseTest, :(cube(x) = x^3)))
         cmpdiff(logs[5], "Eval"; deltainfo=(ReviseTest, :(fourth(x) = x^4)))
         stmpfile = Symbol(tmpfile)
-        cmpdiff(logs[6], "LineOffset"; deltainfo=(Any[nothing => Tuple{typeof(ReviseTest.Internal.mult2),Any}], LineNumberNode(11,stmpfile)=>LineNumberNode(13,stmpfile)))
+        cmpdiff(logs[6], "LineOffset"; deltainfo=(Any[Revise.SigInfo(nothing, Tuple{typeof(ReviseTest.Internal.mult2),Any})], LineNumberNode(11,stmpfile)=>LineNumberNode(13,stmpfile)))
         cmpdiff(logs[7], "Eval"; deltainfo=(ReviseTest.Internal, :(mult3(x) = 3*x)))
-        cmpdiff(logs[8], "LineOffset"; deltainfo=(Any[nothing => Tuple{typeof(ReviseTest.Internal.unchanged),Any}], LineNumberNode(18,stmpfile)=>LineNumberNode(19,stmpfile)))
-        cmpdiff(logs[9], "LineOffset"; deltainfo=(Any[nothing => Tuple{typeof(ReviseTest.Internal.unchanged2),Any}], LineNumberNode(20,stmpfile)=>LineNumberNode(21,stmpfile)))
+        cmpdiff(logs[8], "LineOffset"; deltainfo=(Any[Revise.SigInfo(nothing, Tuple{typeof(ReviseTest.Internal.unchanged),Any})], LineNumberNode(18,stmpfile)=>LineNumberNode(19,stmpfile)))
+        cmpdiff(logs[9], "LineOffset"; deltainfo=(Any[Revise.SigInfo(nothing, Tuple{typeof(ReviseTest.Internal.unchanged2),Any})], LineNumberNode(20,stmpfile)=>LineNumberNode(21,stmpfile)))
         @test length(Revise.actions(rlogger)) == 6  # by default LineOffset is skipped
         @test length(Revise.actions(rlogger; line=true)) == 9
         @test_broken length(Revise.diffs(rlogger)) == 2
@@ -496,8 +496,8 @@ const issue639report = []
                 m3 = first(methods(eval(fn3)))
                 m3file = joinpath(dn, "subdir", "file3.jl")
                 @test whereis(m3) == (m3file, 1)
-                @test signatures_at(m3file, 1) == [nothing => m3.sig]
-                @test signatures_at(eval(Symbol(modname)), joinpath("src", "subdir", "file3.jl"), 1) == [nothing => m3.sig]
+                @test signatures_at(m3file, 1) == [Revise.SigInfo(nothing, m3.sig)]
+                @test signatures_at(eval(Symbol(modname)), joinpath("src", "subdir", "file3.jl"), 1) == [Revise.SigInfo(nothing, m3.sig)]
 
                 id = Base.PkgId(eval(Symbol(modname)))   # for testing #596
                 pkgdata = Revise.pkgdatas[id]
@@ -1902,8 +1902,8 @@ const issue639report = []
         ex2 = :(methspecificity(x::Integer) = 2)
         Core.eval(ReviseTestPrivate, ex1)
         Core.eval(ReviseTestPrivate, ex2)
-        exsig1 = Revise.RelocatableExpr(ex1) => [nothing => Tuple{typeof(ReviseTestPrivate.methspecificity),Int}]
-        exsig2 = Revise.RelocatableExpr(ex2) => [nothing => Tuple{typeof(ReviseTestPrivate.methspecificity),Integer}]
+        exsig1 = Revise.RelocatableExpr(ex1) => [Revise.SigInfo(nothing, Tuple{typeof(ReviseTestPrivate.methspecificity),Int})]
+        exsig2 = Revise.RelocatableExpr(ex2) => [Revise.SigInfo(nothing, Tuple{typeof(ReviseTestPrivate.methspecificity),Integer})]
         f_old, f_new = Revise.ExprsSigs(exsig1, exsig2), Revise.ExprsSigs(exsig2)
         Revise.delete_missing!(f_old, f_new)
         m = @which ReviseTestPrivate.methspecificity(1)


### PR DESCRIPTION
We are currently implementing an incremental analysis system for JET and JETLS by integrating them with Revise. We considered other approaches such as implementing their own Revise-like system on the JET[LS] side (e.g. timholy/Revise.jl#938), but concluded that implementing incremental analysis by making Revise itself extensible would be better in terms of implementation reliability and future maintenance costs.

This commit implements the first step towards this goal by extending Revise's most important data structure `pkgdatas` to hold custom data and providing utilities for interacting with it. Specifically, this commit extends the leaf nodes of the `pkgdatas` data structure, `MethodInfoKey(method_table => signature)`, to a new data structure `SigInfo(method_table, signature, ext_data::ExtendedData)`.

`SigInfo` is defined as follows:
```julia
struct SigInfo
    mt::Union{Nothing,MethodTable}
    sig::Type
    ext::ExtendedData
end

struct ExtendedData
    owner::Symbol
    data::Any
    next::ExtendedData
    ExtendedData(owner::Symbol, data, next::ExtendedData) = new(owner, data, next)
    ExtendedData(owner::Symbol, data) = new(owner, data)
    ExtendedData() = new(:Revise, nothing)
end
```

As seen from the type definition, `SigInfo` can hold `ExtendedData` in addition to the information that the conventional `MethodInfoKey` holds. `ExtendedData` is implemented as a linked list, enabling safe data management per owner through the `owner` field (similar to `Core.CodeInstance` design).

We also implement the following utility functions for getting or replacing `ext_data`:
- `get_extended_data(ext::ExtendedData, owner::Symbol) -> ext::Union{ExtendedData,Nothing}`
- `get_extended_data(siginfo::SigInfo, owner::Symbol) -> ext::Union{ExtendedData,Nothing}`
- `replace_extended_data(ext::ExtendedData, owner::Symbol, data) -> new_ext::ExtendedData`
- `replace_extended_data(siginfo::SigInfo, owner::Symbol, data) -> new_siginfo::SigInfo`

This commit implements these simple extension setup only. To actually use this extension system, external packages need to decide when to inspect `Revise.pkgdatas` by themselves and use functions like `replace_extended_data` to hold custom data. While packages using this extension system and Revise's revision pipeline are not tightly synchronized, stale `SigInfo` objects are automatically removed, enabling minimal external incremental systems. Specifically, using this commit, we can replace `JET.report_package` with a Revise-based implementation and make it incremental (aviatesk/JET.jl#763).

In the future, we may need to set up some callbacks in Revise's revision pipeline to allow external packages to customize in sync with Revise's revision pipeline. However, since the necessary requirements are still unclear at the current stage of extending `JET.report_package`, this commit does not implement them.