### PR TITLE
use `Base.Event` instead of `Base.Condition` for `revision_event`

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,11 +1,11 @@
 # Globals needed to support `entr` and other callbacks
 
 """
-    Revise.revision_event
+    Revise.revision_event::Base.Event
 
-This `Condition` is used to notify `entr` that one of the watched files has changed.
+This event is used to notify `entr` that one of the watched files has changed.
 """
-const revision_event = Condition()
+const revision_event = Base.Event()
 
 """
     Revise.user_callbacks_queue
@@ -160,6 +160,7 @@ function entr(f::Function, files, modules=nothing; all=false, postpone=false, pa
     try
         while true
             wait(revision_event)
+            reset(revision_event)
             revise(throw=true)
         end
     catch err

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4101,4 +4101,7 @@ end
 
 # Run this test in a separate julia process, since it messes with projects, and we don't want to have to
 # worry about making sure it resets cleanly.
-do_test("Switch Versions") && @test success(pipeline(`$(Base.julia_cmd()) switch_version.jl`, stderr=stderr))
+do_test("Switch Versions") && let
+    switch_version = normpath(@__DIR__, "switch_version.jl")
+    @test success(pipeline(`$(Base.julia_cmd()) $switch_version`, stderr=stderr))
+end

--- a/test/switch_version.jl
+++ b/test/switch_version.jl
@@ -29,6 +29,7 @@ mktempdir() do thisdir
         t = @async run(pipeline(Cmd(`$(Base.julia_cmd()) -e $v2_cmd`; dir=$thisdir); stderr, stdout))
         isdefined(Base, :errormonitor) && Base.errormonitor(t)
         wait(Revise.revision_event)
+        reset(Revise.revision_event)
         revise()
         @latestworld
         @test PkgChange.somemethod() === 1   # present in v2
@@ -37,6 +38,7 @@ mktempdir() do thisdir
         t = @async run(pipeline(Cmd(`$(Base.julia_cmd()) -e $v1_cmd`; dir=$thisdir); stderr, stdout))
         isdefined(Base, :errormonitor) && Base.errormonitor(t)
         wait(Revise.revision_event)
+        reset(Revise.revision_event)
         revise()
         @latestworld
         @test_throws MethodError PkgChange.somemethod() # not present in v1


### PR DESCRIPTION
`Base.Condition` is not thread-safe, causing errors like "lock must be held" when `revise()` is called multithreaded. While `Threads.Condition` could be used, `Base.Event` provides a simpler approach to achieve thread-safety, so the code has been rewritten to use it instead.