### PR TITLE
Update IJulia integration

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -34,25 +34,11 @@ is recommended instead.
 
 ### Using Revise automatically within Jupyter/IJulia
 
-If you want Revise to launch automatically within IJulia, then you should also create a `.julia/config/startup_ijulia.jl` file with the contents
-
-```julia
-try
-    @eval using Revise
-catch e
-    @warn "Error initializing Revise" exception=(e, catch_backtrace())
-end
-```
-or simply run
-```bash
-mkdir -p ~/.julia/config/ && tee -a  ~/.julia/config/startup_ijulia.jl << END
-try
-    @eval using Revise
-catch e
-    @warn "Error initializing Revise" exception=(e, catch_backtrace())
-end
-END
-```
+IJulia has an integration with Revise and will automatically add it as a
+[preexecute
+hook](https://julialang.github.io/IJulia.jl/stable/library/public/#IJulia.push_preexecute_hook)
+if Revise is loaded (e.g. through your `startup.jl`), *unless* the
+`JULIA_REVISE` environment variable is set to something other than `auto`.
 
 ## [Editor configuration](@id edcfg)
 


### PR DESCRIPTION
- Removed the automatic preexecute hook, IJulia will soon do this automatically in all cases through a package extension (https://github.com/JuliaLang/IJulia.jl/pull/1220).
- Removed the recommendation of using `startup_ijulia.jl`. This is not necessary since IJulia will already use Revise from `startup.jl` if it's set. And if Revise is loaded only through `startup_ijulia.jl` then IJulia will end up adding a duplicate preexecute hook.

A secondary reason I'd like to discourage `startup_ijulia.jl` is because I've observed it to increase the startup time and invalidations compared to having Revise in `startup.jl`, I assume because `startup.jl` is loaded very early. To be completely safe this shouldn't be merged before https://github.com/JuliaLang/IJulia.jl/pull/1220 gets into a release, though realistically I think everyone uses Revise through a startup file rather than by `using Revise` in a notebook so it likely won't hurt to merge it beforehand.

Also see https://github.com/JuliaLang/IJulia.jl/pull/708 and https://github.com/timholy/Revise.jl/pull/12.