### PR TITLE
Making Revise relocatable

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -262,7 +262,7 @@ See also [`Revise.silence`](@ref).
 """
 const dont_watch_pkgs = Set{Symbol}()
 const silence_pkgs = Set{Symbol}()
-const depsdir::String
+global depsdir::String
 const silencefile = Ref{String}()  # Ref so that tests don't clobber
 
 ##


### PR DESCRIPTION
Currently, Revise hardcodes paths at compilation time, which prevents its pkgimage cache from being relocatable. This creates issues when forming Julia distributions like Jumbo that need relocatable package caches.

This PR addresses the issue by converting the hardcoded path constants to uninitialized globals that are assigned in the `__init__` function instead. Limited testing shows that the relocated Revise works fine with this approach.