### PR TITLE
update for CodeTracking v3 (`MethodInfoKey` struct change)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,10 +24,10 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DistributedExt = "Distributed"
 
 [compat]
-CodeTracking = "2"
+CodeTracking = "3"
 Distributed = "1"
-JuliaInterpreter = "0.10"
-LoweredCodeUtils = "3.4.3"
+JuliaInterpreter = "0.10.8"
+LoweredCodeUtils = "3.5"
 OrderedCollections = "1"
 # Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94
 Requires = "~1.0, ^1.1.1"

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -187,7 +187,7 @@ end)))
             x ^ 4
         end
 end)))
- Revise.LogRecord(Debug, LineOffset, Action, Revise_fcadbd44, "/home/tim/.julia/dev/Revise/src/packagedef.jl", 369, (time=1.753703251787128e9, deltainfo=(Pair{Union{Nothing, Core.MethodTable}, Type}[nothing => Tuple{typeof(Main.ReviseTest.Internal.mult2), Any}], :(#= /tmp/revisetest.jl:11 =#) => :(#= /tmp/revisetest.jl:13 =#))))
+ Revise.LogRecord(Debug, LineOffset, Action, Revise_fcadbd44, "/home/tim/.julia/dev/Revise/src/packagedef.jl", 369, (time=1.753703251787128e9, deltainfo=(CodeTracking.MethodInfoKey[CodeTracking.MethodInfoKey(nothing, Tuple{typeof(Main.ReviseTest.Internal.mult2), Any})], :(#= /tmp/revisetest.jl:11 =#) => :(#= /tmp/revisetest.jl:13 =#))))
  Revise.LogRecord(Debug, Eval, Action, Revise_9147188b, "/home/tim/.julia/dev/Revise/src/packagedef.jl", 347, (time=1.753703251793889e9, deltainfo=(Main.ReviseTest.Internal, quote
     #= /tmp/revisetest.jl:14 =#
     mult3(x) = begin
@@ -195,8 +195,8 @@ end)))
             3x
         end
 end)))
- Revise.LogRecord(Debug, LineOffset, Action, Revise_fcadbd44, "/home/tim/.julia/dev/Revise/src/packagedef.jl", 369, (time=1.753703251795383e9, deltainfo=(Pair{Union{Nothing, Core.MethodTable}, Type}[nothing => Tuple{typeof(Main.ReviseTest.Internal.unchanged), Any}], :(#= /tmp/revisetest.jl:18 =#) => :(#= /tmp/revisetest.jl:19 =#))))
- Revise.LogRecord(Debug, LineOffset, Action, Revise_fcadbd44, "/home/tim/.julia/dev/Revise/src/packagedef.jl", 369, (time=1.753703251795399e9, deltainfo=(Pair{Union{Nothing, Core.MethodTable}, Type}[nothing => Tuple{typeof(Main.ReviseTest.Internal.unchanged2), Any}], :(#= /tmp/revisetest.jl:20 =#) => :(#= /tmp/revisetest.jl:21 =#))))
+ Revise.LogRecord(Debug, LineOffset, Action, Revise_fcadbd44, "/home/tim/.julia/dev/Revise/src/packagedef.jl", 369, (time=1.753703251795383e9, deltainfo=(CodeTracking.MethodInfoKey[CodeTracking.MethodInfoKey(nothing, Tuple{typeof(Main.ReviseTest.Internal.unchanged), Any})], :(#= /tmp/revisetest.jl:18 =#) => :(#= /tmp/revisetest.jl:19 =#))))
+ Revise.LogRecord(Debug, LineOffset, Action, Revise_fcadbd44, "/home/tim/.julia/dev/Revise/src/packagedef.jl", 369, (time=1.753703251795399e9, deltainfo=(CodeTracking.MethodInfoKey[CodeTracking.MethodInfoKey(nothing, Tuple{typeof(Main.ReviseTest.Internal.unchanged2), Any})], :(#= /tmp/revisetest.jl:20 =#) => :(#= /tmp/revisetest.jl:21 =#))))
 ```
 
 Perhaps the most useful component of this is the timing information, as it gives clues to what you might have been doing to trigger revisions.

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -228,7 +228,7 @@ Two "maps" are central to Revise's inner workings: `ExprsSigs` maps link
 definition=>signature-types (the forward workflow), while `CodeTracking` (specifically,
 its internal variable `method_info`) links from a
 method table/signature-type pair to the corresponding definition (the backward workflow).
-Concretely, `CodeTracking.method_info` is just an `IdDict` mapping `(mt => sigt) => (locationinfo, def)`.
+Concretely, `CodeTracking.method_info` is just an `IdDict` mapping `MethodInfoKey(mt, sigt) => (locationinfo, def)`.
 Of note, a stack frame typically contains a link to a method, which stores the equivalent
 of `sigt`; consequently, this information allows one to look up the corresponding
 `locationinfo` and `def`. (When methods move, the location information stored by CodeTracking
@@ -338,9 +338,9 @@ This is just a summary; to see the actual `def=>mt_sigts` map, do the following:
 
 ```julia-repl
 julia> pkgdata.fileinfos[2].modexsigs[Items]
-OrderedCollections.OrderedDict{Module, OrderedCollections.OrderedDict{Revise.RelocatableExpr, Union{Nothing, Vector{Pair{Union{Nothing, Core.MethodTable}, Type}}}}} with 2 entries:
-  :(indent(::UInt16) = begin…                       => Pair{Union{Nothing, MethodTable}, Type}[nothing => Tuple{typeof(indent),UInt16}]
-  :(indent(::UInt8) = begin…                        => Pair{Union{Nothing, MethodTable}, Type}[nothing => Tuple{typeof(indent),UInt8}]
+OrderedCollections.OrderedDict{Module, OrderedCollections.OrderedDict{Revise.RelocatableExpr, Union{Nothing, Vector{CodeTracking.MethodInfoKey}}}} with 2 entries:
+  :(indent(::UInt16) = begin…                       => CodeTracking.MethodInfoKey[CodeTracking.MethodInfoKey(nothing, Tuple{typeof(indent),UInt16})]
+  :(indent(::UInt8) = begin…                        => CodeTracking.MethodInfoKey[CodeTracking.MethodInfoKey(nothing, Tuple{typeof(indent),UInt8})]
 ```
 
 These are populated now because we specified `__precompile__(false)`, which forces


### PR DESCRIPTION
CodeTracking v3.0.0 changed `MethodInfoKey` from a `Pair` type alias to a proper struct. This updates the compat bound and documentation examples to reflect the new representation.