### PR TITLE
Adjust for base paths possibly being non-normalized

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -928,7 +928,7 @@ function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
     id = Base.moduleroot(mod) == Main ? PkgId(mod, string(mod)) : PkgId(mod)  # see #689 for `Main`
     if haskey(pkgdatas, id)
         pkgdata = pkgdatas[id]
-        relfile = relpath(file, pkgdata)
+        relfile = relpath(abspath_no_normalize(file), pkgdata)
         hasfile(pkgdata, relfile) && return nothing
         # Use any "fixes" provided by relpath
         file = joinpath(basedir(pkgdata), relfile)
@@ -939,7 +939,7 @@ function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
             nameof(mod) === :Plots || Base.depwarn("Revise@2.4 or higher automatically handles `include` statements in `@require` expressions.\nPlease do not call `Revise.track` from such blocks.", :track)
             return nothing
         end
-        file = realpath(file)
+        file = abspath_no_normalize(file)
     end
     # Set up tracking
     mod_exs_sigs = parse_source(file, mod; mode)
@@ -954,8 +954,7 @@ function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
         end
         pkgdata = get(pkgdatas, id, nothing)
         if pkgdata === nothing
-            modpath = pathof(mod)
-            pkgdata = PkgData(id, modpath === nothing ? nothing : realpath(modpath))
+            pkgdata = PkgData(id, pathof(mod))
         end
         if !haskey(CodeTracking._pkgfiles, id)
             CodeTracking._pkgfiles[id] = pkgdata.info

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -362,7 +362,7 @@ function has_writable_paths(pkgdata::PkgData)
 end
 
 function watch_includes(mod::Module, fn::AbstractString)
-    @lock included_files_lock push!(included_files, (mod, realpath(fn)))
+    @lock included_files_lock push!(included_files, (mod, abspath_no_normalize(fn)))
 end
 
 ## Working with Pkg and code-loading
@@ -390,7 +390,6 @@ function manifest_paths!(pkgpaths::Dict, manifest_file::String)
         for entry in entries
             id = PkgId(UUID(entry["uuid"]::String), name)
             path = Base.explicit_manifest_entry_path(manifest_file, id, entry)
-            ispath(path) && (path = realpath(path))
             if path isa String
                 if isfile(path)
                     # Workaround for #802

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -65,7 +65,7 @@ function _track(id::PkgId, modname::Symbol; modified_files=revision_queue)
         # note any modified since Base was built
         pkgdata = get(pkgdatas, id, nothing)
         if pkgdata === nothing
-            pkgdata = PkgData(id, realpath(srcdir))
+            pkgdata = PkgData(id, srcdir)
         end
         lock(revision_queue_lock) do
             for (submod, filename) in Iterators.drop(Base._included_files, 1)  # stepping through sysimg.jl rebuilds Base, omit it
@@ -99,7 +99,7 @@ function _track(id::PkgId, modname::Symbol; modified_files=revision_queue)
         isdir(compilerdir) || (compilerdir = compilerdir_pre_112)
         pkgdata = get(pkgdatas, id, nothing)
         if pkgdata === nothing
-            pkgdata = PkgData(id, realpath(compilerdir))
+            pkgdata = PkgData(id, compilerdir)
         end
         track_subdir_from_git!(pkgdata, compilerdir; modified_files=modified_files)
         # insertion into pkgdatas is done by track_subdir_from_git!

--- a/src/types.jl
+++ b/src/types.jl
@@ -259,8 +259,8 @@ PkgData(id::PkgId, path) = PkgData(PkgFiles(id, path), FileInfo[], PkgId[])
 PkgData(id::PkgId, ::Nothing) = PkgData(id, "")
 function PkgData(id::PkgId)
     bp = basepath(id)
-    if !isempty(bp) && ispath(bp)
-        bp = realpath(bp)
+    if !isempty(bp) && !isabspath(bp)
+        bp = abspath(bp)
     end
     PkgData(id, bp)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,11 @@
-relpath_safe(path::AbstractString, startpath::AbstractString) = isempty(startpath) ? path :
-                                                                ispath(path)       ? relpath(realpath(path), startpath) :
-                                                                                     relpath(path, startpath)
+function relpath_safe(path::AbstractString, startpath::AbstractString)
+    isempty(startpath) && return path
+    if ispath(path)
+        path = relpath(realpath(path), realpath(startpath))
+        !isabspath(path) && return path
+    end
+    return relpath(path, startpath)
+end
 
 function Base.relpath(filename::AbstractString, pkgdata::PkgData)
     if isabspath(filename)
@@ -23,6 +28,20 @@ function unique_dirs(iter)
         push!(udirs, dir)
     end
     return udirs
+end
+
+function abspath_no_normalize(a)
+    if !isabspath(a)
+        cwd = pwd()
+        a_drive, a_nodrive = splitdrive(a)
+        if a_drive != "" && lowercase(splitdrive(cwd)[1]) != lowercase(a_drive)
+            cwd = a_drive * path_separator
+            a = joinpath(cwd, a_nodrive)
+        else
+            a = joinpath(cwd, a)
+        end
+    end
+    return a
 end
 
 function file_exists(filename::AbstractString)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -499,7 +499,7 @@ const issue639report = []
                 @test Revise.RelocatableExpr(definition(m)) != rex
                 # CodeTracking methods
                 m3 = first(methods(eval(fn3)))
-                m3file = realpath(joinpath(dn, "subdir", "file3.jl"))
+                m3file = joinpath(dn, "subdir", "file3.jl")
                 w = whereis(m3)
                 @test samefile(w[1], m3file)
                 @test w[2] == 1


### PR DESCRIPTION
Fixes test failures with https://github.com/JuliaLang/julia/pull/60251. Also fixes an unrelated test where Revise was using the wrong PkgId for Core.Compiler (failure not seen on CI, because it's explicitly disabled there).