### PR TITLE
Remove Requires and Unicode as dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,7 @@ LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [weakdeps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"


### PR DESCRIPTION
Requires is never actually loaded by Revise, Revise only defines a function that can be called by Requires. Unicode is also not used at all.