### PR TITLE
Move REPL support into a package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,14 +14,15 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
-REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [weakdeps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [extensions]
 ReviseDistributedExt = "Distributed"
+ReviseREPLExt = "REPL"
 
 [compat]
 CodeTracking = "3"
@@ -31,6 +32,7 @@ JuliaInterpreter = "0.10.8"
 LoweredCodeUtils = "3.5"
 OrderedCollections = "1"
 Preferences = "1.5.0"
+REPL = "1"
 # Exclude Requires-1.1.0 - see https://github.com/JuliaPackaging/Requires.jl/issues/94
 Requires = "~1.0, ^1.1.1"
 julia = "1.10"
@@ -50,10 +52,11 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 RoundingIntegers = "d5f540fe-1c90-5db3-b776-2e2f362d9394"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [targets]
-test = ["CatIndices", "Distributed", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Pkg", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]
+test = ["CatIndices", "Distributed", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Pkg", "Random", "REPL", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [extensions]
-DistributedExt = "Distributed"
+ReviseDistributedExt = "Distributed"
 
 [compat]
 CodeTracking = "3"

--- a/ext/ReviseDistributedExt.jl
+++ b/ext/ReviseDistributedExt.jl
@@ -1,4 +1,4 @@
-module DistributedExt
+module ReviseDistributedExt
 
 import Distributed: myid, workers, remotecall
 

--- a/ext/ReviseREPLExt.jl
+++ b/ext/ReviseREPLExt.jl
@@ -1,0 +1,118 @@
+module ReviseREPLExt
+
+import REPL
+using Revise: Revise, revision_queue, revise, pkgdatas, pkgdatas_lock, PkgData, FileInfo,
+              ModuleExprsInfos, parse_source!, instantiate_sigs!, unwrap, isexpr, revise_first,
+              LoweredCodeUtils, is_quotenode_egal, @warnpcfail
+
+using Base: PkgId
+
+
+const original_repl_prefix = Ref{Union{String, Function, Nothing}}(nothing)
+
+Revise.revise(::REPL.REPLBackend) = revise()
+
+# Check if the active REPL backend is available
+active_repl_backend_available() = isdefined(Base, :active_repl_backend) && Base.active_repl_backend !== nothing
+
+function maybe_set_prompt_color_impl(color::Symbol)
+    if isdefined(Base, :active_repl)
+        repl = Base.active_repl
+        if isa(repl, REPL.LineEditREPL)
+            if color === :warn
+                # First save the original setting
+                if original_repl_prefix[] === nothing
+                    original_repl_prefix[] = repl.mistate.current_mode.prompt_prefix
+                end
+                repl.mistate.current_mode.prompt_prefix = "\e[33m"  # yellow
+            else
+                color = original_repl_prefix[]
+                color === nothing && return nothing
+                repl.mistate.current_mode.prompt_prefix = color
+                original_repl_prefix[] = nothing
+            end
+        end
+    end
+    return nothing
+end
+
+function add_definitions_from_repl_impl(filename::String)
+    hist_idx = parse(Int, filename[6:end-1])
+    hp = (Base.active_repl::REPL.LineEditREPL).interface.modes[1].hist::REPL.REPLHistoryProvider
+    src = hp.history[hp.start_idx+hist_idx]
+    id = PkgId(nothing, "@REPL")
+    pkgdata = pkgdatas[id]
+    mod_exs_infos = ModuleExprsInfos(Main::Module)
+    parse_source!(mod_exs_infos, src, filename, Main::Module)
+    instantiate_sigs!(mod_exs_infos)
+    fi = FileInfo(mod_exs_infos)
+    push!(pkgdata, filename=>fi)
+    return fi
+end
+add_definitions_from_repl_impl(filename::AbstractString) = add_definitions_from_repl_impl(convert(String, filename)::String)
+
+# `revise_first` gets called by the REPL prior to executing the next command (by having been pushed
+# onto the `ast_transform` list).
+# This uses invokelatest not for reasons of world age but to ensure that the call is made at runtime.
+# This allows `revise_first` to be compiled without compiling `revise` itself, and greatly
+# reduces the overhead of using Revise.
+function Revise.revise_first(ex)
+    # Special-case `exit()` (issue #562)
+    if isa(ex, Expr)
+        exu = unwrap(ex)
+        if isexpr(exu, :block, 2)
+            arg1 = exu.args[1]
+            if isexpr(arg1, :softscope)
+                exu = exu.args[2]
+            end
+        end
+        if isa(exu, Expr)
+            exu.head === :call && length(exu.args) == 1 && exu.args[1] === :exit && return ex
+            lhsrhs = LoweredCodeUtils.get_lhs_rhs(exu)
+            if lhsrhs !== nothing
+                lhs, _ = lhsrhs
+                if isexpr(lhs, :ref) && length(lhs.args) == 1
+                    arg1 = lhs.args[1]
+                    isexpr(arg1, :(.), 2) && arg1.args[1] === :Revise && is_quotenode_egal(arg1.args[2], :active) && return ex
+                end
+            end
+        end
+    end
+    # Check for queued revisions, and if so call `revise` first before executing the expression
+    return Expr(:toplevel, :($isempty($revision_queue) || $(Base.invokelatest)($revise)), ex)
+end
+
+function __init__()
+    # Set REPL functions in Revise
+    Revise.maybe_set_prompt_color = maybe_set_prompt_color_impl
+    Revise.add_definitions_from_repl = add_definitions_from_repl_impl
+
+    if Revise.should_enable_revise()
+        pushfirst!(REPL.repl_ast_transforms, revise_first)
+        # #664: once a REPL is started, it no longer interacts with REPL.repl_ast_transforms
+        if active_repl_backend_available()
+            push!(Base.active_repl_backend.ast_transforms, revise_first)
+        else
+            # wait for active_repl_backend to exist
+            # #719: do this async in case Revise is being loaded from startup.jl
+            t = @async begin
+                iter = 0
+                while !active_repl_backend_available() && iter < 20
+                    sleep(0.05)
+                    iter += 1
+                end
+                if active_repl_backend_available()
+                    push!(Base.active_repl_backend.ast_transforms, revise_first)
+                end
+            end
+            errormonitor(t)
+        end
+    end
+end
+
+@warnpcfail precompile(active_repl_backend_available, ())
+@warnpcfail precompile(maybe_set_prompt_color_impl, (Symbol,))
+@warnpcfail precompile(add_definitions_from_repl_impl, (String,))
+@warnpcfail precompile(revise_first, (Expr,))
+
+end

--- a/ext/ReviseREPLExt.jl
+++ b/ext/ReviseREPLExt.jl
@@ -1,12 +1,11 @@
 module ReviseREPLExt
 
-import REPL
-using Revise: Revise, revision_queue, revise, pkgdatas, pkgdatas_lock, PkgData, FileInfo,
-              ModuleExprsInfos, parse_source!, instantiate_sigs!, unwrap, isexpr, revise_first,
-              LoweredCodeUtils, is_quotenode_egal, @warnpcfail
-
+using REPL: REPL
 using Base: PkgId
-
+using Base.Meta: isexpr
+using Revise: @warnpcfail, FileInfo, LoweredCodeUtils, ModuleExprsInfos, Revise,
+    instantiate_sigs!, is_quotenode_egal, parse_source!, pkgdatas, revise, revise_first,
+    revision_queue, unwrap
 
 const original_repl_prefix = Ref{Union{String, Function, Nothing}}(nothing)
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -25,7 +25,6 @@ function _precompile_()
     @warnpcfail precompile(Tuple{typeof(watch_package_callback), PkgId})
 
     @warnpcfail precompile(Tuple{typeof(revise)})
-    @warnpcfail precompile(Tuple{typeof(revise_first), Expr})
     @warnpcfail precompile(Tuple{typeof(includet), String})
     @warnpcfail precompile(Tuple{typeof(track), Module, String})
     # setindex! doesn't fully precompile, but it's still beneficial to do it
@@ -73,7 +72,6 @@ function _precompile_()
         @warnpcfail precompile(Tuple{typeof(filter_valid_cachefiles), String, Vector{String}})
     end
     @warnpcfail precompile(Tuple{typeof(Revise.iswritable), String})
-    @warnpcfail precompile(Tuple{typeof(Revise.active_repl_backend_available)})
     @warnpcfail precompile(Tuple{typeof(pkg_fileinfo), PkgId})
     @warnpcfail precompile(Tuple{typeof(push!), WatchList, Pair{String,PkgId}})
     @warnpcfail precompile(Tuple{typeof(pushex!), ExprsInfos, Expr})

--- a/test/start_late.jl
+++ b/test/start_late.jl
@@ -12,7 +12,7 @@ while !isdefined(Base, :active_repl_backend) || isnothing(Base.active_repl_backe
     sleep(0.5)
 end
 
-using Revise
+using Revise, REPL
 @test Revise.revise_first ∈ Base.active_repl_backend.ast_transforms
 
 exit()


### PR DESCRIPTION
The main reason for this is to make Revise a bit more light-weight for packages that only need the revision API, and to reduce the overhead of loading Revise by default outside of the REPL. The load time when loaded without the REPL is almost halved:
```shell-session
# Master
$ julia --startup-file=no --project -e '@time import Revise'                                                                                                                                                           
  0.319723 seconds (404.29 k allocations: 27.255 MiB)

# PR
$ julia --startup-file=no --project -e '@time import Revise'                                                                                                                                                             
  0.182584 seconds (314.75 k allocations: 21.336 MiB)
```

I also renamed the Distributed extension in 8d4a07f to make it easier to distinguish where the extension module comes from.
Written with help from Claude :robot: 