### PR TITLE
Rename `CodeTrackingMethodInfo` to `MethodInfo`

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -118,7 +118,7 @@ This part of the package is not as well documented.
 ```@docs
 Revise.minimal_evaluation!
 Revise.methods_by_execution!
-Revise.CodeTrackingMethodInfo
+Revise.MethodInfo
 ```
 
 ### Modules and paths

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -4,17 +4,6 @@ function assign_this!(frame, value)
     frame.framedata.ssavalues[frame.pc] = value
 end
 
-# TODO Define abstract type MethodInfo end
-
-# This defines the API needed to store signatures using methods_by_execution!
-# This default version is simple and only used for testing purposes.
-# The "real" one is CodeTrackingMethodInfo in Revise.jl.
-const MethodInfo = IdDict{MethodInfoKey,LineNumberNode}
-add_signature!(methodinfo::MethodInfo, sig::MethodInfoKey, ln::LineNumberNode) = push!(methodinfo, sig=>ln)
-push_expr!(methodinfo::MethodInfo, ::Expr) = methodinfo
-pop_expr!(methodinfo::MethodInfo) = methodinfo
-add_includes!(methodinfo::MethodInfo, ::Module, _) = methodinfo
-
 function is_some_include(@nospecialize(f))
     @assert !isa(f, Core.SSAValue) && !isa(f, JuliaInterpreter.SSAValue)
     if isa(f, GlobalRef)
@@ -165,7 +154,7 @@ function minimal_evaluation!(frame::Frame, mode::Symbol)
 end
 
 function methods_by_execution(mod::Module, ex::Expr; kwargs...)
-    methodinfo = MethodInfo()
+    methodinfo = MethodInfo(ex)
     _, thk = methods_by_execution!(JuliaInterpreter.Compiled(), methodinfo, mod, ex; kwargs...)
     return methodinfo, thk
 end
@@ -179,7 +168,7 @@ Depending on the setting of `mode` (see the Extended help), it supports full eva
 evaluation needed to extract method signatures.
 `interp` controls JuliaInterpreter's evaluation of any non-intercepted statement;
 likely choices are `JuliaInterpreter.Compiled()` or `JuliaInterpreter.RecursiveInterpreter()`.
-`methodinfo` is a cache for storing information about any method definitions (see [`CodeTrackingMethodInfo`](@ref)).
+`methodinfo` is a cache for storing information about any method definitions (see [`MethodInfo`](@ref)).
 
 # Extended help
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -38,7 +38,7 @@ function _precompile_()
     @warnpcfail precompile(Tuple{Type{WatchList}})
     @warnpcfail precompile(Tuple{typeof(setindex!), Dict{String,WatchList}, WatchList, String})
 
-    MI = CodeTrackingMethodInfo
+    MI = MethodInfo
     @warnpcfail precompile(Tuple{typeof(minimal_evaluation!), Any, Module, Core.CodeInfo, Symbol})
     @warnpcfail precompile(Tuple{typeof(methods_by_execution!), Compiled, MI, Module, Expr})
     @warnpcfail precompile(Tuple{typeof(_methods_by_execution!), Compiled, MI, Frame, Vector{Bool}})

--- a/test/backedges.jl
+++ b/test/backedges.jl
@@ -81,5 +81,4 @@ do_test("Backedges") && @testset "Backedges" begin
     """
     ex = Meta.parse(src)
     @test Revise.methods_by_execution(BackEdgesTest, ex) isa Tuple
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1104,7 +1104,7 @@ const issue639report = []
         pop!(LOAD_PATH)
     end
 
-    do_test("Changing docstrings") && @testset "Changing docstring" begin
+    do_test("Changing docstring") && @testset "Changing docstring" begin
         # Compiled mode covers most docstring changes, so we have to go to
         # special effort to test the older interpreter-based solution.
         testdir = newtestdir()
@@ -1145,7 +1145,7 @@ const issue639report = []
         ex = quote "g" f() = 1 end
         lwr = Meta.lower(ChangeDocstring, ex)
         frame = Frame(ChangeDocstring, lwr.args[1])
-        methodinfo = Revise.MethodInfo()
+        methodinfo = Revise.MethodInfo(ex)
         ret = Revise._methods_by_execution!(JuliaInterpreter.RecursiveInterpreter(), methodinfo,
                                             frame, trues(length(frame.framecode.src.code)); mode=:sigs)
         ds = @doc(ChangeDocstring.f)


### PR DESCRIPTION
Consolidate the two `MethodInfo` types into one, as managing two `MethodInfo` implementations is tedious, so let's make it so we can manage only the full method info.

Previously there was a simple `IdDict`-based `MethodInfo` in lowered.jl for testing and the full `CodeTrackingMethodInfo` in packagedef.jl. This removes the simpler version and renames `CodeTrackingMethodInfo` to `MethodInfo`.