### PR TITLE
Rename `modexsigs` to `mod_exs_sigs` and related variables

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -337,7 +337,7 @@ FileInfo(Items=>ExprsSigs with the following expressions:
 This is just a summary; to see the actual `def=>mt_sigts` map, do the following:
 
 ```julia-repl
-julia> pkgdata.fileinfos[2].modexsigs[Items]
+julia> pkgdata.fileinfos[2].mod_exs_sigs[Items]
 OrderedCollections.OrderedDict{Module, OrderedCollections.OrderedDict{Revise.RelocatableExpr, Union{Nothing, Vector{CodeTracking.MethodInfoKey}}}} with 2 entries:
   :(indent(::UInt16) = begin…                       => CodeTracking.MethodInfoKey[CodeTracking.MethodInfoKey(nothing, Tuple{typeof(indent),UInt16})]
   :(indent(::UInt8) = begin…                        => CodeTracking.MethodInfoKey[CodeTracking.MethodInfoKey(nothing, Tuple{typeof(indent),UInt8})]
@@ -361,21 +361,21 @@ and other expressions that are `eval`ed in `Items`.
 
 When the file system notifies Revise that a file has been modified, Revise re-parses
 the file and assigns the expressions to the appropriate modules, creating a
-[`Revise.ModuleExprsSigs`](@ref) `mexsnew`.
-It then compares `mexsnew` against `mexsref`, the reference object that is synchronized to
-code as it was `eval`ed.
+[`Revise.ModuleExprsSigs`](@ref) `mod_exs_sigs_new`.
+It then compares `mod_exs_sigs_new` against `mod_exs_sigs_ref`, 
+the reference object that is synchronized to code as it was `eval`ed.
+
 The following actions are taken:
-
-- if a `def` entry in `mexsref` is equal to one in `mexsnew`, the expression is "unchanged"
+- if a `def` entry in `mod_exs_sigs_ref` is equal to one in `mod_exs_sigs_new`, the expression is "unchanged"
   except possibly for line number. The `locationinfo` in `CodeTracking` is updated as needed.
-- if a `def` entry in `mexsref` is not present in `mexsnew`, that entry is deleted and
+- if a `def` entry in `mod_exs_sigs_ref` is not present in `mod_exs_sigs_new`, that entry is deleted and
   any corresponding methods are also deleted.
-- if a `def` entry in `mexsnew` is not present in `mexsref`, it is `eval`ed and then added to
-  `mexsref`.
+- if a `def` entry in `mod_exs_sigs_new` is not present in `mod_exs_sigs_ref`, it is `eval`ed and then added to
+  `mod_exs_sigs_ref`.
 
-Technically, a new `mexsref` is generated every time to ensure that the expressions are
-ordered as in `mexsnew`; however, conceptually this is better thought of as an updating of
-`mexsref`, after which `mexsnew` is discarded.
+Technically, a new `mod_exs_sigs_ref` is generated every time to ensure that the expressions are
+ordered as in `mod_exs_sigs_new`; however, conceptually this is better thought of as an updating of
+`mod_exs_sigs_ref`, after which `mod_exs_sigs_new` is discarded.
 
 Note that one consequence is that modifying a method causes two actions, the deletion of
 the original followed by `eval`ing a new version.

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -25,10 +25,10 @@ function queue_includes!(pkgdata::PkgData, id::PkgId)
             end
             modname = String(Symbol(mod))
             if startswith(modname, modstring) || endswith(fname, modstring*".jl")
-                modexsigs = parse_source(fname, mod)
-                if modexsigs !== nothing
+                mod_exs_sigs = parse_source(fname, mod)
+                if mod_exs_sigs !== nothing
                     fname = relpath(fname, pkgdata)
-                    push!(pkgdata, fname=>FileInfo(modexsigs))
+                    push!(pkgdata, fname=>FileInfo(mod_exs_sigs))
                 end
                 push!(delids, i)
             end
@@ -90,13 +90,13 @@ function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString)
         return add_definitions_from_repl(file)
     end
     fi = fileinfo(pkgdata, file)
-    if (isempty(fi.modexsigs) && !fi.parsed[]) && (!isempty(fi.cachefile) || !isempty(fi.cacheexprs))
+    if (isempty(fi.mod_exs_sigs) && !fi.parsed[]) && (!isempty(fi.cachefile) || !isempty(fi.cacheexprs))
         # Source was never parsed, get it from the precompile cache
         src = read_from_cache(pkgdata, file)
         filep = joinpath(basedir(pkgdata), file)
         filec = get(cache_file_key, filep, filep)
-        topmod = first(keys(fi.modexsigs))
-        ret = parse_source!(fi.modexsigs, src, filec, topmod)
+        topmod = first(keys(fi.mod_exs_sigs))
+        ret = parse_source!(fi.mod_exs_sigs, src, filec, topmod)
         if ret === nothing
             @error "failed to parse cache file source text for $file"
         end
@@ -109,20 +109,20 @@ function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString)
     return fi
 end
 
-function add_modexs!(fi::FileInfo, modexs)
+function add_modexs!(fi::FileInfo, modexs::Vector{Tuple{Module,Expr}})
     for (mod, rex) in modexs
-        exsigs = get(fi.modexsigs, mod, nothing)
-        if exsigs === nothing
-            fi.modexsigs[mod] = exsigs = ExprsSigs()
+        exs_sigs = get(fi.mod_exs_sigs, mod, nothing)
+        if exs_sigs === nothing
+            fi.mod_exs_sigs[mod] = exs_sigs = ExprsSigs()
         end
-        pushex!(exsigs, rex)
+        pushex!(exs_sigs, rex)
     end
     return fi
 end
 
 function maybe_extract_sigs!(fi::FileInfo)
     if !fi.extracted[]
-        instantiate_sigs!(fi.modexsigs)
+        instantiate_sigs!(fi.mod_exs_sigs)
         fi.extracted[] = true
     end
     return fi
@@ -148,10 +148,10 @@ function maybe_add_includes_to_pkgdata!(pkgdata::PkgData, file::AbstractString, 
             # Parse the source of the new file
             fullfile = joinpath(basedir(pkgdata), incrp)
             if isfile(fullfile)
-                parse_source!(fi.modexsigs, fullfile, mod)
+                parse_source!(fi.mod_exs_sigs, fullfile, mod)
                 if eval_now
                     # Use runtime dispatch to reduce latency
-                    Base.invokelatest(instantiate_sigs!, fi.modexsigs; mode=:eval)
+                    Base.invokelatest(instantiate_sigs!, fi.mod_exs_sigs; mode=:eval)
                 end
             end
             # Add to watchlist
@@ -202,11 +202,11 @@ function add_require(sourcefile::String, modcaller::Module, idmod::String, ::Str
                     push!(modincludes, (modcaller, inc))
                 end
                 maybe_add_includes_to_pkgdata!(pkgdata, filekey, modincludes)
-                if isempty(fi.modexsigs)
+                if isempty(fi.mod_exs_sigs)
                     # Source has not even been parsed
                     push!(fi.cacheexprs, (modcaller, expr))
                 else
-                    add_modexs!(fi, [(modcaller, expr)])
+                    add_modexs!(fi, Tuple{Module,Expr}[(modcaller, expr)])
                 end
             end
         end
@@ -245,16 +245,16 @@ end
 
 function eval_require_now(pkgdata::PkgData, fileidx::Int, filekey::String, sourcefile::String, modcaller::Module, expr::Expr)
     fi = pkgdata.fileinfos[fileidx]
-    exsnew = ExprsSigs()
-    exsnew[RelocatableExpr(expr)] = nothing
-    mexsnew = ModuleExprsSigs(modcaller=>exsnew)
+    exs_sigs_new = ExprsSigs()
+    exs_sigs_new[RelocatableExpr(expr)] = nothing
+    mod_exs_sigs_new = ModuleExprsSigs(modcaller=>exs_sigs_new)
     # Before executing the expression we need to set the load path appropriately
     prev = Base.source_path(nothing)
     tls = task_local_storage()
     tls[:SOURCE_PATH] = sourcefile
     # Now execute the expression
-    mexsnew, includes = try
-        eval_new!(mexsnew, fi.modexsigs)
+    mod_exs_sigs_new, includes = try
+        eval_new!(mod_exs_sigs_new, fi.mod_exs_sigs)
     finally
         if prev === nothing
             delete!(tls, :SOURCE_PATH)
@@ -263,7 +263,7 @@ function eval_require_now(pkgdata::PkgData, fileidx::Int, filekey::String, sourc
         end
     end
     # Add any new methods or `include`d files to tracked objects
-    pkgdata.fileinfos[fileidx] = FileInfo(mexsnew, fi)
+    pkgdata.fileinfos[fileidx] = FileInfo(mod_exs_sigs_new, fi)
     ret = maybe_add_includes_to_pkgdata!(pkgdata, filekey, includes; eval_now=true)
     return ret
 end
@@ -465,11 +465,11 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
             # https://github.com/JuliaLang/julia/issues/42404
             # Get the source-text from the package source instead
             fi = fileinfo(pkgdata, file)
-            if isempty(fi.modexsigs) && (!isempty(fi.cachefile) || !isempty(fi.cacheexprs))
+            if isempty(fi.mod_exs_sigs) && (!isempty(fi.cachefile) || !isempty(fi.cacheexprs))
                 filep = joinpath(basedir(pkgdata), file)
                 src = read(filep, String)
-                topmod = first(keys(fi.modexsigs))
-                if parse_source!(fi.modexsigs, src, filep, topmod) === nothing
+                topmod = first(keys(fi.mod_exs_sigs))
+                if parse_source!(fi.mod_exs_sigs, src, filep, topmod) === nothing
                     @error "failed to parse source text for $filep"
                 end
                 add_modexs!(fi, fi.cacheexprs)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -178,10 +178,10 @@ function track_subdir_from_git!(pkgdata::PkgData, subdir::AbstractString; commit
                 push!(modified_files, (pkgdata, rpath))
             end
             fi = FileInfo(fmod)
-            if parse_source!(fi.modexsigs, src, file, fmod) === nothing
+            if parse_source!(fi.mod_exs_sigs, src, file, fmod) === nothing
                 @warn "failed to parse Git source text for $file"
             else
-                instantiate_sigs!(fi.modexsigs)
+                instantiate_sigs!(fi.mod_exs_sigs)
             end
             push!(pkgdata, rpath=>fi)
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -105,14 +105,14 @@ function unwrap_where(ex::Expr)
     return ex::Expr
 end
 
-function pushex!(exsigs::ExprsSigs, ex::Expr)
+function pushex!(exs_sigs::ExprsSigs, ex::Expr)
     uex = unwrap(ex)
     if is_doc_expr(uex)
         body = uex.args[4]
         # Don't trigger for exprs where the documented expression is just a signature
         # (e.g. `"docstr" f(x::Int)`, `"docstr" f(x::T) where T` etc.)
         if isa(body, Expr) && unwrap_where(body).head !== :call
-            exsigs[RelocatableExpr(body)] = nothing
+            exs_sigs[RelocatableExpr(body)] = nothing
         end
         if length(uex.args) < 5
             push!(uex.args, false)
@@ -120,8 +120,8 @@ function pushex!(exsigs::ExprsSigs, ex::Expr)
             uex.args[5] = false
         end
     end
-    exsigs[RelocatableExpr(ex)] = nothing
-    return exsigs
+    exs_sigs[RelocatableExpr(ex)] = nothing
+    return exs_sigs
 end
 
 ## WatchList utilities

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -243,21 +243,21 @@ const issue639report = []
         delmeth = first(methods(ReviseTest.Internal.mult4))
         mmult3 = @which ReviseTest.Internal.mult3(2)
 
-        mexsold = Revise.parse_source(tmpfile, Main)
-        Revise.instantiate_sigs!(mexsold)
+        mod_exs_sigs_old = Revise.parse_source(tmpfile, Main)
+        Revise.instantiate_sigs!(mod_exs_sigs_old)
         mcube = @which ReviseTest.cube(2)
 
         cp(fl2, tmpfile; force=true)
-        mexsnew = Revise.parse_source(tmpfile, Main)
-        mexsnew = Revise.eval_revised(mexsnew, mexsold)
+        mod_exs_sigs_new = Revise.parse_source(tmpfile, Main)
+        mod_exs_sigs_new = Revise.eval_revised(mod_exs_sigs_new, mod_exs_sigs_old)
         @latestworld
         @test ReviseTest.cube(2) == 8
         @test ReviseTest.Internal.mult3(2) == 6
 
-        @test length(mexsnew) == 3
-        @test haskey(mexsnew, ReviseTest) && haskey(mexsnew, ReviseTest.Internal)
+        @test length(mod_exs_sigs_new) == 3
+        @test haskey(mod_exs_sigs_new, ReviseTest) && haskey(mod_exs_sigs_new, ReviseTest.Internal)
 
-        dvs = collect(mexsnew[ReviseTest])
+        dvs = collect(mod_exs_sigs_new[ReviseTest])
         @test length(dvs) == 3
         (def, val) = dvs[1]
         @test isequal(Revise.unwrap(def), Revise.RelocatableExpr(:(square(x) = x^2)))
@@ -282,7 +282,7 @@ const issue639report = []
         @test whereis(m) == (tmpfile, 9)
         @test Revise.RelocatableExpr(definition(m)) == Revise.unwrap(def)
 
-        dvs = collect(mexsnew[ReviseTest.Internal])
+        dvs = collect(mod_exs_sigs_new[ReviseTest.Internal])
         @test length(dvs) == 5
         (def, val) = dvs[1]
         @test isequal(Revise.unwrap(def),  Revise.RelocatableExpr(:(mult2(x) = 2*x)))
@@ -341,9 +341,9 @@ const issue639report = []
         # Backtraces. Note this doesn't test the line-number correction
         # because both of these are revised definitions.
         cp(fl3, tmpfile; force=true)
-        mexsold = mexsnew
-        mexsnew = Revise.parse_source(tmpfile, Main)
-        mexsnew = Revise.eval_revised(mexsnew, mexsold)
+        mod_exs_sigs_old = mod_exs_sigs_new
+        mod_exs_sigs_new = Revise.parse_source(tmpfile, Main)
+        mod_exs_sigs_new = Revise.eval_revised(mod_exs_sigs_new, mod_exs_sigs_old)
         @latestworld
         try
             ReviseTest.cube(2)
@@ -1202,10 +1202,10 @@ const issue639report = []
 
     do_test("Undef in docstrings") && @testset "Undef in docstrings" begin
         fn = Base.find_source_file("abstractset.jl")   # has lots of examples of """str""" func1, func2
-        mexsold = Revise.parse_source(fn, Base)
-        mexsnew = Revise.parse_source(fn, Base)
-        odict = mexsold[Base]
-        ndict = mexsnew[Base]
+        mod_exs_sigs_old = Revise.parse_source(fn, Base)
+        mod_exs_sigs_new = Revise.parse_source(fn, Base)
+        odict = mod_exs_sigs_old[Base]
+        ndict = mod_exs_sigs_new[Base]
         for (k, v) in odict
             @test haskey(ndict, k)
         end


### PR DESCRIPTION
Improve readability by expanding abbreviated variable names:
- `modexsigs` → `mod_exs_sigs` (struct field in `FileInfo`)
- `mexsnew`/`mexsold` → `mod_exs_sigs_new`/`mod_exs_sigs_old`
- `exsigs` → `exs_sigs`
- `mt_sigs` → `siginfos`

Split off from local refactoring work for #894.