### PR TITLE
Yield during type cache creation to avoid very slow exit

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1655,7 +1655,7 @@ function __init__()
 
     # Populate field types map cache (only on main process, not on workers)
     if __bpart__ && (isnothing(distributed_module) || distributed_module.myid() == 1)
-        Threads.@spawn :default foreach_subtype(Any) do type
+        Threads.@spawn :default foreach_subtype(Any) do @nospecialize type
             # Populating this cache can be time consuming (eg, 30s on an
             # i7-7700HQ) so do this incrementally and yield() to the scheduler
             # regularly so this thread gets a chance to exit if the user quits early

--- a/src/visit.jl
+++ b/src/visit.jl
@@ -31,7 +31,7 @@ function old_methods_with(oldtypename::Core.TypeName)
 end
 
 function collect_all_subtypes(@nospecialize(parent_typ::Type))
-    return _foreach_subtype!(ty->nothing, parent_typ, Base.IdSet{Type}())
+    return _foreach_subtype!(Returns(nothing), parent_typ, Base.IdSet{Type}())
 end
 
 function foreach_subtype(f::Function, @nospecialize(parent_typ::Type))


### PR DESCRIPTION
Populating the type cache can be quite time consuming which is fine for long-running REPL jobs but not when (1) the user has Revise in their startup file and (2) they are running Julia for something simple and then exiting.

Before this patch, simply loading Revise then exiting takes 30 seconds on my machine!

To fix this, ensure that we `yield()` to the scheduler so the cache thread can exit gracefully. By itself, inserting a yeild lets the cache thread exit in around 2.5 seconds.

`collect_all_subtypes()` takes 1.5 seconds to run by itself, so I've also made it more incremental here. With this change `using Revise; exit()` is now 0.6s vs just calling `exit()` which is 0.1 seconds.

Fix #985