### PR TITLE
preference to disable initial cache of fieldtypes(#991)

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -185,3 +185,15 @@ string `"1"` (e.g., `JULIA_REVISE_POLL=1` in a bash script).
     NFS stands for [Network File System](https://en.wikipedia.org/wiki/Network_File_System) and is typically only used to mount shared network drives on *Unix* file systems.
     Despite similarities in the acronym, NTFS, the standard [filesystem on Windows](https://en.wikipedia.org/wiki/NTFS), is completely different from NFS; Revise's default configuration should work fine on Windows without polling.
     However, WSL2 users currently need polling due to [this bug](https://github.com/JuliaLang/julia/issues/37029).
+
+
+### Disabling Automatic Fieldtype Caching
+
+When Revise is loaded, it spawns a background task to cache all fieldtypes. This process ensures faster code reloading later but can introduce several seconds of initial startup overhead.
+
+You can disable this behaviour using [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl) by creating a `LocalPreferences.toml` file with the following contents:
+
+```toml
+[Revise]
+precache_fieldtypes = false
+```

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1653,8 +1653,9 @@ function __init__()
         end
     end
 
+    precache = Preferences.@load_preference("precache_fieldtypes", true)
     # Populate field types map cache (only on main process, not on workers)
-    if __bpart__ && (isnothing(distributed_module) || distributed_module.myid() == 1)
+    if precache && __bpart__ && (isnothing(distributed_module) || distributed_module.myid() == 1)
         Threads.@spawn :default foreach_subtype(Any) do @nospecialize type
             # Populating this cache can be time consuming (eg, 30s on an
             # i7-7700HQ) so do this incrementally and yield() to the scheduler


### PR DESCRIPTION
Fixes #991 adding a Preference.jl optional to disable the initial fieltypes cache population 