### PR TITLE
Pass `mod` to `Base.parse_input_line` to support syntax versioning

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -33,7 +33,11 @@ function parse_source!(mod_exprs_sigs::ModuleExprsInfos, src::AbstractString, fi
     if startswith(src, "# REVISE: DO NOT PARSE")
         return DoNotParse()
     end
-    ex = Base.parse_input_line(src; filename)
+    if VERSION ≥ v"1.14-DEV.1836"
+        ex = Base.parse_input_line(src; filename, mod)
+    else
+        ex = Base.parse_input_line(src; filename)
+    end
     if ex === nothing
         return mod_exprs_sigs
     elseif ex isa Expr


### PR DESCRIPTION
Relies on https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/711 or else this may trigger more errors.

Locally this seems to be the only missing piece for syntax versioning support (https://github.com/JuliaLang/julia/pull/60018).

Co-authored-by: Claude <noreply@anthropic.com>