### PR TITLE
release: v3.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.13.3"
+version = "3.14.0"
 
 [workspace]
 projects = ["docs", "test"]


### PR DESCRIPTION
The opt-in for struct revision got merged last week, so we should probably tag a new version too. Not sure if only bumping the patch is appropriate, given that the defaults change, but I thought I'd open this anyways to get the ball rolling.