### PR TITLE
Use per-file ctime (fixes #1025)

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -608,6 +608,8 @@ function init_watching(pkgdata::PkgData, files=srcfiles(pkgdata))
         if new_id != NOPACKAGE || current_id === nothing
             # Allow the package id to be updated
             push!(watchlist, basename=>pkgdata)
+            # Record the current ctime as baseline so only future changes are detected
+            watchlist.file_ctimes[basename] = ctime(joinpath(dirfull, basename))
             if watching_files[]
                 fwatcher = TaskThunk(revise_file_queued, (pkgdata, file))
                 schedule(Task(fwatcher))
@@ -617,7 +619,6 @@ function init_watching(pkgdata::PkgData, files=srcfiles(pkgdata))
         end
     end
     for dirfull in udirs
-        @lock watched_files_lock updatetime!(watched_files[dirfull])
         if !watching_files[]
             dwatcher = TaskThunk(revise_dir_queued, (dirfull,))
             schedule(Task(dwatcher))
@@ -751,6 +752,7 @@ function handle_deletions(
         wl = get(watched_files, basedir(pkgdata), nothing)
         if isa(wl, WatchList)
             delete!(wl.trackedfiles, file)
+            delete!(wl.file_ctimes, file)
         end
     end
     return mod_exs_infos_new, mod_exs_infos_old

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -315,7 +315,6 @@ function watch_files_via_dir(dirname::AbstractString)
     stillwatching = haskey(watched_files, dirname)
     if stillwatching
         wf = watched_files[dirname]
-        timestamp = updatetime!(wf)
         for (file, id) in wf.trackedfiles
             fullpath = joinpath(dirname, file)
             if isdir(fullpath)
@@ -328,11 +327,14 @@ function watch_files_via_dir(dirname::AbstractString)
                 sleep(0.1)
                 if !file_exists(fullpath)
                     push!(latestfiles, file=>id)
+                    wf.file_ctimes[file] = 0.0
                     continue
                 end
             end
-            if newer(ctime(fullpath), timestamp)
+            current_ctime = ctime(fullpath)
+            if current_ctime != get(wf.file_ctimes, file, current_ctime - 1)
                 push!(latestfiles, file=>id)
+                wf.file_ctimes[file] = current_ctime
             end
         end
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,12 +7,12 @@ watch parent directories, and keep track of which files in them
 should be tracked.
 
 Fields:
-- `timestamp`: mtime of last update
-- `trackedfiles`: Set of filenames, generally expressed as a relative path
+- `trackedfiles`: map from basename to `PkgId` for each watched file
+- `file_ctimes`: last-seen `ctime` for each tracked file, used to detect changes
 """
 mutable struct WatchList
-    timestamp::Float64         # unix time of last revision
     trackedfiles::Dict{String,PkgId}
+    file_ctimes::Dict{String,Float64}
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -125,25 +125,14 @@ function pushex!(exs_infos::ExprsInfos, ex::Expr)
 end
 
 ## WatchList utilities
-function updatetime!(wl::WatchList)
-    return @atomicswap :not_atomic wl.timestamp = time()
-end
 Base.push!(wl::WatchList, filenameid::Pair{<:AbstractString,PkgId}) =
     push!(wl.trackedfiles, filenameid)
 Base.push!(wl::WatchList, filenameid::Pair{<:AbstractString,PkgFiles}) =
     push!(wl, filenameid.first=>filenameid.second.id)
 Base.push!(wl::WatchList, filenameid::Pair{<:AbstractString,PkgData}) =
     push!(wl, filenameid.first=>filenameid.second.info)
-WatchList() = WatchList(time(), Dict{String,PkgId}())
+WatchList() = WatchList(Dict{String,PkgId}(), Dict{String,Float64}())
 Base.in(file, wl::WatchList) = haskey(wl.trackedfiles, file)
-
-@static if Sys.isapple()
-    # HFS+ rounds time to seconds, see #22
-    # https://developer.apple.com/library/archive/technotes/tn/tn1150.html#HFSPlusDates
-    newer(mtime, timestamp) = ceil(mtime) >= floor(timestamp)
-else
-    newer(mtime, timestamp) = mtime >= timestamp
-end
 
 """
     success = throwto_repl(e::Exception)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1754,6 +1754,68 @@ end
         rm_precompile("Timing")
     end
 
+    # Regression test for issue #1025: PR #1003 (TOCTOU fix) broke the #341 fix.
+    # An editor save typically generates a burst of directory events: creating a temp file,
+    # renaming it over the tracked file, etc. With #1003, every spurious event advanced
+    # wl.timestamp so the tracked file's ctime could fall behind it and be missed.
+    #
+    # The fix was to track per-file ctimes instead of a directory timestamp.
+    # A file is detected when its ctime changes, not when it exceeds a watermark.
+    # Spurious events touch no tracked files, so no file_ctimes entry changes and
+    # nothing is falsely reported as changed.
+    do_test("Spurious events don't prevent detection (issue #1025)") &&
+    @testset "Spurious events don't prevent detection (issue #1025)" begin
+        testdir = mktempdir()
+        push!(to_remove, testdir)
+        tracked_file = joinpath(testdir, "tracked1025.jl")
+
+        write(tracked_file, "tracked1025_f() = 1")
+        sleep(0.1)  # let ctime settle before creating WatchList
+
+        # Set up a WatchList as init_watching would (baseline ctime recorded at push time)
+        pkgid = Base.PkgId(UUIDs.uuid4(), "tracked1025_test")
+        @lock Revise.watched_files_lock begin
+            wl = Revise.WatchList()
+            push!(wl, basename(tracked_file) => pkgid)
+            wl.file_ctimes[basename(tracked_file)] = stat(tracked_file).ctime
+            Revise.watched_files[testdir] = wl
+        end
+
+        try
+            # --- Phase 1: spurious event; no tracked file changed ---
+            # Start the watcher *before* any modification (naturalistic ordering).
+            t1 = @async Revise.watch_files_via_dir(testdir)
+            sleep(0.05)  # give t1 time to block on wait_changed
+            write(joinpath(testdir, "spurious1025a.tmp"), "")
+            wait(t1)
+            rm(joinpath(testdir, "spurious1025a.tmp"), force=true)
+
+            # Invariant check (deterministic on all platforms):
+            # a spurious event must not change any tracked file's recorded ctime.
+            @test Revise.watched_files[testdir].file_ctimes[basename(tracked_file)] == stat(tracked_file).ctime
+
+            # --- Phase 2: edit the tracked file ---
+            write(tracked_file, "tracked1025_f() = 2")
+
+            # --- Phase 3: detection event; tracked file must be found ---
+            detected = Ref{Vector{String}}(String[])
+            t2 = @async begin
+                latestfiles, _ = Revise.watch_files_via_dir(testdir)
+                detected[] = [first(p) for p in latestfiles]
+            end
+            sleep(0.05)
+            write(joinpath(testdir, "spurious1025b.tmp"), "")
+            wait(t2)
+            rm(joinpath(testdir, "spurious1025b.tmp"), force=true)
+
+            @test basename(tracked_file) ∈ detected[]
+        finally
+            @lock Revise.watched_files_lock begin
+                delete!(Revise.watched_files, testdir)
+            end
+        end
+    end
+
     do_test("DO NOT PARSE") && @testset "DO NOT PARSE" begin
         testdir = newtestdir()
         dn = joinpath(testdir, "DoNotParse", "src")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4322,10 +4322,10 @@ do_test("callbacks") && @testset "callbacks" begin
             contents[] = read(path, String)
         end
 
-        sleep(mtimedelay)
+        sleep(2*mtimedelay)
 
         append(path, "abc")
-        sleep(mtimedelay)
+        sleep(2*mtimedelay)
         revise()
         @test contents[] == "abc"
 
@@ -4543,7 +4543,8 @@ include("backedges.jl")
 do_test("Base signatures") && @testset "Base signatures" begin
     println("beginning signatures tests")
     # Using the extensive repository of code in Base as a testbed
-    @test success(pipeline(`$(Base.julia_cmd()) sigtest.jl`, stderr=stderr))
+    sigfile = normpath(@__DIR__, "sigtest.jl")
+    @test success(pipeline(`$(Base.julia_cmd()) $sigfile`, stderr=stderr))
 end
 
 # Run this test in a separate julia process, since it messes with projects, and we don't want to have to


### PR DESCRIPTION
PR #1003 fixed a possible data race but re-opened issue #341. This commit adds a more rigorous test but also adds a robust fix: store the ctime of each tracked file. This eliminates the whole class of possible bugs that arise from tracking only a directory-wide modification time.

This fix allows us to continue to only monitor directories for changes (important to limit resource usage on platforms like OSX) while having the granularity to robustly detect changes to tracked files.