### PR TITLE
Preserve outer constructors when tracking structs in :sigs mode

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -436,9 +436,26 @@ function _methods_by_execution!(
                 callstmt = stmt
                 @label call_dispatch
                 f = lookup(frame, callstmt.args[1])
-                if __bpart__[] && f === Core._typebody!
-                    analyze_typebody!(exinfo, interp, frame, callstmt)
-                    pc = step_expr!(interp, frame, stmt, true)
+                if @static(isdefined(Core, :_typebody!) ? true : false) && f === Core._typebody!
+                    if __bpart__[]
+                        analyze_typebody!(exinfo, interp, frame, callstmt)
+                    end
+                    if mode === :sigs && length(callstmt.args) >= 4 && reuse_existing_type!(interp, frame, callstmt)
+                        # The type is already defined (e.g., by package loading).
+                        # In :sigs mode we just want to extract signatures, so don't
+                        # execute `_typebody!` — that would rebind the type and clear
+                        # methods that aren't redefined here (e.g., outer constructors
+                        # whose `:method` statements are skipped because `define=false`).
+                        pc = next_or_nothing!(frame)
+                    else
+                        pc = step_expr!(interp, frame, stmt, true)
+                    end
+                elseif mode === :sigs && @static(isdefined(Core, :declare_const) ? true : false) && f === Core.declare_const &&
+                       length(callstmt.args) >= 3 && skip_declare_const(interp, frame, callstmt)
+                    # The corresponding `_typebody!` was skipped above; skip the matching
+                    # `declare_const` to avoid creating a new binding partition for an
+                    # already-defined type.
+                    pc = next_or_nothing!(frame)
                 elseif is_defaultctors(f) && length(callstmt.args) == 3
                     # Create the constructors for a type (i.e., a method definition)
                     T = lookup(frame, callstmt.args[2])
@@ -578,4 +595,44 @@ function analyze_typebody!(exinfo::ExInfo, interp::Interpreter, frame::Frame, st
     datatype = Base.unwrap_unionall(typ)::DataType
     push!(exinfo.typeinfos, TypeInfo(datatype.name))
     return exinfo
+end
+
+# Look up the existing type that this `_typebody!` call would (re)define. If found,
+# assign it as the result of the SSA statement and return `true`; otherwise return
+# `false` so the caller falls back to executing the call normally.
+#
+# Only call this from `mode=:sigs`, which assumes the in-memory bindings already
+# match the source (the same assumption that lets `:sigs` skip `:method` statements
+# via `define=false`). No structural equivalence check is performed: on Julia 1.12+
+# `_equiv_typedef` is exactly what we're trying to avoid tripping, so a comparison
+# here would defeat the purpose. Genuine struct edits arrive through `revise()` in
+# `:eval`/`:evalmeth` mode, which does not take this path.
+#
+# `_typebody!(arg2, new_partial, fieldtypes_svec [, ...])` where `new_partial` is a
+# fresh `DataType` constructed by `_structtype`; its `.name.module/.name.name` give
+# the destination binding.
+function reuse_existing_type!(interp::Interpreter, frame::Frame, stmt::Expr)
+    new_partial = lookup(interp, frame, stmt.args[3])
+    new_partial isa DataType || return false
+    tn = new_partial.name
+    mod = tn.module
+    name = tn.name
+    @invokelatest(isdefined(mod, name)) || return false
+    existing = @invokelatest getfield(mod, name)
+    existing isa Type || return false
+    assign_this!(frame, existing)
+    return true
+end
+
+# Return `true` if the destination of `Core.declare_const(mod, :name, value)` is
+# already defined; if so, the caller will skip the call. This pairs with
+# `reuse_existing_type!` to avoid generating a new binding partition for a struct
+# whose definition we just skipped.
+function skip_declare_const(interp::Interpreter, frame::Frame, stmt::Expr)
+    mod_arg = lookup(interp, frame, stmt.args[2])
+    mod_arg isa Module || return false
+    name_arg = stmt.args[3]
+    name = name_arg isa QuoteNode ? name_arg.value : name_arg
+    name isa Symbol || return false
+    return @invokelatest isdefined(mod_arg, name)
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -168,9 +168,14 @@ function track_subdir_from_git!(pkgdata::PkgData, subdir::AbstractString; commit
                 rethrow(err)
             end
             fmod = get(juliaf2m, fullpath, Core.Compiler)  # Core.Compiler is not cached
+            # The top-level Compiler.jl file `include`s every other Compiler source file
+            # and defines the `Compiler` baremodule itself. We can't usefully parse/track
+            # it as a normal source file: in Julia 1.12+ its parent module is `Base` (via
+            # `Base._included_files`) rather than `Core.Compiler`, and re-executing its
+            # contents would attempt to redefine the `Compiler` baremodule.
+            endswith(fullpath, "compiler.jl") && continue              # v1.11-: defines the module
+            endswith(fullpath, "/Compiler/src/Compiler.jl") && continue  # v1.12+: defines the module
             if fmod === Core.Compiler
-                endswith(fullpath, "compiler.jl") && continue  # defines the module (v1.11-), skip
-                endswith(fullpath, "/Compiler/src/Compiler.jl") && continue  # defines the module (v1.12+), skip
                 @static if isdefined(Core.Compiler, :EscapeAnalysis)
                     # after https://github.com/JuliaLang/julia/pull/43800
                     if endswith(fullpath, "/compiler/ssair/EscapeAnalysis.jl") || contains(fullpath, "/Compiler/src/ssair/EscapeAnalysis.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3433,6 +3433,12 @@ end
             # Determine whether a git repo is available. Travis & Appveyor do not have this.
             repo, path = Revise.git_repo(Revise.juliadir)
             if repo != nothing && isfile(joinpath(path, "VERSION")) && isdir(joinpath(path, "base"))
+                # Capture some Core.Compiler types/methods that have outer constructors
+                # alongside inner constructors so we can verify that tracking does not
+                # clobber them (https://github.com/JuliaLang/julia/issues/61308).
+                @static if VERSION >= v"1.12.0-DEV"
+                    pre_inf_methods = length(methods(Core.Compiler.InferenceResult))
+                end
                 # Tracking Core.Compiler
                 Revise.track(Core.Compiler)
                 id = Revise.pkgidid_for_mod(Core.Compiler)
@@ -3440,6 +3446,18 @@ end
                 @test any(k->endswith(k, "optimize.jl"), Revise.srcfiles(pkgdata))
                 m = first(methods(Core.Compiler.typeinf_code))
                 @test definition(m) isa Expr
+                @static if VERSION >= v"1.12.0-DEV"
+                    # tracking should not have redefined types and dropped methods
+                    @test length(methods(Core.Compiler.InferenceResult)) == pre_inf_methods
+                    @test hasmethod(Core.Compiler.InferenceResult,
+                                    Tuple{Core.MethodInstance, Core.Compiler.AbstractLattice})
+                    # An end-to-end check: InteractiveUtils.code_warntype invokes
+                    # Core.Compiler.InferenceResult(::MethodInstance, ::AbstractLattice).
+                    io = IOBuffer()
+                    InteractiveUtils.code_warntype(IOContext(io, :color=>false),
+                                                   sin, Tuple{Float64})
+                    @test !isempty(String(take!(io)))
+                end
             else
                 @test_throws Revise.GitRepoException Revise.track(Core.Compiler)
                 @warn "skipping Core.Compiler tests due to lack of git repo"


### PR DESCRIPTION
In `:sigs` mode, `:method` statements are skipped (`define=false`) on the assumption that in-memory bindings already match the source. But on Julia 1.12+, executing `Core._typebody!` rebinds the type and clears its method table — wiping any outer constructors that won't be redefined by the skipped `:method` statements. Detect when the type is already defined and skip both `_typebody!` and the paired `Core.declare_const` so the existing type (and its full method table) is reused.

Also unconditionally skip the top-level `Compiler.jl` file in `track_subdir_from_git!`: on 1.12+ its parent module is `Base` rather than `Core.Compiler`, so the previous guard let it through and tried to redefine the `Compiler` baremodule.

Claude largely wrote this, but I forgot to add the attribution to the commit message. Will try to fix when I squash this.

Fixes #1034
Fixes https://github.com/JuliaLang/julia/issues/61308
Closes https://github.com/JuliaLang/julia/pull/61365
