### PR TITLE
Make yry() event-driven for faster, more robust tests

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -25,6 +25,12 @@ else
     const mtimedelay = 0.1
 end
 
+# Upper bound on how long `yry()` will wait for the file-watcher task to push
+# the expected change onto `revision_queue`. Only paid by yry() calls that
+# produce no revision (rare), so a generous value protects against slow
+# FSEvents delivery on macOS CI without significantly affecting wall time.
+const event_timeout = 10.0
+
 if isdefined(Core, :var"@latestworld")
     using Core: @latestworld
 else
@@ -36,7 +42,22 @@ else
     end
 end
 
-yry() = (sleep(mtimedelay); revise(); sleep(mtimedelay))
+# Replaces the historical `sleep(mtimedelay); revise(); sleep(mtimedelay)`:
+#   * pre-revise wait is event-driven (wait for the background watcher task to
+#     populate `Revise.revision_queue`), with `event_timeout` as a fall-through
+#     for tests that legitimately produce no revision.
+#   * a short settling pause lets a *burst* of writes that the watcher delivers
+#     across more than one wakeup land in the queue before we revise.
+#   * the trailing `sleep(mtimedelay)` is retained: it is the ctime-resolution
+#     guard so the *next* test write has a strictly larger ctime than the one
+#     `watch_files_via_dir` just cached. (When the dir watcher learns to use
+#     `watch_folder`, this trailing sleep can be removed.)
+function yry()
+    timedwait(() -> !isempty(Revise.revision_queue), event_timeout; pollint=0.02)
+    sleep(0.02)
+    revise()
+    sleep(mtimedelay)
+end
 macro yry()
     esc(quote
         yry()


### PR DESCRIPTION
## Summary

- Replace the historical `sleep(mtimedelay); revise(); sleep(mtimedelay)` in `yry()` with `timedwait(()->!isempty(Revise.revision_queue), event_timeout; pollint=0.02)`, a 20 ms settling pause, then `revise()` and the existing trailing `sleep(mtimedelay)`.
- Pre-revise wait is now event-class latency (~20–100 ms) instead of `mtimedelay` (3 s on WSL/macOS). The fall-through preserves correctness for tests that legitimately produce no revision.
- Fall-through uses a new constant `event_timeout = 10.0` rather than `mtimedelay`, so the generous timeout is only paid by the ~8–15 % of yry sites that produce no revision — protecting against slow FSEvents delivery on macOS CI without making the trailing sleep or the ~178 explicit `sleep(mtimedelay)` calls slower.
- The trailing `sleep(mtimedelay)` is retained as the ctime-resolution guard so the *next* test write produces a strictly larger ctime than the one `watch_files_via_dir` cached. It can go away when the dir watcher switches from `watch_file`+ctime-diff to `watch_folder`.

## Empirical impact

On WSL2 (ext4 /tmp, ctime resolution ~21 ms, `watch_folder` latency ~70 ms), a 320-assertion sweep across the heaviest file-watch testsets:

| Testsets | master | this PR |
|---|---|---|
| File paths, Revising macros, Manual track, Method deletion, Cross-module extension | 6m40s | **4m36s** |

Same 320 passes on both. All 21 entr-related tests also continue to pass.

## Test plan

- [x] Heavy file-watch sweep (above) passes locally on WSL2 with Julia 1.10.
- [x] `entr`, `entr with modules`, `entr with all files` pass.
- [x] CI green on Linux/macOS/Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)