### PR TITLE
Read cached source by the cache's own key (fixes #1033)

### DIFF
--- a/src/loading.jl
+++ b/src/loading.jl
@@ -57,8 +57,10 @@ function parse_pkg_files(id::PkgId)
                 end
                 fname = relpath(chi.filename, pkgdata)
                 # For precompiled packages, we can read the source later (whenever we need it)
-                # from the *.ji cachefile.
-                push!(pkgdata, fname=>FileInfo(mod, cachefile))
+                # from the *.ji cachefile. Keep `chi.filename` itself: that is the exact key
+                # the cache is indexed by, and reconstructing it from `fname` is unreliable
+                # when path forms diverge (e.g. symlinks, see #1033).
+                push!(pkgdata, fname=>FileInfo(mod, cachefile, chi.filename))
             end
             CodeTracking._pkgfiles[id] = pkgdata.info
             return pkgdata

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -82,7 +82,11 @@ function read_from_cache(pkgdata::PkgData, file::AbstractString)
             Base._read_dependency_src(io, filec)
         end
     end
-    Base.read_dependency_src(fi.cachefile, filep)
+    # `read_dependency_src` matches paths by exact string equality, so look the source
+    # up by the filename the cache was indexed with rather than one reconstructed from
+    # `basedir` (which can diverge in form, e.g. across symlinks; see #1033).
+    lookup = isempty(fi.cachefilename) ? filep : fi.cachefilename
+    Base.read_dependency_src(fi.cachefile, lookup)
 end
 
 function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString)

--- a/src/types.jl
+++ b/src/types.jl
@@ -251,21 +251,23 @@ Source cache files greatly reduce the overhead of using Revise.
 struct FileInfo
     mod_exs_infos::ModuleExprsInfos
     cachefile::String
+    cachefilename::String                              # the source path as recorded inside `cachefile`, used to read from the cache
     cacheexprs::Vector{Tuple{Module,Expr}}             # "unprocessed" exprs, used to support @require
     extracted::Base.RefValue{Bool}                     # true if signatures have been processed from mod_exs_infos
     parsed::Base.RefValue{Bool}                        # true if mod_exs_infos have been parsed from cachefile
 end
-FileInfo(mod_exs_infos::ModuleExprsInfos, cachefile="") =
-    FileInfo(mod_exs_infos, cachefile, Tuple{Module,Expr}[], Ref(false), Ref(false))
+FileInfo(mod_exs_infos::ModuleExprsInfos, cachefile="", cachefilename="") =
+    FileInfo(mod_exs_infos, cachefile, cachefilename, Tuple{Module,Expr}[], Ref(false), Ref(false))
 
 """
-    FileInfo(mod::Module, cachefile="")
+    FileInfo(mod::Module, cachefile="", cachefilename="")
 
 Initialize an empty FileInfo for a file that is `include`d into `mod`.
 """
-FileInfo(mod::Module, cachefile::AbstractString="") = FileInfo(ModuleExprsInfos(mod), cachefile)
+FileInfo(mod::Module, cachefile::AbstractString="", cachefilename::AbstractString="") =
+    FileInfo(ModuleExprsInfos(mod), cachefile, cachefilename)
 
-FileInfo(fm::ModuleExprsInfos, fi::FileInfo) = FileInfo(fm, fi.cachefile, copy(fi.cacheexprs), Ref(fi.extracted[]), Ref(fi.parsed[]))
+FileInfo(fm::ModuleExprsInfos, fi::FileInfo) = FileInfo(fm, fi.cachefile, fi.cachefilename, copy(fi.cacheexprs), Ref(fi.extracted[]), Ref(fi.parsed[]))
 
 function Base.show(io::IO, fi::FileInfo)
     print(io, "FileInfo(")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -753,6 +753,41 @@ end
         pop!(LOAD_PATH)
     end
 
+    # https://github.com/timholy/Revise.jl/issues/1033
+    do_test("Source from cache") && @testset "Source from cache" begin
+        testdir = newtestdir()
+        dn = joinpath(testdir, "CacheLookup1033", "src")
+        mkpath(dn)
+        write(joinpath(dn, "CacheLookup1033.jl"), """
+            module CacheLookup1033
+            include("sub.jl")
+            end
+            """)
+        write(joinpath(dn, "sub.jl"), "f1033() = 1")
+        sleep(mtimedelay)
+        @eval using CacheLookup1033
+        sleep(mtimedelay)
+        pkgdata = Revise.pkgdatas[Base.PkgId(CacheLookup1033)]
+        # Baseline: the source of a precompiled package is read back from its `.ji` cache.
+        for file in Revise.srcfiles(pkgdata)
+            @test occursin("1033", Revise.read_from_cache(pkgdata, file))
+        end
+        # The cache is indexed by the path recorded at precompile time. Reading it must
+        # not depend on reconstructing that path from `basedir`, which can take a
+        # different form than the cache's (e.g. across symlinks). Simulate the
+        # divergence by pointing `basedir` elsewhere; the source should still be found.
+        saved = pkgdata.info.basedir
+        pkgdata.info.basedir = joinpath(saved, "does", "not", "match")
+        try
+            for file in Revise.srcfiles(pkgdata)
+                @test occursin("1033", Revise.read_from_cache(pkgdata, file))
+            end
+        finally
+            pkgdata.info.basedir = saved
+        end
+        rm_precompile("CacheLookup1033")
+    end
+
     # issue #131
     do_test("Base & stdlib file paths") && @testset "Base & stdlib file paths" begin
         @test isfile(Revise.basesrccache)


### PR DESCRIPTION
When a precompiled package is tracked, Revise reads the original source from the `.ji` cache. It looked the source up by reconstructing a path as `joinpath(basedir(pkgdata), file)`, where `basedir` derives from `Base.locate_package` at load time. But the cache's source-text section is keyed by the include paths recorded at precompile time, and `Base.read_dependency_src` matches them by exact string equality. When the two derivations of a file diverge in form -- across symlinks, path separators, or drive-letter case -- the match fails and every file errors with "is not stored in the source-text cache".

Preserve the include path reported by `parse_cache_header` and pass it straight to `read_dependency_src`. That function re-parses the same `.ji`, so the path it reports is exactly the one its matcher accepts, making the lookup correct regardless of how `basedir` is normalized.

Fixes #1033

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>