### PR TITLE
De-flake the `entr` tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4192,6 +4192,12 @@ do_test("entr") && @testset "entr" begin
     # — the latter flakes on a slow CI runner (issue #1039).
     waitfor(pred) = timedwait(pred, event_timeout; pollint=0.02)
 
+    # `entr` coalesces changes that occur within `pause` seconds into a single
+    # callback; the "quick succession" checks below depend on that. Use a generous
+    # `pause` so the two events reliably land in the same window despite variable
+    # filesystem-event detection latency — a tight value flaked on Windows CI (#1040).
+    pause = 2.0
+
     srcfile1 = joinpath(tempdir(), randtmp()*".jl"); push!(to_remove, srcfile1)
     srcfile2 = joinpath(tempdir(), randtmp()*".jl"); push!(to_remove, srcfile2)
     revise(throw=true)   # force compilation
@@ -4204,7 +4210,7 @@ do_test("entr") && @testset "entr" begin
             @test Main.__entr__ == 0
 
             @async begin
-                entr([srcfile1, srcfile2]; pause=0.5) do
+                entr([srcfile1, srcfile2]; pause) do
                     include(srcfile1)
                 end
             end
@@ -4225,7 +4231,7 @@ do_test("entr") && @testset "entr" begin
             sleep(0.1)
             touch(srcfile2)
             waitfor(() -> Main.__entr__ >= 3)
-            sleep(1)                  # settle: a non-coalesced extra callback would land within this window
+            sleep(2*pause)            # settle: a non-coalesced extra callback would fire within ~pause of the first
             @test Main.__entr__ == 3  # callback should have been called only once
 
             write(srcfile1, "error(\"stop\")")
@@ -4261,7 +4267,7 @@ do_test("entr") && @testset "entr" begin
             stop = Ref(false)
 
             @async begin
-                entr([srcdir]; pause=0.5) do
+                entr([srcdir]; pause) do
                     counter[] += 1
                     stop[] && error("stop watching directory")
                 end
@@ -4291,7 +4297,7 @@ do_test("entr") && @testset "entr" begin
             sleep(0.1)
             touch(trigger)       # modification
             waitfor(() -> counter[] >= 5)
-            sleep(1)             # settle: a non-coalesced extra callback would land within this window
+            sleep(2*pause)       # settle: a non-coalesced extra callback would fire within ~pause of the first
             @test counter[] == 5 # Callback should have been called only once
 
             # Stop

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4214,16 +4214,21 @@ do_test("entr") && @testset "entr" begin
                     include(srcfile1)
                 end
             end
-            # `postpone=false` runs the callback synchronously *before* `entr` arms
-            # its watch, so don't `waitfor` the counter here — that would race ahead
-            # and modify the files before the watch exists. A fixed wait is fine: arming
-            # the watch is a bounded local operation, unlike awaiting a change event.
-            sleep(1)
+            # `postpone=false` runs the callback synchronously, *before* `entr` arms
+            # its watch. Wait for that, then probe: a fixed `sleep` here is unreliable
+            # — on a slow CI runner the watch may not be armed in time and the first
+            # change is missed (#1040, #1041). Rewriting the file until the change is
+            # actually detected makes setup robust regardless of arming latency.
+            waitfor(() -> Main.__entr__ >= 1)
             @test Main.__entr__ == 1  # callback should have been run (postpone=false)
 
-            # File modification
-            write(srcfile1, "Core.eval(Main, :(__entr__ = 2))")
-            waitfor(() -> Main.__entr__ >= 2)
+            # File modification — doubles as the probe that the watch is live
+            probed = timedwait(event_timeout; pollint=0.1) do
+                write(srcfile1, "Core.eval(Main, :(__entr__ = 2))")
+                Main.__entr__ >= 2
+            end
+            @test probed === :ok
+            sleep(2*pause)            # let any still-pending probe callbacks drain
             @test Main.__entr__ == 2  # callback should have been called
 
             # Two events in quick succession (w.r.t. the `pause` argument)
@@ -4272,33 +4277,38 @@ do_test("entr") && @testset "entr" begin
                     stop[] && error("stop watching directory")
                 end
             end
-            sleep(1)                           # let `entr` arm the watch (see above)
-            @test length(readdir(srcdir)) == 0 # directory should still be empty
+            waitfor(() -> counter[] >= 1)
             @test counter[] == 1               # postpone=false
+            @test length(readdir(srcdir)) == 0 # directory should still be empty
 
-            # File creation
-            touch(trigger)
-            waitfor(() -> counter[] >= 2)
-            @test counter[] == 2
+            # Probe that the watch is live before running the checks: touch a file
+            # until a change is actually detected (see the file-watching block above).
+            probed = timedwait(event_timeout; pollint=0.1) do
+                touch(trigger)
+                counter[] > 1
+            end
+            @test probed === :ok
+            sleep(2*pause)                     # let pending probe callbacks drain
+            counter[] = 0                      # watch is live now; count from a clean slate
 
             # File modification
             touch(trigger)
-            waitfor(() -> counter[] >= 3)
-            @test counter[] == 3
+            waitfor(() -> counter[] >= 1)
+            @test counter[] == 1
 
             # File deletion -> the directory should be empty again
             rm(trigger)
-            waitfor(() -> counter[] >= 4)
+            waitfor(() -> counter[] >= 2)
             @test length(readdir(srcdir)) == 0
-            @test counter[] == 4
+            @test counter[] == 2
 
             # Two events in quick succession (w.r.t. the `pause` argument)
             touch(trigger)       # creation
             sleep(0.1)
             touch(trigger)       # modification
-            waitfor(() -> counter[] >= 5)
+            waitfor(() -> counter[] >= 3)
             sleep(2*pause)       # settle: a non-coalesced extra callback would fire within ~pause of the first
-            @test counter[] == 5 # Callback should have been called only once
+            @test counter[] == 3 # Callback should have been called only once
 
             # Stop
             stop[] = true


### PR DESCRIPTION
Follow-up to #1040, which made the `entr` testset event-driven. Two residual
flakes surfaced on Windows CI after that merge; both are fixed here. Test-only
changes — no change to Revise itself.

1. **Coalescing window.** The "two events in quick succession" checks verify that
   `entr` merges changes occurring within `pause` seconds into a single callback.
   They fired the two events 0.1s apart with `pause=0.5`. Coalescing only happens
   if both events are *detected* within one `pause` window, and filesystem-event
   detection latency varies enough on Windows that the second event sometimes
   landed outside it — producing two callbacks and a spurious failure
   (`Julia 1 - windows`, #1040).
  Fixed by adding a longer `pause`

2. **Watch-arming race.** #1040 kept a fixed `sleep(1)` to wait for `entr` to arm
   its watch after startup. `entr` arms the watch asynchronously, so on a slow
   runner the first change was triggered before the watch existed, was missed,
   and every subsequent `timedwait` then ran one event behind
   (`Julia pre - windows`, observed on #1041).
  Fixed by probing to ensure watching is active.
