### PR TITLE
Generalize inotify warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,14 @@ jobs:
         curl -s -L https://github.com/JuliaLang/julia/archive/$path.tar.gz --output - | tar -xz -C $dn
         julia --project test/juliadir.jl "$dn/julia-$ver"
 
-    # # Running out of inotify storage (see #26)
+    # # Check that Revise degrades gracefully when the OS runs out of inotify
+    # # watches (see #26, #1010). `tee` (not `tee -a`) is required: a sysctl proc
+    # # file must be written at offset 0, otherwise the write is silently ignored.
+    # # Revise must not be pre-loaded here, so that inotify.jl can capture the
+    # # `using Revise` warning (which fires at most once, see `maxlog`).
     # - name: inotify
     #   if: ${{ matrix.os == 'ubuntu-latest' }}
-    #   run: echo 4 | sudo tee -a /proc/sys/fs/inotify/max_user_watches; julia --project --code-coverage=user -e 'using Pkg, Revise; cd(joinpath(dirname(pathof(Revise)), "..", "test")); include("inotify.jl")'
+    #   run: echo 4 | sudo tee /proc/sys/fs/inotify/max_user_watches; julia --project --code-coverage=user -e 'cd("test"); include("inotify.jl")'
     - uses: julia-actions/julia-processcoverage@latest
     - uses: codecov/codecov-action@v6
       with:

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -79,12 +79,21 @@ function wait_changed(file)
     try
         polling_files[] ? poll_file(file) : watch_file(file)
     catch err
-        if Sys.islinux() && err isa Base.IOError && err.code == -28  # ENOSPC
-            @warn """Your operating system has run out of inotify capacity.
-            Check the current value with `cat /proc/sys/fs/inotify/max_user_watches`.
-            Set it to a higher level with, e.g., `echo 65536 | sudo tee -a /proc/sys/fs/inotify/max_user_watches`.
-            This requires having administrative privileges on your machine (or talk to your sysadmin).
-            See https://github.com/timholy/Revise.jl/issues/26 for more information."""
+        if Sys.islinux() && err isa Base.IOError && err.code == -28  # ENOSPC; issue #1010
+            @warn """Revise was unable to watch files for changes via inotify (ENOSPC).
+            This can happen because:
+            - the filesystem does not support inotify (e.g., a WSL `/mnt/...` drive or
+              some network mounts);
+            - a per-user-namespace limit is in effect (common inside containers,
+              snaps, or Flatpaks), in which case `cat /proc/sys/fs/inotify/max_user_watches`
+              may report a large value that is not the limit actually enforced;
+            - the per-user `max_user_watches` limit is genuinely exhausted.
+            As a workaround, set the environment variable `JULIA_REVISE_POLL=1` before
+            `using Revise` to poll the filesystem instead of using inotify.
+            If `max_user_watches` is genuinely the cause, raise it with, e.g.,
+            `echo 65536 | sudo tee /proc/sys/fs/inotify/max_user_watches` (administrative
+            privileges required).
+            See https://github.com/timholy/Revise.jl/issues/26 for more information.""" maxlog=1
         end
         rethrow(err)
     end

--- a/test/inotify.jl
+++ b/test/inotify.jl
@@ -1,11 +1,26 @@
-using Revise, Test
-# This test should only be run if you have a very small inotify limit
+using Test
+
+# Verifies that Revise emits a single, actionable warning when the OS refuses an
+# inotify watch (ENOSPC). This is only meaningful when the inotify watch limit has
+# been set very low first; see the (currently disabled) `inotify` step in
+# `.github/workflows/ci.yml`. Relevant issues: #26, #1010.
+#
+# `using Revise` is loaded inside the log collector on purpose: the warning uses
+# `maxlog=1`, so it fires only once per session and may be triggered as soon as
+# Revise starts watching its own dependencies.
 
 @testset "inotify" begin
     logs, _ = Test.collect_test_logs() do
-        Revise.track("revisetest.jl")
+        @eval using Revise
+        Revise.track(joinpath(@__DIR__, "revisetest.jl"))
+        sleep(1)   # let the watcher tasks run and hit the inotify limit
     end
-    sleep(0.1)
-    @test !isempty(logs)
-    @test any(rec->occursin("inotify", rec.message), logs)
+    inotify_warnings = filter(rec -> occursin("inotify", rec.message), logs)
+    # `maxlog=1` collapses the per-directory flood into a single warning
+    @test length(inotify_warnings) == 1
+    if !isempty(inotify_warnings)
+        msg = first(inotify_warnings).message
+        @test occursin("ENOSPC", msg)
+        @test occursin("JULIA_REVISE_POLL", msg)
+    end
 end


### PR DESCRIPTION
The existing warning made strong assumptions. This is a bit more agnostic about the cause.

In parallel, `test/inotify.jl` has been updated. Currently this test does not run, but changing it now simplifies future experimentation.

Fixes #1010