### PR TITLE
Give `entr` a real trailing-edge debounce

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -137,10 +137,10 @@ any module tracked by Revise.
 
 `entr` will process updates (and block your command line) until you press Ctrl-C.
 Unless `postpone` is `true`, `f()` will be executed also when calling `entr`,
-regardless of file changes. The `pause` is the period (in seconds) that `entr`
-will wait between being triggered and actually calling `f()`, to handle
-clusters of modifications, such as those produced by saving files in certain
-text editors.
+regardless of file changes. The `pause` is the quiet period (in seconds) that
+`entr` waits after the most recent change before calling `f()`; a cluster of
+modifications less than `pause` apart — such as those produced by saving files
+in certain text editors — therefore triggers only a single call.
 
 # Example
 
@@ -155,18 +155,62 @@ This will print "update" every time `"/tmp/watched.txt"` or any of the code defi
 function entr(f::Function, files, modules=nothing; all=false, postpone=false, pause=0.02)
     yield()
     postpone || f()
+    # `entr` runs `f` on a trailing-edge debounce: a change schedules `f` for
+    # `pause` seconds later, and any further change before then pushes the
+    # deadline out. A burst of changes no more than `pause` apart therefore
+    # collapses into a single `f()` call.
+    lk = ReentrantLock()
+    deadline = Ref(0.0)                          # `time()` at which `f` should next run; a past value means "nothing pending"
+    dtask = Ref{Union{Task,Nothing}}(nothing)    # the in-flight debounce task, or `nothing`
+    err = Ref{Any}(nothing)                      # an error from `f`, relayed to the loop below so it can rethrow
+    stopped = Ref(false)
+    function run_debounce()
+        while true
+            local remaining
+            @lock lk begin
+                remaining = deadline[] - time()
+                # Decide to exit and clear `dtask` atomically, so a change
+                # arriving now either extends this task or spawns a fresh one.
+                remaining <= 0 && (dtask[] = nothing)
+            end
+            remaining <= 0 && break
+            sleep(remaining)
+        end
+        stopped[] && return
+        try
+            Base.invokelatest(f)  # `f` typically calls code that `revise` just updated
+        catch e
+            err[] = e
+            notify(revision_event)  # wake the loop below so it can rethrow
+        end
+        return
+    end
+    # The watch callback fires once per detected change and must return
+    # promptly (it runs while `revise` holds `revision_queue_lock`), so it only
+    # records a new deadline; the wait and `f()` happen in `run_debounce`. A
+    # debounce task already counting down will see the bumped `deadline` and
+    # extend itself, so spawn one only when `dtask` is empty. Pairing this with
+    # the task clearing `dtask` as it commits to exit (both under `lk`) means a
+    # change racing an expiring task either extends it or spawns its successor.
     key = add_callback(files, modules; all=all) do
-        sleep(pause)
-        f()
+        @lock lk begin
+            deadline[] = time() + pause
+            if dtask[] === nothing
+                dtask[] = @async run_debounce()
+            end
+        end
     end
     try
         while true
             wait(revision_event)  # autoreset; see issue #837
+            err[] === nothing || throw(err[])
             revise(throw=true)
+            err[] === nothing || throw(err[])
         end
-    catch err
-        isa(err, InterruptException) || rethrow(err)
+    catch e
+        isa(e, InterruptException) || rethrow(e)
     finally
+        stopped[] = true
         remove_callback(key)
     end
     nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4186,16 +4186,15 @@ do_test("revision_event autoreset") && @testset "revision_event autoreset (issue
 end
 
 do_test("entr") && @testset "entr" begin
-    # `entr` runs its callback asynchronously: a background task detects the change,
-    # then `entr` waits `pause` seconds before calling `f`. Poll for the expected
-    # state with `timedwait` rather than assuming a fixed `sleep` outlasts that chain
-    # — the latter flakes on a slow CI runner (issue #1039).
+    # `entr` debounces file changes: a change schedules the callback to run
+    # `pause` seconds later, and any further change before then pushes that
+    # deadline out, so a burst of changes less than `pause` apart triggers the
+    # callback exactly once. Poll for the expected state with `timedwait`
+    # rather than fixed `sleep`s, which flake on slow CI runners (#1039-#1042).
     waitfor(pred) = timedwait(pred, event_timeout; pollint=0.02)
 
-    # `entr` coalesces changes that occur within `pause` seconds into a single
-    # callback; the "quick succession" checks below depend on that. Use a generous
-    # `pause` so the two events reliably land in the same window despite variable
-    # filesystem-event detection latency — a tight value flaked on Windows CI (#1040).
+    # A generous `pause` keeps a burst coalesced despite variable
+    # filesystem-event detection latency; a tight value flaked on Windows (#1040).
     pause = 2.0
 
     srcfile1 = joinpath(tempdir(), randtmp()*".jl"); push!(to_remove, srcfile1)
@@ -4214,30 +4213,34 @@ do_test("entr") && @testset "entr" begin
                     include(srcfile1)
                 end
             end
-            # `postpone=false` runs the callback synchronously, *before* `entr` arms
-            # its watch. Wait for that, then probe: a fixed `sleep` here is unreliable
-            # — on a slow CI runner the watch may not be armed in time and the first
-            # change is missed (#1040, #1041). Rewriting the file until the change is
-            # actually detected makes setup robust regardless of arming latency.
+            # `postpone=false` runs the callback synchronously, before `entr`
+            # arms its watch.
             waitfor(() -> Main.__entr__ >= 1)
             @test Main.__entr__ == 1  # callback should have been run (postpone=false)
 
-            # File modification — doubles as the probe that the watch is live
-            probed = timedwait(event_timeout; pollint=0.1) do
-                write(srcfile1, "Core.eval(Main, :(__entr__ = 2))")
-                Main.__entr__ >= 2
+            # Drive a single modification through the watch. The watch may not
+            # be armed the instant `entr` starts (#1040, #1041), so retry the
+            # write — but space the retries more than `pause` apart so each is
+            # its own burst and the debounce is allowed to fire between them.
+            probed = timedwait(event_timeout; pollint=pause+1) do
+                Main.__entr__ >= 2 || (write(srcfile1, "Core.eval(Main, :(__entr__ = 2))"); false)
             end
             @test probed === :ok
-            sleep(2*pause)            # let any still-pending probe callbacks drain
+            sleep(2*pause)            # let the debounce settle
             @test Main.__entr__ == 2  # callback should have been called
 
-            # Two events in quick succession (w.r.t. the `pause` argument)
+            # A burst of changes less than `pause` apart must coalesce into a
+            # single callback. Switch `srcfile1` to an increment so a surplus
+            # callback would be visible, hammer both files, then stop and let
+            # the debounce fire.
             write(srcfile1, "Core.eval(Main, :(__entr__ += 1))")
-            sleep(0.1)
-            touch(srcfile2)
+            for _ in 1:8
+                touch(srcfile2)
+                sleep(pause/4)
+            end
             waitfor(() -> Main.__entr__ >= 3)
-            sleep(2*pause)            # settle: a non-coalesced extra callback would fire within ~pause of the first
-            @test Main.__entr__ == 3  # callback should have been called only once
+            sleep(2*pause)            # a surplus callback would fire within ~pause
+            @test Main.__entr__ == 3  # the whole burst triggered the callback once
 
             write(srcfile1, "error(\"stop\")")
         end
@@ -4260,75 +4263,81 @@ do_test("entr") && @testset "entr" begin
     @test isempty(Revise.user_callbacks_by_file[srcfile1])
 
 
-    # Watch directories (#470)
-    try
-        @sync let
-            srcdir = joinpath(tempdir(), randtmp())
-            mkdir(srcdir)
+    # Watch directories (#470). Skipped under polling: poll mode watches a
+    # directory through its own `stat`, which does not change when a file
+    # inside it is modified in place, so the checks below cannot be detected.
+    if !Revise.polling_files[]
+        try
+            @sync let
+                srcdir = joinpath(tempdir(), randtmp())
+                mkdir(srcdir)
 
-            trigger = joinpath(srcdir, "trigger.txt")
+                trigger = joinpath(srcdir, "trigger.txt")
 
-            counter = Ref(0)
-            stop = Ref(false)
+                counter = Ref(0)
+                stop = Ref(false)
 
-            @async begin
-                entr([srcdir]; pause) do
-                    counter[] += 1
-                    stop[] && error("stop watching directory")
+                @async begin
+                    entr([srcdir]; pause) do
+                        counter[] += 1
+                        stop[] && error("stop watching directory")
+                    end
+                end
+                waitfor(() -> counter[] >= 1)
+                @test counter[] == 1               # postpone=false
+                @test length(readdir(srcdir)) == 0 # directory should still be empty
+
+                # Drive a detected change to confirm the watch is live, retrying
+                # more than `pause` apart so the debounce can fire between attempts.
+                probed = timedwait(event_timeout; pollint=pause+1) do
+                    counter[] >= 2 || (touch(trigger); false)
+                end
+                @test probed === :ok
+                sleep(2*pause)                     # let the debounce settle
+                counter[] = 0                      # watch is live now; count from a clean slate
+
+                # File modification
+                touch(trigger)
+                waitfor(() -> counter[] >= 1)
+                @test counter[] == 1
+
+                # File deletion -> the directory should be empty again
+                rm(trigger)
+                waitfor(() -> counter[] >= 2)
+                @test length(readdir(srcdir)) == 0
+                @test counter[] == 2
+
+                # A burst of changes less than `pause` apart must coalesce into a
+                # single callback.
+                for _ in 1:8
+                    touch(trigger)
+                    rm(trigger)
+                    sleep(pause/4)
+                end
+                waitfor(() -> counter[] >= 3)
+                sleep(2*pause)       # a surplus callback would fire within ~pause
+                @test counter[] == 3 # the whole burst triggered the callback once
+
+                # Stop
+                stop[] = true
+                touch(trigger)
+            end
+
+            # `entr` should have errored by now
+            @test false
+        catch err
+            while err isa CompositeException
+                err = err.exceptions[1]
+                if err isa TaskFailedException
+                    err = err.task.exception
+                end
+                if err isa CapturedException
+                    err = err.ex
                 end
             end
-            waitfor(() -> counter[] >= 1)
-            @test counter[] == 1               # postpone=false
-            @test length(readdir(srcdir)) == 0 # directory should still be empty
-
-            # Probe that the watch is live before running the checks: touch a file
-            # until a change is actually detected (see the file-watching block above).
-            probed = timedwait(event_timeout; pollint=0.1) do
-                touch(trigger)
-                counter[] > 1
-            end
-            @test probed === :ok
-            sleep(2*pause)                     # let pending probe callbacks drain
-            counter[] = 0                      # watch is live now; count from a clean slate
-
-            # File modification
-            touch(trigger)
-            waitfor(() -> counter[] >= 1)
-            @test counter[] == 1
-
-            # File deletion -> the directory should be empty again
-            rm(trigger)
-            waitfor(() -> counter[] >= 2)
-            @test length(readdir(srcdir)) == 0
-            @test counter[] == 2
-
-            # Two events in quick succession (w.r.t. the `pause` argument)
-            touch(trigger)       # creation
-            sleep(0.1)
-            touch(trigger)       # modification
-            waitfor(() -> counter[] >= 3)
-            sleep(2*pause)       # settle: a non-coalesced extra callback would fire within ~pause of the first
-            @test counter[] == 3 # Callback should have been called only once
-
-            # Stop
-            stop[] = true
-            touch(trigger)
+            @test isa(err, ErrorException)
+            @test err.msg == "stop watching directory"
         end
-
-        # `entr` should have errored by now
-        @test false
-    catch err
-        while err isa CompositeException
-            err = err.exceptions[1]
-            if err isa TaskFailedException
-                err = err.task.exception
-            end
-            if err isa CapturedException
-                err = err.ex
-            end
-        end
-        @test isa(err, ErrorException)
-        @test err.msg == "stop watching directory"
     end
 end
 


### PR DESCRIPTION
I've been doing some work to try to make Revise's tests less flaky. #1037 was easy and seems to have been quite effective in getting rid of one whole class of sporadic failures. It's been much more difficult to get rid of flakiness in the `entr` tests (see #1039, #1040, #1041, #1042), despite the fact that these are a tiny fraction of Revise's tests.

My current sense is that a better approach is to change `entr` itself. I don't use it myself and it's always been community-maintained, so it's a little risky for me to be the one doing this. But with Claude as my sidekick and some careful supervision, it seems worth a try. I'd be really grateful if @ffevotte and/or @frankier could review this and/or try it out under real workloads.

Here is Claude's commit message:

`entr`'s coalescing of rapid file changes was an accident of locking: `process_user_callbacks!` runs callbacks under `@sync`, and the registered callback was `() -> (sleep(pause); f())`, so the `@sync` blocked for `pause` seconds while holding `revision_queue_lock`. A second change landing in that window had its queued key wiped by the trailing `empty!`; a change landing after it started a fresh callback. Whether two changes coalesced thus depended on their relative filesystem-event detection latency, which no OS bounds.

Replace this with a genuine trailing-edge debounce: the watch callback only records an extendable deadline and lazily spawns a single debounce task, which sleeps until `pause` seconds of quiet and then runs `f()`. The callback now returns immediately, so it no longer holds `revision_queue_lock` for `pause` seconds. Errors from `f()` are relayed to `entr`'s loop so a throwing `f()` still terminates `entr`.

Rework the `entr` tests accordingly: the "quick succession" checks now use a sustained burst rather than two lone events whose relative detection timing is unbounded, and the watch-arming probes are spaced more than `pause` apart so they no longer defeat the debounce. The directory-watch block is skipped under `JULIA_REVISE_POLL=1`, since poll mode watches a directory via its own `stat` and cannot detect in-place modification of a file inside it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>