### PR TITLE
Allow `HistEntry` in history (1.14)

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1400,7 +1400,8 @@ end
 function add_definitions_from_repl(filename::String)
     hist_idx = parse(Int, filename[6:end-1])
     hp = (Base.active_repl::REPL.LineEditREPL).interface.modes[1].hist::REPL.REPLHistoryProvider
-    src = hp.history[hp.start_idx+hist_idx]
+    entry = hp.history[hp.start_idx+hist_idx]
+    src = entry isa AbstractString ? entry : entry.content
     id = PkgId(nothing, "@REPL")
     pkgdata = pkgdatas[id]
     mod_exs_infos = ModuleExprsInfos(Main::Module)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 EndpointRanges = "340492b5-2a47-5f55-813d-aca7ddf97656"
 EponymTuples = "97e2ac4a-e175-5f49-beb1-4d6866a6cdc3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using Test
 
 @test isempty(detect_ambiguities(Revise))
 
-using Pkg, Unicode, Distributed, InteractiveUtils, REPL, UUIDs
+using Pkg, Unicode, Distributed, InteractiveUtils, REPL, UUIDs, Dates
 import LibGit2
 using Revise.OrderedCollections: OrderedSet
 using Test: collect_test_logs
@@ -3527,6 +3527,14 @@ end
     do_test("Methods at REPL") && @testset "Methods at REPL" begin
         if isdefined(Base, :active_repl) && !isnothing(Base.active_repl)
             hp = Base.active_repl.interface.modes[1].hist
+            # The element type of `hp.history` changed from `String` to
+            # `REPL.History.HistEntry` in Julia 1.14; wrap accordingly.
+            push_hist! = if isdefined(REPL, :History) && isdefined(REPL.History, :HistEntry)
+                (h, s) -> push!(h.history, REPL.History.HistEntry(
+                    :julia, Dates.now(), s, UInt32(length(h.history) + 1)))
+            else
+                (h, s) -> push!(h.history, s)
+            end
             fstr = "__fREPL__(x::Int16) = 0"
             histidx = length(hp.history) + 1 - hp.start_idx
             ex = Base.parse_input_line(fstr; filename="REPL[$histidx]")
@@ -3534,7 +3542,7 @@ end
             if ex.head === :toplevel
                 ex = ex.args[end]
             end
-            push!(hp.history, fstr)
+            push_hist!(hp, fstr)
             m = first(methods(f))
             @test !isempty(signatures_at(String(m.file), m.line))
             @test isequal(Revise.RelocatableExpr(definition(m)), Revise.RelocatableExpr(ex))
@@ -3548,7 +3556,7 @@ end
             if ex.head === :toplevel
                 ex = ex.args[end]
             end
-            push!(hp.history, fstr)
+            push_hist!(hp, fstr)
             m = first(methods(f))
             @test isequal(Revise.RelocatableExpr(definition(m)), Revise.RelocatableExpr(ex))
             @test definition(String, m)[1] == fstr


### PR DESCRIPTION
Julia #59819 added `HistEntry`. Revise tests for the REPL don't run on Julia CI, so this comes up mostly in interactive sessions. Worth a fix.