### PR TITLE
Tolerate missing sysimg.jl in Base._included_files

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -219,8 +219,9 @@ Julia's top-level directory when Julia was built, as recorded by the entries in
 `Base._included_files`.
 """
 const basebuilddir = begin
-    sysimg = filter(x->endswith(x[2], "sysimg.jl"), Base._included_files)[1][2]
-    dirname(dirname(sysimg))
+    # issue #1045: non-incremental PackageCompiler sysimages have no sysimg.jl entry
+    idx = findfirst(x -> endswith(x[2], "sysimg.jl"), Base._included_files)
+    idx === nothing ? expected_juliadir() : dirname(dirname(Base._included_files[idx][2]))
 end
 
 function fallback_juliadir(candidate = expected_juliadir())


### PR DESCRIPTION
Non-incremental PackageCompiler sysimages produce a `Base._included_files` with no entry ending in `sysimg.jl`, which broke Revise's precompilation with a `BoundsError`. Fall back to `expected_juliadir()` in that case; the two consumers of `basebuilddir` (path remapping for Base sources and the build-tree detection in `juliadir`) are not meaningful for such installs.

Fixes #1045