### PR TITLE
Recolor only the `julia>` prompt for revision errors

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1476,25 +1476,27 @@ end
 # Set the prompt color to indicate the presence of unhandled revision errors
 const original_repl_prefix = Ref{Union{String,Function,Nothing}}(nothing)
 function maybe_set_prompt_color(color)
-    if isdefined(Base, :active_repl)
-        repl = Base.active_repl
-        if isa(repl, REPL.LineEditREPL) && isdefined(repl, :interface)
-            # Always recolor the `julia>` prompt, never whatever mode happens to
-            # be active, so a revision error raised while in shell/help/pkg mode
-            # does not leak that mode's color onto `julia>` (issue #755).
-            julia_prompt = repl.interface.modes[1]
-            if color === :warn
-                # First save the original setting
-                if original_repl_prefix[] === nothing
-                    original_repl_prefix[] = julia_prompt.prompt_prefix
-                end
-                julia_prompt.prompt_prefix = "\e[33m"  # yellow
-            else
-                color = original_repl_prefix[]
-                color === nothing && return nothing
-                julia_prompt.prompt_prefix = color
-                original_repl_prefix[] = nothing
+    isdefined(Base, :active_repl) || return nothing
+    return set_prompt_color!(color, Base.active_repl)
+end
+
+function set_prompt_color!(color, repl)
+    if isa(repl, REPL.LineEditREPL) && isdefined(repl, :interface)
+        # Always recolor the `julia>` prompt, never whatever mode happens to
+        # be active, so a revision error raised while in shell/help/pkg mode
+        # does not leak that mode's color onto `julia>` (issue #755).
+        julia_prompt = repl.interface.modes[1]
+        if color === :warn
+            # First save the original setting
+            if original_repl_prefix[] === nothing
+                original_repl_prefix[] = julia_prompt.prompt_prefix
             end
+            julia_prompt.prompt_prefix = "\e[33m"  # yellow
+        else
+            color = original_repl_prefix[]
+            color === nothing && return nothing
+            julia_prompt.prompt_prefix = color
+            original_repl_prefix[] = nothing
         end
     end
     return nothing

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1478,17 +1478,21 @@ const original_repl_prefix = Ref{Union{String,Function,Nothing}}(nothing)
 function maybe_set_prompt_color(color)
     if isdefined(Base, :active_repl)
         repl = Base.active_repl
-        if isa(repl, REPL.LineEditREPL)
+        if isa(repl, REPL.LineEditREPL) && isdefined(repl, :interface)
+            # Always recolor the `julia>` prompt, never whatever mode happens to
+            # be active, so a revision error raised while in shell/help/pkg mode
+            # does not leak that mode's color onto `julia>` (issue #755).
+            julia_prompt = repl.interface.modes[1]
             if color === :warn
                 # First save the original setting
                 if original_repl_prefix[] === nothing
-                    original_repl_prefix[] = repl.mistate.current_mode.prompt_prefix
+                    original_repl_prefix[] = julia_prompt.prompt_prefix
                 end
-                repl.mistate.current_mode.prompt_prefix = "\e[33m"  # yellow
+                julia_prompt.prompt_prefix = "\e[33m"  # yellow
             else
                 color = original_repl_prefix[]
                 color === nothing && return nothing
-                repl.mistate.current_mode.prompt_prefix = color
+                julia_prompt.prompt_prefix = color
                 original_repl_prefix[] = nothing
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3623,19 +3623,16 @@ end
         repl = REPL.LineEditREPL(term, true)
         repl.interface = REPL.LineEdit.ModalInterface(
             REPL.LineEdit.TextInterface[julia_prompt, shell_prompt])
-        old_repl = isdefined(Base, :active_repl) ? Base.active_repl : nothing
         old_prefix = Revise.original_repl_prefix[]
         try
-            @eval Base active_repl = $repl
             Revise.original_repl_prefix[] = nothing
-            Revise.maybe_set_prompt_color(:warn)
+            Revise.set_prompt_color!(:warn, repl)
             @test julia_prompt.prompt_prefix == "\e[33m"   # yellow
             @test shell_prompt.prompt_prefix == red        # left untouched
-            Revise.maybe_set_prompt_color(:ok)
+            Revise.set_prompt_color!(:ok, repl)
             @test julia_prompt.prompt_prefix == green       # restored, not red
             @test shell_prompt.prompt_prefix == red
         finally
-            @eval Base active_repl = $old_repl
             Revise.original_repl_prefix[] = old_prefix
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3610,6 +3610,36 @@ end
         @test endswith(file, "reducedim.jl") && line > 1
     end
 
+    do_test("Prompt color #755") && @testset "Prompt color #755" begin
+        # A revision error raised while the REPL is in a non-Julia mode (e.g.
+        # shell mode) must recolor only the `julia>` prompt, and must restore it
+        # to its own original color, rather than leaking the active mode's color
+        # onto `julia>` (issue #755).
+        green = Base.text_colors[:green]
+        red = Base.text_colors[:red]
+        julia_prompt = REPL.LineEdit.Prompt("julia> "; prompt_prefix=green)
+        shell_prompt = REPL.LineEdit.Prompt("shell> "; prompt_prefix=red)
+        term = REPL.Terminals.TTYTerminal("dumb", stdin, stdout, stderr)
+        repl = REPL.LineEditREPL(term, true)
+        repl.interface = REPL.LineEdit.ModalInterface(
+            REPL.LineEdit.TextInterface[julia_prompt, shell_prompt])
+        old_repl = isdefined(Base, :active_repl) ? Base.active_repl : nothing
+        old_prefix = Revise.original_repl_prefix[]
+        try
+            @eval Base active_repl = $repl
+            Revise.original_repl_prefix[] = nothing
+            Revise.maybe_set_prompt_color(:warn)
+            @test julia_prompt.prompt_prefix == "\e[33m"   # yellow
+            @test shell_prompt.prompt_prefix == red        # left untouched
+            Revise.maybe_set_prompt_color(:ok)
+            @test julia_prompt.prompt_prefix == green       # restored, not red
+            @test shell_prompt.prompt_prefix == red
+        finally
+            @eval Base active_repl = $old_repl
+            Revise.original_repl_prefix[] = old_prefix
+        end
+    end
+
     do_test("Methods at REPL") && @testset "Methods at REPL" begin
         if isdefined(Base, :active_repl) && !isnothing(Base.active_repl)
             hp = Base.active_repl.interface.modes[1].hist


### PR DESCRIPTION
`maybe_set_prompt_color` operated on `repl.mistate.current_mode`, the mode active at the moment it ran. When a queued revision error first surfaced while the REPL was in shell mode, it saved the shell prompt's red into the single global save slot and recolored the shell prompt; when the error later resolved, the `:ok` branch wrote that saved red onto the then-active `julia>` prompt, leaving it red instead of restoring green.

Always target the `julia>` prompt (`repl.interface.modes[1]`, the accessor Julia's own REPL.jl uses) for both save and restore, so the yellow warning lands on `julia>` and restoration returns it to its own original color regardless of which mode was active.

Fixes #755