### PR TITLE
Protect all global state with a single coarse lock

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -57,7 +57,7 @@ function add_callback(f, files, modules=nothing; all=false, key=gensym())
     # in case the `all` kwarg was set:
     # add all files which are already known to Revise
     if all
-        for pkgdata in values(pkgdatas)
+        for pkgdata in allpkgdatas()
             append!(files, joinpath.(Ref(basedir(pkgdata)), srcfiles(pkgdata)))
         end
     end
@@ -66,7 +66,8 @@ function add_callback(f, files, modules=nothing; all=false, key=gensym())
         for mod in modules
             track(mod)  # Potentially needed for modules like e.g. Base
             id = PkgId(mod)
-            pkgdata = pkgdatas[id]
+            pkgdata = getpkgdata(id)
+            pkgdata === nothing && continue
             for file in srcfiles(pkgdata)
                 absname = joinpath(basedir(pkgdata), file)
                 push!(files, absname)
@@ -76,11 +77,13 @@ function add_callback(f, files, modules=nothing; all=false, key=gensym())
 
     # There might be duplicate entries in `files`, but it shouldn't cause any
     # problem with the sort of things we do here
-    for file in files
-        cb = get!(Set, user_callbacks_by_file, file)
-        push!(cb, key)
+    @lock revise_lock begin
+        for file in files
+            cb = get!(Set, user_callbacks_by_file, file)
+            push!(cb, key)
+        end
+        user_callbacks_by_key[key] = f
     end
-    user_callbacks_by_key[key] = f
 
     return key
 end
@@ -92,11 +95,13 @@ Remove a callback previously installed by a call to `Revise.add_callback(...)`.
 See its docstring for details.
 """
 function remove_callback(key)
-    for cbs in values(user_callbacks_by_file)
-        delete!(cbs, key)
+    @lock revise_lock begin
+        for cbs in values(user_callbacks_by_file)
+            delete!(cbs, key)
+        end
+        delete!(user_callbacks_queue, key)
+        delete!(user_callbacks_by_key, key)
     end
-    delete!(user_callbacks_queue, key)
-    delete!(user_callbacks_by_key, key)
 
     # possible future work: we may stop watching (some of) these files
     # now. But we don't really keep track of what background tasks are running
@@ -186,7 +191,7 @@ function entr(f::Function, files, modules=nothing; all=false, postpone=false, pa
         return
     end
     # The watch callback fires once per detected change and must return
-    # promptly (it runs while `revise` holds `revision_queue_lock`), so it only
+    # promptly (it runs while `revise` holds `revise_lock`), so it only
     # records a new deadline; the wait and `f()` happen in `run_debounce`. A
     # debounce task already counting down will see the bumped `deadline` and
     # extend itself, so spawn one only when `dtask` is empty. Pairing this with

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -124,6 +124,30 @@ include("callbacks.jl")
 
 ### Globals to keep track of state
 
+# All of Revise's mutable global state (the dictionaries, sets, and vectors
+# defined below) is protected by a single coarse lock. A coarse lock is used
+# because these structures are interdependent and are touched from several
+# threads: the REPL/interactive thread (via `revise`), the package-load callback
+# (`watch_package`, which since Julia 1.12 can run on a background thread when
+# `require` finishes there), and the file/manifest-watcher tasks. Earlier
+# per-structure locks did not compose, so a reader on one thread could observe a
+# dictionary mid-rehash while a writer on another thread mutated it, which
+# segfaults.
+#
+# The lock is a `ReentrantLock`, so nested acquisitions on the same task are
+# fine. It is held only around state access, with one deliberate exception:
+# `revise` holds it across evaluation of revised code to serialize concurrent
+# revisions, as it always has (see issues #837 and #845). It must NOT be held
+# across a blocking `wait`/`sleep`; the watcher tasks therefore acquire it only
+# to enqueue work, never while waiting for filesystem events.
+#
+# Guards: `watched_files`, `watched_manifests`, `revision_queue`, `queue_errors`,
+# `pkgdatas`, `included_files`, `cache_file_key`, `src_file_key`,
+# `dont_watch_pkgs`, `silence_pkgs`, the `user_callbacks_*` collections, and the
+# `@require` bookkeeping. (`types_cache` in visit.jl has its own independent
+# lock, on a separate code path.)
+const revise_lock = ReentrantLock()
+
 """
     Revise.watched_files
 
@@ -134,7 +158,6 @@ This variable allows us to watch directories rather than files, reducing the bur
 the OS.
 """
 const watched_files = Dict{String,WatchList}()
-const watched_files_lock = ReentrantLock()
 
 """
     Revise.watched_manifests
@@ -142,7 +165,6 @@ const watched_files_lock = ReentrantLock()
 Global variable, a set of `Manifest.toml` files from the active projects used during this session.
 """
 const watched_manifests = Set{String}()
-const watched_manifests_lock = ReentrantLock()
 
 """
     Revise.revision_queue
@@ -152,7 +174,6 @@ that these files have changed since we last processed a revision.
 This list gets populated by callbacks that watch directories for updates.
 """
 const revision_queue = Set{Tuple{PkgData,String}}()
-const revision_queue_lock = ReentrantLock() # see issues #837 and #845
 
 """
     Revise.queue_errors
@@ -160,7 +181,7 @@ const revision_queue_lock = ReentrantLock() # see issues #837 and #845
 Global variable, maps `(pkgdata, filename)` pairs that errored upon last revision to
 `(exception, backtrace)`.
 """
-const queue_errors = Dict{Tuple{PkgData,String},Tuple{Exception, Any}}() # locking is covered by revision_queue_lock
+const queue_errors = Dict{Tuple{PkgData,String},Tuple{Exception, Any}}() # locking is covered by revise_lock
 
 # Can we revise types? This is assigned in __init__() based on the Julia version
 # and preference.
@@ -184,7 +205,16 @@ It is a dictionary indexed by PkgId:
 `pkgdatas[id]` returns a value of type [`Revise.PkgData`](@ref).
 """
 const pkgdatas = Dict{PkgId,PkgData}(NOPACKAGE => PkgData(NOPACKAGE))
-const pkgdatas_lock = ReentrantLock()
+
+# Accessors that take `revise_lock` for the duration of a single `pkgdatas`
+# operation. Use these (rather than touching `pkgdatas` directly) anywhere that
+# might run concurrently with package loading, so a read never observes the
+# dictionary mid-rehash. They release the lock before returning, so the result
+# may be stale by the time it is used; any authoritative read-modify-write must
+# happen inside its own `@lock revise_lock` block.
+getpkgdata(id::PkgId) = @lock revise_lock get(pkgdatas, id, nothing)
+haspkgdata(id::PkgId) = @lock revise_lock haskey(pkgdatas, id)
+allpkgdatas() = @lock revise_lock collect(values(pkgdatas))
 
 """
     Revise.included_files
@@ -193,8 +223,7 @@ Global variable, `included_files` gets populated by callbacks we register with `
 It's used to track non-precompiled packages and, optionally, user scripts (see docs on
 `JULIA_REVISE_INCLUDE`).
 """
-const included_files = Tuple{Module,String}[]  # (module, filename)
-const included_files_lock = ReentrantLock()    # issue #947
+const included_files = Tuple{Module,String}[]  # (module, filename); see issue #947
 
 """
     expected_juliadir()
@@ -612,23 +641,25 @@ function init_watching(pkgdata::PkgData, files=srcfiles(pkgdata))
         file = String(file)::String
         dir, basename = splitdir(file)
         dirfull = joinpath(basedir(pkgdata), dir)
-        already_watching_dir = haskey(watched_files, dirfull)
-        @lock watched_files_lock begin
+        # Hold the lock across the whole body: we both query/insert `watched_files`
+        # and mutate the `WatchList` it stores, which the watcher tasks read.
+        @lock revise_lock begin
+            already_watching_dir = haskey(watched_files, dirfull)
             already_watching_dir || (watched_files[dirfull] = WatchList())
-        end
-        watchlist = watched_files[dirfull]
-        current_id = get(watchlist.trackedfiles, basename, nothing)
-        new_id = pkgdata.info.id
-        if new_id != NOPACKAGE || current_id === nothing
-            # Allow the package id to be updated
-            push!(watchlist, basename=>pkgdata)
-            # Record the current ctime as baseline so only future changes are detected
-            watchlist.file_ctimes[basename] = ctime(joinpath(dirfull, basename))
-            if watching_files[]
-                fwatcher = TaskThunk(revise_file_queued, (pkgdata, file))
-                schedule(Task(fwatcher))
-            else
-                already_watching_dir || push!(udirs, dirfull)
+            watchlist = watched_files[dirfull]
+            current_id = get(watchlist.trackedfiles, basename, nothing)
+            new_id = pkgdata.info.id
+            if new_id != NOPACKAGE || current_id === nothing
+                # Allow the package id to be updated
+                push!(watchlist, basename=>pkgdata)
+                # Record the current ctime as baseline so only future changes are detected
+                watchlist.file_ctimes[basename] = ctime(joinpath(dirfull, basename))
+                if watching_files[]
+                    fwatcher = TaskThunk(revise_file_queued, (pkgdata, file))
+                    schedule(Task(fwatcher))
+                else
+                    already_watching_dir || push!(udirs, dirfull)
+                end
             end
         end
     end
@@ -640,7 +671,7 @@ function init_watching(pkgdata::PkgData, files=srcfiles(pkgdata))
     end
     return nothing
 end
-init_watching(files) = init_watching(pkgdatas[NOPACKAGE], files)
+init_watching(files) = init_watching((@lock revise_lock pkgdatas[NOPACKAGE]), files)
 
 """
     revise_dir_queued(dirname::AbstractString)
@@ -666,13 +697,13 @@ This is generally called via a [`Revise.TaskThunk`](@ref).
         latestfiles, stillwatching = watch_files_via_dir(dirname)  # will block here until file(s) change
         for (file, id) in latestfiles
             key = joinpath(dirname, file)
-            if key in keys(user_callbacks_by_file)
-                union!(user_callbacks_queue, user_callbacks_by_file[key])
-                notify(revision_event)
-            end
-            if id != NOPACKAGE
-                pkgdata = pkgdatas[id]
-                @lock revision_queue_lock begin
+            @lock revise_lock begin
+                if key in keys(user_callbacks_by_file)
+                    union!(user_callbacks_queue, user_callbacks_by_file[key])
+                    notify(revision_event)
+                end
+                if id != NOPACKAGE
+                    pkgdata = pkgdatas[id]
                     if hasfile(pkgdata, key)  # issue #228
                         push!(revision_queue, (pkgdata, relpath(key, pkgdata)))
                         notify(revision_event)
@@ -720,15 +751,14 @@ function revise_file_queued(pkgdata::PkgData, file)
             (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
         end
 
-        if file in keys(user_callbacks_by_file)
-            union!(user_callbacks_queue, user_callbacks_by_file[file])
-            notify(revision_event)
-        end
-
-        # Check to see if we're still watching this file
-        stillwatching = haskey(watched_files, dirfull)
-        if PkgId(pkgdata) != NOPACKAGE
-            @lock revision_queue_lock begin
+        @lock revise_lock begin
+            if file in keys(user_callbacks_by_file)
+                union!(user_callbacks_queue, user_callbacks_by_file[file])
+                notify(revision_event)
+            end
+            # Check to see if we're still watching this file
+            stillwatching = haskey(watched_files, dirfull)
+            if PkgId(pkgdata) != NOPACKAGE
                 push!(revision_queue, (pkgdata, relpath(file, pkgdata)))
             end
         end
@@ -924,7 +954,7 @@ end
 Attempt to perform previously-failed revisions. This can be useful in cases of order-dependent errors.
 """
 function retry()
-    @lock revision_queue_lock begin
+    @lock revise_lock begin
         for k in keys(queue_errors)
             push!(revision_queue, k)
         end
@@ -943,7 +973,7 @@ function revise(; throw::Bool=false)
     active[] || return nothing
     sleep(0.01)  # in case the file system isn't quite done writing out the new files
 
-    @lock revision_queue_lock begin
+    @lock revise_lock begin
         have_queue_errors = !isempty(queue_errors)
 
         # Julia 1.12+: when bindings switch to a new type, we need to re-evaluate method
@@ -1075,8 +1105,8 @@ and can lead to long recompilation times.
 function revise(mod::Module; force::Bool=true)
     mod == Main && error("cannot revise(Main)")
     id = PkgId(mod)
-    pkgdata = pkgdatas[id]
-    for file in pkgdata.info.files
+    pkgdata = @lock revise_lock pkgdatas[id]
+    @lock revise_lock for file in pkgdata.info.files
         push!(revision_queue, (pkgdata, file))
     end
     revise()
@@ -1115,8 +1145,8 @@ function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
     isfile(file) || error(file, " is not a file")
     # Determine whether we're already tracking this file
     id = Base.moduleroot(mod) == Main ? PkgId(mod, string(mod)) : PkgId(mod)  # see #689 for `Main`
-    if haskey(pkgdatas, id)
-        pkgdata = pkgdatas[id]
+    pkgdata = getpkgdata(id)
+    if pkgdata !== nothing
         relfile = relpath(abspath_no_normalize(file), pkgdata)
         hasfile(pkgdata, relfile) && return nothing
         # Use any "fixes" provided by relpath
@@ -1137,18 +1167,18 @@ function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
             mode = :sigs   # we already handled evaluation in `parse_source`
         end
         invokelatest(instantiate_sigs!, mod_exs_infos; mode, kwargs...)
-        if !haskey(pkgdatas, id)
+        if !haspkgdata(id)
             # Wait a bit to see if `mod` gets initialized
             sleep(0.1)
         end
-        pkgdata = get(pkgdatas, id, nothing)
+        pkgdata = getpkgdata(id)
         if pkgdata === nothing
             pkgdata = PkgData(id, pathof(mod))
         end
         if !haskey(CodeTracking._pkgfiles, id)
             CodeTracking._pkgfiles[id] = pkgdata.info
         end
-        @lock pkgdatas_lock begin
+        @lock revise_lock begin
             push!(pkgdata, relpath(file, pkgdata)=>FileInfo(mod_exs_infos))
             init_watching(pkgdata, (String(file)::String,))
             pkgdatas[id] = pkgdata
@@ -1267,7 +1297,7 @@ See also [`Revise.unsilence`](@ref).
 """
 silence(pkg::Symbol) = silence(String(pkg))
 function silence(pkg::AbstractString)
-    push!(silence_pkgs, pkg)
+    @lock revise_lock push!(silence_pkgs, pkg)
     Preferences.@set_preferences!("silenced_packages" => collect(silence_pkgs))
     nothing
 end
@@ -1282,7 +1312,7 @@ See also [`Revise.silence`](@ref).
 """
 unsilence(pkg::Symbol) = unsilence(String(pkg))
 function unsilence(pkg::AbstractString)
-    delete!(silence_pkgs, pkg)
+    @lock revise_lock delete!(silence_pkgs, pkg)
     Preferences.@set_preferences!("silenced_packages" => collect(silence_pkgs))
     nothing
 end
@@ -1296,7 +1326,7 @@ The list of excluded packages is stored persistently using Preferences.jl.
 See also [`Revise.allow_watch`](@ref) and [`Revise.silence`](@ref).
 """
 function dont_watch(pkg::Symbol)
-    push!(dont_watch_pkgs, pkg)
+    @lock revise_lock push!(dont_watch_pkgs, pkg)
     Preferences.@set_preferences!("dont_watch_packages" => String[string(p) for p in dont_watch_pkgs])
     nothing
 end
@@ -1311,7 +1341,7 @@ changes to that package again.
 See also [`Revise.dont_watch`](@ref).
 """
 function allow_watch(pkg::Symbol)
-    delete!(dont_watch_pkgs, pkg)
+    @lock revise_lock delete!(dont_watch_pkgs, pkg)
     Preferences.@set_preferences!("dont_watch_packages" => String[string(p) for p in dont_watch_pkgs])
     nothing
 end
@@ -1348,7 +1378,7 @@ function get_def(method::Method; modified_files=revision_queue)
     end
     id = get_tracked_id(method.module; modified_files=modified_files)
     id === nothing && return false
-    pkgdata = pkgdatas[id]
+    pkgdata = @lock revise_lock pkgdatas[id]
     filename = relpath(filename, pkgdata)
     if hasfile(pkgdata, filename)
         def = get_def(method, pkgdata, filename)
@@ -1388,12 +1418,12 @@ end
 
 function get_tracked_id(id::PkgId; modified_files=revision_queue)
     # Methods from Base or the stdlibs may require that we start tracking
-    if !haskey(pkgdatas, id)
+    if !haspkgdata(id)
         recipe = id.name === "Compiler" ? :Compiler : Symbol(id.name)
         recipe === :Core && return nothing
         _track(id, recipe; modified_files=modified_files)
         @info "tracking $recipe"
-        if !haskey(pkgdatas, id)
+        if !haspkgdata(id)
             @warn "despite tracking $recipe, $id was not found"
             return nothing
         end
@@ -1405,7 +1435,7 @@ get_tracked_id(mod::Module; modified_files=revision_queue) =
 
 function get_expressions(id::PkgId, filename)
     get_tracked_id(id)
-    pkgdata = pkgdatas[id]
+    pkgdata = @lock revise_lock pkgdatas[id]
     fi = maybe_parse_from_cache!(pkgdata, filename)
     maybe_extract_sigs!(fi)
     return fi.mod_exs_infos
@@ -1417,7 +1447,7 @@ function add_definitions_from_repl(filename::String)
     entry = hp.history[hp.start_idx+hist_idx]
     src = entry isa AbstractString ? entry : entry.content
     id = PkgId(nothing, "@REPL")
-    pkgdata = pkgdatas[id]
+    pkgdata = @lock revise_lock pkgdatas[id]
     mod_exs_infos = ModuleExprsInfos(Main::Module)
     parse_source!(mod_exs_infos, src, filename, Main::Module)
     instantiate_sigs!(mod_exs_infos)
@@ -1636,7 +1666,7 @@ function __init__()
     end
     # Set up a repository for methods defined at the REPL
     id = PkgId(nothing, "@REPL")
-    @lock pkgdatas_lock begin
+    @lock revise_lock begin
         pkgdatas[id] = PkgData(id, nothing)
     end
     # Set the lookup callbacks
@@ -1646,7 +1676,7 @@ function __init__()
     # Watch the manifest file for changes
     mfile = manifest_file()
     if mfile !== nothing
-        @lock watched_manifests_lock begin
+        @lock revise_lock begin
             push!(watched_manifests, mfile)
             wmthunk = TaskThunk(watch_manifest, (mfile,))
             schedule(Task(wmthunk))
@@ -1733,7 +1763,7 @@ end
 
 function add_revise_deps()
     # Populate CodeTracking data for dependencies and initialize watching on code that Revise depends on
-    @lock pkgdatas_lock begin
+    @lock revise_lock begin
         for mod in (CodeTracking, OrderedCollections, JuliaInterpreter, LoweredCodeUtils, Revise)
             id = PkgId(mod)
             pkgdata = parse_pkg_files(id)

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -22,7 +22,7 @@
 # fallback and synthesize an empty `Main.PkgName` stub (#961).
 function queue_includes!(pkgdata::PkgData, id::PkgId)
     modstring = id.name
-    @lock included_files_lock begin
+    @lock revise_lock begin
         delids = Int[]
         for i = 1:length(included_files)
             mod, fname = included_files[i]
@@ -52,7 +52,7 @@ function queue_includes(mod::Module)
     if has_writable_paths(pkgdata)
         init_watching(pkgdata)
     end
-    @lock pkgdatas_lock pkgdatas[id] = pkgdata
+    @lock revise_lock pkgdatas[id] = pkgdata
     return pkgdata
 end
 
@@ -62,7 +62,7 @@ end
 function remove_from_included_files(modsym::Symbol)
     i = 1
     modstring = string(modsym)
-    @lock included_files_lock begin
+    @lock revise_lock begin
         while i <= length(included_files)
             mod, fname = included_files[i]
             modname = String(Symbol(mod))
@@ -203,20 +203,17 @@ function maybe_add_includes_to_pkgdata!(pkgdata::PkgData, file::AbstractString, 
     end
 end
 
-# Use locking to prevent races between inner and outer @require blocks
-const requires_lock = ReentrantLock()
-
 # This is used by Requires.jl: therefore even if it appears unused by Revise.jl,
 # it cannot be removed as long as we support integration with Requires.jl
 function add_require(sourcefile::String, modcaller::Module, idmod::String, ::String, expr::Expr)
     id = PkgId(modcaller)
     # If this fires when the module is first being loaded (because the dependency
     # was already loaded), Revise may not yet have the pkgdata for this package.
-    if !haskey(pkgdatas, id)
+    if !haspkgdata(id)
         watch_package(id)
     end
 
-    @lock requires_lock begin
+    @lock revise_lock begin
         # Get/create the FileInfo specifically for tracking @require blocks
         pkgdata = pkgdatas[id]
         filekey = relpath(sourcefile, pkgdata) * "__@require__"
@@ -318,11 +315,17 @@ function watch_files_via_dir(dirname::AbstractString)
         (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
     end
     latestfiles = Pair{String,PkgId}[]
-    # Check to see if we're still watching this directory
-    stillwatching = haskey(watched_files, dirname)
+    # Snapshot the tracked files under the lock. We then do the (potentially
+    # blocking) filesystem checks below without holding it, reacquiring only to
+    # read/update ctimes, so we never hold `revise_lock` across `sleep`.
+    snap = @lock revise_lock begin
+        wf = get(watched_files, dirname, nothing)
+        wf === nothing ? nothing : (wf, collect(wf.trackedfiles))
+    end
+    stillwatching = snap !== nothing
     if stillwatching
-        wf = watched_files[dirname]
-        for (file, id) in wf.trackedfiles
+        wf, tracked = snap
+        for (file, id) in tracked
             fullpath = joinpath(dirname, file)
             if isdir(fullpath)
                 # Detected a modification in a directory that we're watching in
@@ -334,21 +337,19 @@ function watch_files_via_dir(dirname::AbstractString)
                 sleep(0.1)
                 if !file_exists(fullpath)
                     push!(latestfiles, file=>id)
-                    wf.file_ctimes[file] = 0.0
+                    @lock revise_lock wf.file_ctimes[file] = 0.0
                     continue
                 end
             end
             current_ctime = ctime(fullpath)
-            if current_ctime != get(wf.file_ctimes, file, current_ctime - 1)
+            if current_ctime != @lock revise_lock get(wf.file_ctimes, file, current_ctime - 1)
                 push!(latestfiles, file=>id)
-                wf.file_ctimes[file] = current_ctime
+                @lock revise_lock wf.file_ctimes[file] = current_ctime
             end
         end
     end
     return latestfiles, stillwatching
 end
-
-const wplock = ReentrantLock()
 
 """
     watch_package(id::Base.PkgId)
@@ -361,9 +362,10 @@ function watch_package(id::PkgId)
     # we may have switched environments, so make sure we're watching the right manifest
     active_project_watcher()
 
-    pkgdata = get(pkgdatas, id, nothing)
-    pkgdata !== nothing && return pkgdata
-    @lock wplock begin
+    local pkgdata   # declared here so it outlives the `try` scope that `@lock` introduces
+    @lock revise_lock begin
+        pkgdata = get(pkgdatas, id, nothing)
+        pkgdata !== nothing && return pkgdata
         modsym = Symbol(id.name)
         if modsym ∈ dont_watch_pkgs
             if id.name ∉ silence_pkgs
@@ -376,7 +378,7 @@ function watch_package(id::PkgId)
         if has_writable_paths(pkgdata)
             init_watching(pkgdata, srcfiles(pkgdata))
         end
-        @lock pkgdatas_lock pkgdatas[id] = pkgdata
+        pkgdatas[id] = pkgdata
     end
     return pkgdata
 end
@@ -403,7 +405,7 @@ function has_writable_paths(pkgdata::PkgData)
 end
 
 function watch_includes(mod::Module, fn::AbstractString)
-    @lock included_files_lock push!(included_files, (mod, abspath_no_normalize(fn)))
+    @lock revise_lock push!(included_files, (mod, abspath_no_normalize(fn)))
 end
 
 ## Working with Pkg and code-loading
@@ -461,22 +463,24 @@ function watch_manifest(mfile::String)
                 isfile(mfile) || return nothing
                 pkgdirs = manifest_paths(mfile)
                 pathreplacements = Pair{String,String}[]
-                for (id, pkgdir) in pkgdirs
-                    if haskey(pkgdatas, id)
-                        pkgdata = pkgdatas[id]
-                        if !samefile(pkgdir, basedir(pkgdata))
-                            ## The package directory has changed
-                            @debug "Pkg" _group="pathswitch" oldpath=basedir(pkgdata) newpath=pkgdir
-                            push!(pathreplacements, basedir(pkgdata)=>pkgdir)
-                            switch_basepath(pkgdata, pkgdir)
+                @lock revise_lock begin
+                    for (id, pkgdir) in pkgdirs
+                        if haskey(pkgdatas, id)
+                            pkgdata = pkgdatas[id]
+                            if !samefile(pkgdir, basedir(pkgdata))
+                                ## The package directory has changed
+                                @debug "Pkg" _group="pathswitch" oldpath=basedir(pkgdata) newpath=pkgdir
+                                push!(pathreplacements, basedir(pkgdata)=>pkgdir)
+                                switch_basepath(pkgdata, pkgdir)
+                            end
                         end
                     end
-                end
-                # Update the paths in the watchlist
-                for (oldpath, newpath) in pathreplacements
-                    for (_, pkgdata) in pkgdatas
-                        if samefile(basedir(pkgdata), oldpath)
-                            switch_basepath(pkgdata, newpath)
+                    # Update the paths in the watchlist
+                    for (oldpath, newpath) in pathreplacements
+                        for (_, pkgdata) in pkgdatas
+                            if samefile(basedir(pkgdata), oldpath)
+                                switch_basepath(pkgdata, newpath)
+                            end
                         end
                     end
                 end
@@ -491,7 +495,7 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
     # Stop all associated watching tasks
     for dir in unique_dirs(srcfiles(pkgdata))
         @debug "Pkg" _group="unwatch" dir=dir
-        @lock watched_files_lock delete!(watched_files, joinpath(basedir(pkgdata), dir))
+        @lock revise_lock delete!(watched_files, joinpath(basedir(pkgdata), dir))
         # Note: if the file is revised, the task(s) will run one more time.
         # However, because we've removed the directory from the watch list this will be a no-op,
         # and then the tasks will be dropped.
@@ -520,7 +524,7 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
             fi
         end
         maybe_extract_sigs!(fi)
-        push!(revision_queue, (pkgdata, file))
+        @lock revise_lock push!(revision_queue, (pkgdata, file))
         push!(files, file)
         mustnotify = true
     end
@@ -536,10 +540,12 @@ end
 
 function active_project_watcher()
     mfile = manifest_file()
-    if !isnothing(mfile) && mfile ∉ watched_manifests
+    isnothing(mfile) && return
+    @lock revise_lock begin
+        mfile ∈ watched_manifests && return
         push!(watched_manifests, mfile)
-        wmthunk = TaskThunk(watch_manifest, (mfile,))
-        schedule(Task(wmthunk))
     end
+    wmthunk = TaskThunk(watch_manifest, (mfile,))
+    schedule(Task(wmthunk))
     return
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -36,7 +36,7 @@ function inpath(path::AbstractString, dirs::Vector{String})
 end
 
 function _track(id::PkgId, modname::Symbol; modified_files=revision_queue)
-    haskey(pkgdatas, id) && return nothing  # already tracked
+    haspkgdata(id) && return nothing  # already tracked
     isbase = modname === :Base
     isstdlib = !isbase && modname ∈ stdlib_names
     if isbase || isstdlib
@@ -63,7 +63,7 @@ function _track(id::PkgId, modname::Symbol; modified_files=revision_queue)
         mtcache = mtime(basesrccache)
         # Initialize expression-tracking for files, and
         # note any modified since Base was built
-        pkgdata = get(pkgdatas, id, nothing)
+        pkgdata = getpkgdata(id)
         if pkgdata === nothing
             pkgdata = PkgData(id, srcdir)
         end
@@ -76,7 +76,7 @@ function _track(id::PkgId, modname::Symbol; modified_files=revision_queue)
         else
             cachefile = basesrccache
         end
-        @lock revision_queue_lock begin
+        @lock revise_lock begin
             for (submod, filename) in modulefiles_basestlibs(id)
                 ffilename = fixpath(filename)
                 inpath(ffilename, dirs) || continue
@@ -101,12 +101,12 @@ function _track(id::PkgId, modname::Symbol; modified_files=revision_queue)
         # Add the files to the watch list
         init_watching(pkgdata, srcfiles(pkgdata))
         # Save the result (unnecessary if already in pkgdatas, but doesn't hurt either)
-        @lock pkgdatas_lock pkgdatas[id] = pkgdata
+        @lock revise_lock pkgdatas[id] = pkgdata
     elseif modname === :Compiler
         compilerdir = joinpath(juliadir, "Compiler", "src")
         compilerdir_pre_112 = joinpath(juliadir, "base", "compiler")
         isdir(compilerdir) || (compilerdir = compilerdir_pre_112)
-        pkgdata = get(pkgdatas, id, nothing)
+        pkgdata = getpkgdata(id)
         if pkgdata === nothing
             pkgdata = PkgData(id, compilerdir)
         end
@@ -153,7 +153,7 @@ function track_subdir_from_git!(pkgdata::PkgData, subdir::AbstractString; commit
     tree = git_tree(repo, commit)
     files = Iterators.filter(file->startswith(file, prefix) && endswith(file, ".jl"), keys(tree))
     ccall((:giterr_clear, :libgit2), Cvoid, ())  # necessary to avoid errors like "the global/xdg file 'attributes' doesn't exist: No such file or directory"
-    @lock revision_queue_lock begin
+    @lock revise_lock begin
         for file in files
             fullpath = joinpath(repo_path, file)
             rpath = relpath(fullpath, pkgdata)  # this might undo the above, except for Core.Compiler
@@ -204,7 +204,7 @@ function track_subdir_from_git!(pkgdata::PkgData, subdir::AbstractString; commit
         id = PkgId(pkgdata)
         CodeTracking._pkgfiles[id] = pkgdata.info
         init_watching(pkgdata, srcfiles(pkgdata))
-        @lock pkgdatas_lock pkgdatas[id] = pkgdata
+        @lock revise_lock pkgdatas[id] = pkgdata
     end
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1809,7 +1809,7 @@ end
 
         # Set up a WatchList as init_watching would (baseline ctime recorded at push time)
         pkgid = Base.PkgId(UUIDs.uuid4(), "tracked1025_test")
-        @lock Revise.watched_files_lock begin
+        @lock Revise.revise_lock begin
             wl = Revise.WatchList()
             push!(wl, basename(tracked_file) => pkgid)
             wl.file_ctimes[basename(tracked_file)] = stat(tracked_file).ctime
@@ -1845,7 +1845,7 @@ end
 
             @test basename(tracked_file) ∈ detected[]
         finally
-            @lock Revise.watched_files_lock begin
+            @lock Revise.revise_lock begin
                 delete!(Revise.watched_files, testdir)
             end
         end


### PR DESCRIPTION
Revise's mutable global state -- `pkgdatas`, `watched_files`, `watched_manifests`, `revision_queue`, `included_files`, the `user_callbacks_*` collections, `cache_file_key`/`src_file_key`, and the `dont_watch`/`silence` sets -- had accumulated several per-structure `ReentrantLock`s applied inconsistently: writers generally took a lock while many readers did not.

This stayed mostly latent while the package-load callback, `revise`, and the file-watcher tasks were effectively cooperatively scheduled. On Julia 1.12 `require` can finish on a background thread, so `watch_package` now runs concurrently with work on the interactive thread and the races become live. vtjnash noticed this problem in JuliaLang/julia#60721.

The fix: collapse the seven separate locks into a single reentrant `revise_lock` and route every accessor through it. The lock is held only around state access, never across a blocking `wait`/`sleep`. `revise` continues to hold it across evaluation to serialize concurrent revisions, as it always has (issues #837, #845). Interactive readers that feed longer computations go through the `getpkgdata`/`haspkgdata`/`allpkgdatas` helpers, which take the lock for just the dictionary operation.

`types_cache` keeps its own independent lock, on a separate code path.

CC @vtjnash