### PR TITLE
Auto-poll files on WSL drvfs/9p mounts

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -202,4 +202,12 @@ string `"1"` (e.g., `JULIA_REVISE_POLL=1` in a bash script).
 !!! note
     NFS stands for [Network File System](https://en.wikipedia.org/wiki/Network_File_System) and is typically only used to mount shared network drives on *Unix* file systems.
     Despite similarities in the acronym, NTFS, the standard [filesystem on Windows](https://en.wikipedia.org/wiki/NTFS), is completely different from NFS; Revise's default configuration should work fine on Windows without polling.
-    However, WSL2 users currently need polling due to [this bug](https://github.com/JuliaLang/julia/issues/37029).
+
+!!! note
+    Under WSL, the Windows filesystem mounted at `/mnt/...` does not deliver file-change
+    notifications to Linux (an upstream [WSL bug](https://github.com/microsoft/WSL/issues/4739),
+    surfaced in Julia as [this issue](https://github.com/JuliaLang/julia/issues/37029)).
+    Revise detects this case automatically and falls back to polling for code stored there,
+    so you should not need to set `JULIA_REVISE_POLL` manually. Code kept in the native Linux
+    filesystem (e.g. under your home directory) continues to use fast notification-based watching.
+    Polling these `/mnt/...` files means revisions may take a few seconds to register.

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -83,12 +83,7 @@ const polling_files = Ref(false)
 # paths Revise must poll regardless of the global `polling_files[]` setting.
 
 const _is_wsl = Ref{Union{Nothing,Bool}}(nothing)
-"""
-    Revise.is_wsl() -> Bool
-
-Return `true` if we are running under the Windows Subsystem for Linux. The result
-is cached after the first call.
-"""
+# Are we running under the Windows Subsystem for Linux? Cached after the first call.
 function is_wsl()
     cached = _is_wsl[]
     cached === nothing || return cached
@@ -136,15 +131,11 @@ end
 mount_fstype(path::AbstractString) =
     fstype_for_path(path, try eachline("/proc/mounts") catch; () end)
 
-"""
-    Revise.nonnotifying_path(path) -> Bool
-
-Return `true` if `path` lives on a filesystem that accepts file-watching calls but
-never delivers change notifications, so Revise must poll instead. The motivating
-case is the Windows filesystem mounted into WSL (a `drvfs`/`9p` mount); see issue
-#514. Only Linux's `/proc/mounts` is consulted, so the result is `false` on every
-other platform.
-"""
+# Does `path` live on a filesystem that accepts file-watching calls but never
+# delivers change notifications, so that Revise must poll instead? The motivating
+# case is the Windows filesystem mounted into WSL (a `drvfs`/`9p` mount); see issue
+# #514. Only Linux's `/proc/mounts` is consulted, so the result is `false` on every
+# other platform.
 function nonnotifying_path(path::AbstractString)
     is_wsl() || return false
     fstype = mount_fstype(path)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -75,9 +75,86 @@ on such filesystems you should turn polling on.
 See the documentation for the `JULIA_REVISE_POLL` environment variable.
 """
 const polling_files = Ref(false)
+
+# Some filesystems accept `watch_file`/`watch_dir` calls but never deliver a
+# notification, so the watch silently blocks forever. The motivating case is the
+# Windows filesystem mounted into WSL under `/mnt/...` (a `drvfs`/`9p` mount):
+# inotify is broken there but `stat`-based polling works (issue #514). On such
+# paths Revise must poll regardless of the global `polling_files[]` setting.
+
+const _is_wsl = Ref{Union{Nothing,Bool}}(nothing)
+"""
+    Revise.is_wsl() -> Bool
+
+Return `true` if we are running under the Windows Subsystem for Linux. The result
+is cached after the first call.
+"""
+function is_wsl()
+    cached = _is_wsl[]
+    cached === nothing || return cached
+    wsl = false
+    if Sys.islinux()
+        try
+            wsl = occursin(r"microsoft|WSL"i, read("/proc/sys/kernel/osrelease", String))
+        catch
+            wsl = false
+        end
+    end
+    return _is_wsl[] = wsl
+end
+
+# `/proc/mounts` encodes spaces, tabs, etc. in mount points as octal escapes.
+function unescape_mount(s::AbstractString)
+    occursin('\\', s) || return s
+    return replace(s, r"\\([0-7]{3})" => m -> string(Char(parse(UInt8, m[2:end]; base=8))))
+end
+
+# Is `prefix` a path-component prefix of `path`? (`/mnt` is a prefix of `/mnt/c`
+# but not of `/mnts`.)
+function is_path_prefix(prefix::AbstractString, path::AbstractString)
+    prefix == path && return true
+    prefix == "/" && return startswith(path, "/")
+    return startswith(path, prefix * "/")
+end
+
+# Filesystem type for the most specific mount point containing `path`, given the
+# lines of a `/proc/mounts`-format table. Returns "" if none matches.
+function fstype_for_path(path::AbstractString, mount_lines)
+    apath = abspath(path)
+    best_mount = best_fstype = ""
+    for line in mount_lines
+        fields = split(line)
+        length(fields) >= 3 || continue
+        mountpoint = unescape_mount(fields[2])
+        if is_path_prefix(mountpoint, apath) && length(mountpoint) >= length(best_mount)
+            best_mount, best_fstype = mountpoint, fields[3]
+        end
+    end
+    return best_fstype
+end
+
+mount_fstype(path::AbstractString) =
+    fstype_for_path(path, try eachline("/proc/mounts") catch; () end)
+
+"""
+    Revise.nonnotifying_path(path) -> Bool
+
+Return `true` if `path` lives on a filesystem that accepts file-watching calls but
+never delivers change notifications, so Revise must poll instead. The motivating
+case is the Windows filesystem mounted into WSL (a `drvfs`/`9p` mount); see issue
+#514. Only Linux's `/proc/mounts` is consulted, so the result is `false` on every
+other platform.
+"""
+function nonnotifying_path(path::AbstractString)
+    is_wsl() || return false
+    fstype = mount_fstype(path)
+    return fstype == "9p" || fstype == "drvfs"
+end
+
 function wait_changed(file)
+    poll = polling_files[] || nonnotifying_path(file)
     try
-        polling_files[] ? poll_file(file) : watch_file(file)
+        poll ? poll_file(file) : watch_file(file)
     catch err
         if Sys.islinux() && err isa Base.IOError && err.code == -28  # ENOSPC; issue #1010
             @warn """Revise was unable to watch files for changes via inotify (ENOSPC).
@@ -654,7 +731,16 @@ function init_watching(pkgdata::PkgData, files=srcfiles(pkgdata))
                 push!(watchlist, basename=>pkgdata)
                 # Record the current ctime as baseline so only future changes are detected
                 watchlist.file_ctimes[basename] = ctime(joinpath(dirfull, basename))
-                if watching_files[]
+                # On filesystems that never deliver notifications (e.g. WSL drvfs,
+                # issue #514) we must watch each file individually and poll it;
+                # directory-polling cannot detect content changes within a file.
+                if watching_files[] || nonnotifying_path(dirfull)
+                    if !watching_files[]
+                        @info """Revise: code under $dirfull is on a filesystem that does not deliver \
+                                 file-change notifications (e.g. a WSL `/mnt/...` drive, issue #514). \
+                                 Falling back to polling these files; revisions may take a few seconds \
+                                 to register.""" maxlog=1
+                    end
                     fwatcher = TaskThunk(revise_file_queued, (pkgdata, file))
                     schedule(Task(fwatcher))
                 else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -446,6 +446,35 @@ end
         @test occursin("1/1 parsed files", str)
     end
 
+    do_test("Non-notifying filesystems (issue #514)") && @testset "Non-notifying filesystems (issue #514)" begin
+        # Path-prefix matching must respect path components.
+        @test Revise.is_path_prefix("/mnt", "/mnt/c")
+        @test Revise.is_path_prefix("/mnt/c", "/mnt/c")
+        @test Revise.is_path_prefix("/", "/anything")
+        @test !Revise.is_path_prefix("/mnt", "/mnts")
+        @test !Revise.is_path_prefix("/mnt/c", "/mnt")
+
+        # `/proc/mounts` escapes spaces, backslashes, etc. as octal.
+        @test Revise.unescape_mount("C:\\134") == "C:\\"
+        @test Revise.unescape_mount("a\\040b") == "a b"
+        @test Revise.unescape_mount("/plain/path") == "/plain/path"
+
+        # The fstype is taken from the most specific (longest) matching mount point.
+        mounts = [
+            "drivers /usr/lib/wsl/drivers 9p ro 0 0",
+            "C:\\134 /mnt/c 9p rw,aname=drvfs 0 0",
+            "/dev/sdc / ext4 rw 0 0",
+        ]
+        @test Revise.fstype_for_path("/mnt/c/Users/foo", mounts) == "9p"
+        @test Revise.fstype_for_path("/home/tim/x", mounts) == "ext4"
+        @test Revise.fstype_for_path("/mnt/cdrom/x", mounts) == "ext4"  # not under /mnt/c
+
+        # Off WSL, no path is ever treated as non-notifying.
+        if !Revise.is_wsl()
+            @test !Revise.nonnotifying_path("/mnt/c/whatever")
+        end
+    end
+
     do_test("File paths") && @testset "File paths" begin
         testdir = newtestdir()
         for wf in (Revise.watching_files[] ? (true,) : (true, false))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -460,14 +460,18 @@ end
         @test Revise.unescape_mount("/plain/path") == "/plain/path"
 
         # The fstype is taken from the most specific (longest) matching mount point.
-        mounts = [
-            "drivers /usr/lib/wsl/drivers 9p ro 0 0",
-            "C:\\134 /mnt/c 9p rw,aname=drvfs 0 0",
-            "/dev/sdc / ext4 rw 0 0",
-        ]
-        @test Revise.fstype_for_path("/mnt/c/Users/foo", mounts) == "9p"
-        @test Revise.fstype_for_path("/home/tim/x", mounts) == "ext4"
-        @test Revise.fstype_for_path("/mnt/cdrom/x", mounts) == "ext4"  # not under /mnt/c
+        # These use Unix-style absolute paths (the only ones `/proc/mounts` describes),
+        # so restrict to Unix where `abspath` leaves them unchanged.
+        if Sys.isunix()
+            mounts = [
+                "drivers /usr/lib/wsl/drivers 9p ro 0 0",
+                "C:\\134 /mnt/c 9p rw,aname=drvfs 0 0",
+                "/dev/sdc / ext4 rw 0 0",
+            ]
+            @test Revise.fstype_for_path("/mnt/c/Users/foo", mounts) == "9p"
+            @test Revise.fstype_for_path("/home/tim/x", mounts) == "ext4"
+            @test Revise.fstype_for_path("/mnt/cdrom/x", mounts) == "ext4"  # not under /mnt/c
+        end
 
         # Off WSL, no path is ever treated as non-notifying.
         if !Revise.is_wsl()


### PR DESCRIPTION
Under WSL, the Windows filesystem mounted at /mnt/... accepts inotify watches but never delivers notifications, so file-watching silently blocks forever and revisions go unnoticed. The watch does not error, so the existing ENOSPC handler never helped. `stat`-based polling does work on these mounts.

Detect this case (WSL kernel plus a 9p/drvfs mount, read from /proc/mounts) and fall back to per-file polling only for the affected files; native-filesystem packages keep fast notification-based watching. A one-time message explains the fallback and its latency. The detection is gated to WSL and short-circuits to false off Linux, so it adds no cost elsewhere.

Fixes #514