### PR TITLE
Re-alias orphaned function bindings on revision

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1153,6 +1153,121 @@ function redefine_bindings!(revision_errors::Vector{Tuple{PkgData,String}}, reev
     return revision_errors
 end
 
+# Extract the singleton function instance from a method signature `Tuple{typeof(f), ...}`.
+# Returns `nothing` for constructors (`Type{T}`) or callable objects with no singleton instance.
+function sig_function(@nospecialize(sig))
+    ft = Base.unwrap_unionall(sig)
+    ft isa DataType && !isempty(ft.parameters) || return nothing
+    F = Base.unwrap_unionall(ft.parameters[1])
+    (F isa DataType && isdefined(F, :instance)) || return nothing
+    return F.instance
+end
+
+# Collect the set of method signatures defined by the `SigInfo`s in `exs_infos`.
+function sigset(exs_infos::ExprsInfos)
+    sigs = Set{Any}()
+    for (_, exinfos) in exs_infos
+        exinfos === nothing && continue
+        for exinfo in exinfos
+            exinfo isa SigInfo || continue
+            push!(sigs, exinfo.sig)
+        end
+    end
+    return sigs
+end
+
+# Issue #239. An accidental definition such as
+#     foo() = iterate(x)        # intends to call Base.iterate
+#     iterate(x::Foo) = ...     # OOPS: defines a *new* `MyMod.iterate`, shadowing Base.iterate
+# creates a module-local `iterate` that shadows the imported one, and `foo`
+# binds to it. When the user corrects it to `Base.iterate(x::Foo) = ...`, Revise
+# deletes the wrong method, but the now-methodless `MyMod.iterate` binding
+# lingers; unqualified references keep resolving to it, so the package stays
+# broken until the session is restarted.
+#
+# This shadowing can only happen for a name that was implicitly in scope; an
+# explicit import errors when code like the above is encountered. Thus if an
+# edit (a) *empties* a module-owned function binding and (b) adds a method to a
+# *different* function of the same name that is implicitly in scope, we take a
+# stab at guessing user-intent and make the change. Because this involves
+# inference on Revise's part, we log this with an `@info`.
+#
+# Requires binding partitions (Julia 1.12+): earlier, function bindings are
+# `const` and cannot be reassigned, and `delete_binding` does not exist.
+# This 1.12+ feature is not hidden behind a check on `__bpart__`, as that
+# focuses on type-redefinition.
+function realias_orphaned_bindings!(mod_exs_infos_new::ModuleExprsInfos,
+                                    mod_exs_infos_old::ModuleExprsInfos)
+    Base.VERSION >= v"1.12.0-DEV.2047" || return nothing
+    repaired = Tuple{Module,Symbol,Module}[]
+    with_logger(_debug_logger) do
+        for (mod, exs_infos_old) in mod_exs_infos_old
+            oldsigs = sigset(exs_infos_old)
+            newsigs = sigset(get(mod_exs_infos_new, mod, empty_exs_infos))
+            # (b) functions that gained a method this revision, indexed by name
+            added = Dict{Symbol,Any}()
+            for s in newsigs
+                s in oldsigs && continue
+                f = sig_function(s)
+                f === nothing && continue
+                added[nameof(f)] = f
+            end
+            isempty(added) && continue
+            # (a) functions that lost a method this revision and are now empty + module-owned
+            for s in oldsigs
+                s in newsigs && continue
+                fdel = sig_function(s)
+                fdel === nothing && continue
+                isempty(methods(fdel)) || continue       # still has methods => not orphaned
+                parentmodule(fdel) === mod || continue    # only repair bindings this module owns
+                n = nameof(fdel)
+                fadd = get(added, n, nothing)
+                (fadd === nothing || fadd === fdel) && continue
+                # Only repair when `fadd` was implicitly in scope (an export of a module `mod`
+                # bare-`using`s, including Base/Core): that is the sole situation that can
+                # produce this shadow, so re-importing reproduces the original implicit scope.
+                src = implicit_import_source(mod, n, fadd)
+                src === nothing && continue
+                # `delete_binding` clears the orphan; `using src: n` re-establishes the import.
+                # A bare `delete_binding` is not enough: implicit-import fallthrough after
+                # deletion is not yet implemented, so `n` would resolve to `UndefVarError`.
+                # TODO: replicate to distributed workers (cf. `delete_method_by_sig`).
+                # See https://github.com/timholy/Revise.jl/pull/1056#discussion_r3338811301
+                try
+                    Base.delete_binding(mod, n)
+                    usestmt = Expr(:using, Expr(:(:), Expr(:., fullname(src)...), Expr(:., n)))
+                    Core.eval(mod, usestmt)
+                    @debug "RealiasOrphan" _group="Action" time=time() deltainfo=(mod, n, src)
+                    push!(repaired, (mod, n, src))
+                catch err
+                    @debug "RealiasOrphanFailed" _group="Action" time=time() deltainfo=(mod, n, err)
+                end
+            end
+        end
+    end
+    # Surface the repair to the user. Unlike method deletion/redefinition (logged only at
+    # `@debug`), this is a binding mutation Revise infers — it does not correspond 1:1 to a
+    # source edit the user made — so it is worth an `@info`.
+    for (mod, n, src) in repaired
+        @info "Revise re-imported `$n` into `$mod` from `$src`, repairing an orphaned binding (issue #239)"
+    end
+    return nothing
+end
+
+# If `n` is implicitly in scope in `mod` — an export of a module `mod` brings in via a bare
+# `using` (including the implicit `Base`/`Core`) — and that export is the function `f`, return
+# the module supplying it; otherwise `nothing`. This is precisely the condition under which an
+# unqualified `n(x::T) = ...` definition shadows `f` with a new module-local binding (#239).
+function implicit_import_source(mod::Module, n::Symbol, @nospecialize(f))
+    for used in ccall(:jl_module_usings, Any, (Any,), mod)::Vector{Any}
+        used isa Module || continue
+        Base.isexported(used, n) || continue
+        isdefined(used, n) || continue
+        getglobal(used, n) === f && return used
+    end
+    return nothing
+end
+
 """
     Revise.revise_file_now(pkgdata::PkgData, file)
 
@@ -1178,6 +1293,7 @@ function revise_file_now(pkgdata::PkgData, file)
     mod_exs_infos_new, mod_exs_infos_old = handle_deletions(pkgdata, file, reeval_list, handled_types, world)
     if mod_exs_infos_new != nothing
         _, includes = eval_new!(mod_exs_infos_new, mod_exs_infos_old)
+        realias_orphaned_bindings!(mod_exs_infos_new, mod_exs_infos_old)   # issue #239
         fi = fileinfo(pkgdata, i)
         pkgdata.fileinfos[i] = FileInfo(mod_exs_infos_new, fi)
         maybe_add_includes_to_pkgdata!(pkgdata, file, includes; eval_now=true)
@@ -1354,6 +1470,7 @@ function revise(; throw::Bool=false)
                 pkgdata.fileinfos[i] = FileInfo(mod_exs_infos_new, fi)
             end
             if isempty(modsremaining)
+                realias_orphaned_bindings!(mod_exs_infos_new, fi.mod_exs_infos)  # issue #239
                 delete!(queue_errors, (pkgdata, file))
             else
                 throw && Base.throw(err)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -873,7 +873,13 @@ end
         @test Namespace.sin(0) == 10
         @test Base.sin(0) == 0
         @test Base.cos(Namespace.X()) == 20
-        @test_throws MethodError Namespace.cos(Namespace.X())
+        if Base.VERSION >= v"1.12.0-DEV.2047"
+            # The orphaned local `cos` is re-imported from `Base` (issue #239), matching what
+            # a fresh load of the revised source would give (`Namespace.cos === Base.cos`).
+            @test Namespace.cos(Namespace.X()) == 20
+        else
+            @test_throws MethodError Namespace.cos(Namespace.X())
+        end
 
         rm_precompile("Namespace")
         pop!(LOAD_PATH)
@@ -2168,6 +2174,101 @@ end
             m = @which ReviseTestPrivate.methspecificity(1)
             @test m.sig.parameters[2] === Integer
         end
+    end
+
+    # Repairing an orphaned binding requires binding partitions (`delete_binding`, 1.12+).
+    do_test("Orphaned binding realias (issue #239)") && Base.VERSION >= v"1.12.0-DEV.2047" &&
+            @testset "Orphaned binding realias (issue #239)" begin
+        # An accidental `iterate(x::Foo)=...` defines a module-local `iterate` that shadows
+        # `Base.iterate`, and `caller` binds to it. Correcting it to `Base.iterate(x::Foo)=...`
+        # must leave the unqualified reference in `caller` resolving to `Base.iterate`, without
+        # a session restart.
+        testdir = newtestdir()
+        dn = joinpath(testdir, "Orphan239", "src"); mkpath(dn)
+        fn = joinpath(dn, "Orphan239.jl")
+        write(fn, """
+            module Orphan239
+            struct Foo end
+            caller() = iterate(Foo())
+            iterate(x::Foo) = (42, nothing)   # accidental shadow of Base.iterate
+            end
+            """)
+        sleep(mtimedelay)
+        @eval using Orphan239
+        @test Orphan239.caller() == (42, nothing)
+        @test Orphan239.iterate !== Base.iterate
+        sleep(mtimedelay)
+        write(fn, """
+            module Orphan239
+            struct Foo end
+            caller() = iterate(Foo())
+            Base.iterate(x::Foo) = (42, nothing)   # fixed: extend Base.iterate
+            end
+            """)
+        @yry()
+        @test Orphan239.iterate === Base.iterate     # orphaned binding re-imported from Base
+        @test Orphan239.caller() == (42, nothing)    # `caller` works again, no restart
+
+        rm_precompile("Orphan239")
+
+        # The bug is not specific to `Base`: it arises for any name brought into implicit scope
+        # by a bare `using`. Here `flatten` (not a `Base` export) is shadowed via
+        # `using Base.Iterators`, and the repair must re-import it from `Base.Iterators`.
+        dn = joinpath(testdir, "Orphan239c", "src"); mkpath(dn)
+        fn = joinpath(dn, "Orphan239c.jl")
+        write(fn, """
+            module Orphan239c
+            using Base.Iterators
+            struct Foo end
+            caller() = flatten(Foo())
+            flatten(x::Foo) = :shadow   # accidental shadow of Base.Iterators.flatten
+            end
+            """)
+        sleep(mtimedelay)
+        @eval using Orphan239c
+        @test Orphan239c.caller() == :shadow
+        @test Orphan239c.flatten !== Base.Iterators.flatten
+        sleep(mtimedelay)
+        write(fn, """
+            module Orphan239c
+            using Base.Iterators
+            struct Foo end
+            caller() = flatten(Foo())
+            Base.Iterators.flatten(x::Foo) = :fixed   # fixed: extend Base.Iterators.flatten
+            end
+            """)
+        @yry()
+        @test Orphan239c.flatten === Base.Iterators.flatten   # re-imported from Base.Iterators
+        @test Orphan239c.caller() == :fixed                   # `caller` works again, no restart
+
+        rm_precompile("Orphan239c")
+
+        # The repair must be narrow: deleting a method that is NOT replaced by a same-named
+        # function leaves the (now empty) binding alone rather than re-importing it.
+        dn = joinpath(testdir, "Orphan239b", "src"); mkpath(dn)
+        fn = joinpath(dn, "Orphan239b.jl")
+        write(fn, """
+            module Orphan239b
+            gone(x::Int) = 1
+            keep() = 2
+            end
+            """)
+        sleep(mtimedelay)
+        @eval using Orphan239b
+        @test Orphan239b.gone(0) == 1
+        sleep(mtimedelay)
+        write(fn, """
+            module Orphan239b
+            function fwd end    # genuine forward declaration, must stay empty
+            keep() = 3
+            end
+            """)
+        @yry()
+        @test Orphan239b.keep() == 3
+        @test isempty(methods(Orphan239b.gone))             # emptied, not re-imported
+        @test isdefined(Orphan239b, :fwd) && isempty(methods(Orphan239b.fwd))  # left untouched
+
+        rm_precompile("Orphan239b")
     end
 
     do_test("Duplicate macro-defined methods") && @testset "Duplicate macro-defined methods" begin


### PR DESCRIPTION
When a method is accidentally defined as `f(x::Foo) = ...` (creating a new module-local `f` that shadows an imported `Base.f`) and then corrected to `Base.f(x::Foo) = ...`, deleting the mistaken method left the now-methodless local `f` binding in place. Unqualified references elsewhere in the module kept resolving to it, so the package stayed broken until a session restart.

This was previously a hard Julia limitation: function bindings are `const` and could not be reassigned. Binding partitions (Julia 1.12+) permit a `const` redefinition, so when one revision both empties a module-owned function binding and adds a method to a different function of the same name, we read that as the method having moved and alias the orphaned binding onto the function the user actually extended. The repair is surfaced with an `@info`, since it is a binding mutation Revise infers rather than one the user wrote directly.

The change applies only on Julia 1.12+; on earlier versions the behavior is unchanged. This is not subject to the LocalPreferences.toml `revise_structs` setting. If it were, the name alone would be misleading. Moreover, the underlying purpose of that setting is to handle the fact that walking the type-tree is currently too slow to be on-by-default. This change does not involve the type-tree and should be fast enough to be on by default.

Fixes #239