### PR TITLE
Tolerate transient absence of watched paths

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -791,6 +791,12 @@ This is generally called via a [`Revise.TaskThunk`](@ref).
                     with_logger(SimpleLogger(stderr)) do
                         @warn "$dirname is not an existing directory, Revise is not watching"
                     end
+                    # Drop the watch registration as we stop. Otherwise, if `dirname`
+                    # is recreated later (e.g. switching back to a branch that has it),
+                    # `init_watching` would see the stale entry, assume a watcher is
+                    # already running, and never start a replacement — so edits to the
+                    # reappeared files would go unnoticed.
+                    @lock revise_lock delete!(watched_files, dirname)
                 end
                 break
             end

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -750,6 +750,29 @@ function init_watching(pkgdata::PkgData, files=srcfiles(pkgdata))
 end
 init_watching(files) = init_watching((@lock revise_lock pkgdatas[NOPACKAGE]), files)
 
+# Maximum time (in seconds) a watched path may be absent before Revise concludes
+# it was genuinely removed. A shorter absence is treated as transient: a
+# `Pkg.build`, a git checkout, an environment switch, or an editor's
+# atomic-rename save can briefly remove and recreate a directory or file, and in
+# those cases the watch should resume silently rather than stop and warn (#523).
+const watch_reappear_grace = Ref(5.0)
+
+# Block while a watched path is missing. `exists(path)` reports whether it is
+# currently present; `watchkey` is its entry in `watched_files`. Returns:
+#   :reappeared — came back within the grace period (resume watching)
+#   :removed    — no longer in the watch list, e.g. the package moved (stop quietly)
+#   :gone       — stayed missing past the grace period (stop and warn)
+function await_watched_path(exists, path::AbstractString, watchkey::AbstractString)
+    waited = 0.0
+    while !exists(path)
+        @lock revise_lock haskey(watched_files, watchkey) || return :removed
+        waited ≥ watch_reappear_grace[] && return :gone
+        sleep(0.1)
+        waited += 0.1
+    end
+    return :reappeared
+end
+
 """
     revise_dir_queued(dirname::AbstractString)
 
@@ -759,16 +782,18 @@ This is generally called via a [`Revise.TaskThunk`](@ref).
 """
 @noinline function revise_dir_queued(dirname::AbstractString)
     @assert isabspath(dirname)
-    if !isdir(dirname)
-        sleep(0.1)   # in case git has done a delete/replace cycle
-    end
     stillwatching = true
     while stillwatching
         if !isdir(dirname)
-            with_logger(SimpleLogger(stderr)) do
-                @warn "$dirname is not an existing directory, Revise is not watching"
+            status = await_watched_path(isdir, dirname, dirname)
+            if status !== :reappeared
+                if status === :gone
+                    with_logger(SimpleLogger(stderr)) do
+                        @warn "$dirname is not an existing directory, Revise is not watching"
+                    end
+                end
+                break
             end
-            break
         end
 
         latestfiles, stillwatching = watch_files_via_dir(dirname)  # will block here until file(s) change
@@ -805,21 +830,24 @@ function revise_file_queued(pkgdata::PkgData, file)
     if !isabspath(file)
         file = joinpath(basedir(pkgdata), file)
     end
-    if !file_exists(file)
-        sleep(0.1)  # in case git has done a delete/replace cycle
-    end
 
     dirfull, _ = splitdir(file)
+    fileexists(f) = file_exists(f) || isdir(f)
     stillwatching = true
     while stillwatching
-        if !file_exists(file) && !isdir(file)
-            let file=file
-                with_logger(SimpleLogger(stderr)) do
-                    @warn "$file is not an existing file, Revise is not watching"
+        if !fileexists(file)
+            status = await_watched_path(fileexists, file, dirfull)
+            if status !== :reappeared
+                if status === :gone
+                    let file=file
+                        with_logger(SimpleLogger(stderr)) do
+                            @warn "$file is not an existing file, Revise is not watching"
+                        end
+                    end
                 end
+                notify(revision_event)
+                break
             end
-            notify(revision_event)
-            break
         end
         try
             wait_changed(file)  # will block here until the file changes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4774,9 +4774,12 @@ do_test("watch reappearance") && @testset "watch reappearance" begin
     end
 end
 
-# FSEvents does not reliably deliver directory-removal events, so this round-trip
-# is exercised only in directory-watching mode off macOS (cf. the `Cleanup` test).
-do_test("re-watch after reappearance") && !Revise.watching_files[] && !Sys.isapple() &&
+# Restricted to directory-watching mode on Linux: this exercises a full
+# delete/recreate/edit round-trip through the filesystem watcher, and only inotify
+# delivers those events reliably enough to test. (FSEvents drops directory-removal
+# events -- cf. the `Cleanup` test -- and on Windows a same-path recreate-then-edit
+# races ReadDirectoryChangesW arming.) The fix itself is platform-general.
+do_test("re-watch after reappearance") && !Revise.watching_files[] && Sys.islinux() &&
         @testset "re-watch after reappearance (#1057)" begin
     # A branch switch can remove a watched subdirectory and later restore it. When
     # it reappears, Revise must resume watching it so that subsequent edits are

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4743,6 +4743,37 @@ do_test("misc - coverage") && !isinteractive() && @testset "misc - coverage" beg
     @test isnothing(Revise.revise(REPL.REPLBackend()))
 end
 
+do_test("watch reappearance") && @testset "watch reappearance" begin
+    # A transiently-missing watched path must not be abandoned (#523): the watcher
+    # waits up to `watch_reappear_grace[]` for it to return before giving up.
+    dir = mktempdir()
+    key = dir
+    Revise.watched_files[key] = Revise.WatchList()
+    old_grace = Revise.watch_reappear_grace[]
+    try
+        # Present: resume immediately.
+        @test Revise.await_watched_path(isdir, dir, key) === :reappeared
+        # Missing but reappears within the grace period: resume.
+        rm(dir; recursive=true)
+        recreate = @async (sleep(0.3); mkdir(dir))
+        Revise.watch_reappear_grace[] = 5.0
+        @test Revise.await_watched_path(isdir, dir, key) === :reappeared
+        wait(recreate)
+        # Missing past the grace period: give up (and the caller warns).
+        rm(dir; recursive=true)
+        Revise.watch_reappear_grace[] = 0.2
+        @test Revise.await_watched_path(isdir, dir, key) === :gone
+        # Missing and no longer registered (package moved/removed): give up quietly.
+        Revise.watch_reappear_grace[] = 5.0
+        delete!(Revise.watched_files, key)
+        @test Revise.await_watched_path(isdir, dir, key) === :removed
+    finally
+        Revise.watch_reappear_grace[] = old_grace
+        haskey(Revise.watched_files, key) && delete!(Revise.watched_files, key)
+        isdir(dir) && rm(dir; recursive=true)
+    end
+end
+
 do_test("deprecated") && @testset "deprecated" begin
     @test_logs (:warn, r"`steal_repl_backend` has been removed.*") Revise.async_steal_repl_backend()
     @test_logs (:warn, r"`steal_repl_backend` has been removed.*") Revise.wait_steal_repl_backend()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4774,6 +4774,65 @@ do_test("watch reappearance") && @testset "watch reappearance" begin
     end
 end
 
+# FSEvents does not reliably deliver directory-removal events, so this round-trip
+# is exercised only in directory-watching mode off macOS (cf. the `Cleanup` test).
+do_test("re-watch after reappearance") && !Revise.watching_files[] && !Sys.isapple() &&
+        @testset "re-watch after reappearance (#1057)" begin
+    # A branch switch can remove a watched subdirectory and later restore it. When
+    # it reappears, Revise must resume watching it so that subsequent edits are
+    # still detected, rather than leaving a stale, watcher-less registration.
+    testdir = newtestdir()
+    dn = joinpath(testdir, "ReWatch", "src")
+    mkpath(joinpath(dn, "sub"))
+    withinclude = """
+        module ReWatch
+        include("sub/extra.jl")
+        f() = 1
+        end
+        """
+    noinclude = """
+        module ReWatch
+        f() = 1
+        end
+        """
+    write(joinpath(dn, "ReWatch.jl"), withinclude)
+    write(joinpath(dn, "sub", "extra.jl"), "g() = 2")
+    sleep(mtimedelay)
+    @eval using ReWatch
+    sleep(mtimedelay)
+    subdir = joinpath(dn, "sub")
+    @test ReWatch.f() == 1
+    @test ReWatch.g() == 2
+    @test haskey(Revise.watched_files, subdir)
+
+    old_grace = Revise.watch_reappear_grace[]
+    Revise.watch_reappear_grace[] = 0.0   # give up promptly so the round-trip is quick
+    try
+        # "Switch away": drop the subdirectory and the `include`.
+        rm(subdir; recursive=true)
+        write(joinpath(dn, "ReWatch.jl"), noinclude)
+        # The watcher must relinquish the directory: releasing its registration is
+        # exactly what lets a fresh watcher start when the directory returns.
+        @test timedwait(() -> !haskey(Revise.watched_files, subdir), event_timeout) === :ok
+        @yry
+
+        # "Switch back": restore the subdirectory and the `include`.
+        mkdir(subdir)
+        write(joinpath(subdir, "extra.jl"), "g() = 2")
+        write(joinpath(dn, "ReWatch.jl"), withinclude)
+        @yry
+        @test haskey(Revise.watched_files, subdir)
+        @test ReWatch.g() == 2
+
+        # The crucial check: an edit to the reappeared file is detected.
+        write(joinpath(subdir, "extra.jl"), "g() = 99")
+        @yry
+        @test ReWatch.g() == 99
+    finally
+        Revise.watch_reappear_grace[] = old_grace
+    end
+end
+
 do_test("deprecated") && @testset "deprecated" begin
     @test_logs (:warn, r"`steal_repl_backend` has been removed.*") Revise.async_steal_repl_backend()
     @test_logs (:warn, r"`steal_repl_backend` has been removed.*") Revise.wait_steal_repl_backend()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4783,26 +4783,35 @@ println("beginning cleanup")
 GC.gc(); GC.gc()
 
 @testset "Cleanup" begin
-    logs, _ = Test.collect_test_logs() do
-        warnfile = randtmp()
-        open(warnfile, "w") do io
-            redirect_stderr(io) do
-                for name in to_remove
-                    try
-                        rm(name; force=true, recursive=true)
-                        deleteat!(LOAD_PATH, findall(LOAD_PATH .== name))
-                    catch
+    # The watchers defer their "is not watching" warning by `watch_reappear_grace`
+    # to ride out transient disappearances (#523). These deletions are permanent,
+    # so drop the grace to make the warning fire promptly within the window below.
+    old_grace = Revise.watch_reappear_grace[]
+    Revise.watch_reappear_grace[] = 0.0
+    try
+        logs, _ = Test.collect_test_logs() do
+            warnfile = randtmp()
+            open(warnfile, "w") do io
+                redirect_stderr(io) do
+                    for name in to_remove
+                        try
+                            rm(name; force=true, recursive=true)
+                            deleteat!(LOAD_PATH, findall(LOAD_PATH .== name))
+                        catch
+                        end
+                    end
+                    for i = 1:3
+                        yry()
+                        GC.gc()
                     end
                 end
-                for i = 1:3
-                    yry()
-                    GC.gc()
-                end
             end
+            msg = Revise.watching_files[] ? "is not an existing file" : "is not an existing directory"
+            isempty(ARGS) && !Sys.isapple() && @test occursin(msg, read(warnfile, String))
+            rm(warnfile)
         end
-        msg = Revise.watching_files[] ? "is not an existing file" : "is not an existing directory"
-        isempty(ARGS) && !Sys.isapple() && @test occursin(msg, read(warnfile, String))
-        rm(warnfile)
+    finally
+        Revise.watch_reappear_grace[] = old_grace
     end
 end
 


### PR DESCRIPTION
A watched directory or file can disappear briefly and then return: a `Pkg.build`, a git checkout, an environment switch, or an editor's atomic-rename save can remove and recreate it within moments. Previously the watcher tasks reacted to any disappearance by emitting an alarming "is not watching" warning to stderr and then permanently abandoning the watch, so a benign blip both startled the user and silently stopped tracking the path until the session was reloaded.

Both watcher loops now wait up to `watch_reappear_grace[]` (default 5s) for the path to return. If it reappears, watching resumes silently; if it is deregistered (the package moved or was removed), the task stops quietly; only if it stays gone past the grace period do we warn and stop, as before. Genuine-deletion handling is unchanged: the deletion is still queued by the prior loop iteration, so only the final warn-and-stop is deferred.

Fixes #523