### PR TITLE
Catch up late-added workers on init_worker

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -45,6 +45,43 @@ function remotecall_impl end
 # - is_master_worker(w::MyWorkerType): check if `w` is the master.
 function is_master_worker end
 
+# Ordered record of the revision actions applied on the master this session, each
+# stored as `(mod, expr)` meaning "evaluate `expr` in `mod`". Revisions are
+# normally pushed to the workers that exist at revision time, but a worker added
+# *later* loads the package fresh from disk and would otherwise miss them; in
+# particular it would lack the freshly-gensym'd closures that `@distributed`
+# bodies serialize, giving an `UndefVarError` on deserialization (issue #637).
+# `init_worker` replays this log to bring such a worker up to date. Reads and
+# writes both go through `revise_lock` (see `record_worker_replay!` and
+# `init_worker`). Only populated while a Distributed-like library is loaded and
+# this process is the master, so non-distributed sessions pay nothing.
+const worker_replay_log = Tuple{Module,Any}[]
+
+# Record `(mod, expr)` for later replay onto workers added after this revision,
+# but only when this process is the master for some registered worker library.
+# Takes `revise_lock` directly: on the normal `revise` path the caller already
+# holds it (a reentrant re-acquire is cheap), and this also covers the side paths
+# (`revise_file_now`, `eval_revised`) that reach here without holding it.
+function record_worker_replay!(mod::Module, expr)
+    @lock revise_lock for get_workers in workers_functions
+        if @invokelatest is_master_worker(get_workers)
+            push!(worker_replay_log, (mod, expr))
+            break
+        end
+    end
+    return nothing
+end
+
+# Evaluate `expr` in `mod` on worker `p`, ignoring failures (e.g. `mod` not yet
+# loaded there, or a type the expression references being absent).
+function apply_worker_action(p, mod::Module, expr)
+    try
+        @invokelatest remotecall_impl(Core.eval, p, mod, expr)
+    catch
+    end
+    return nothing
+end
+
 ## END abstract Distributed API
 
 """
@@ -211,9 +248,9 @@ include("callbacks.jl")
 #
 # Guards: `watched_files`, `watched_manifests`, `revision_queue`, `queue_errors`,
 # `pkgdatas`, `included_files`, `cache_file_key`, `src_file_key`,
-# `dont_watch_pkgs`, `silence_pkgs`, the `user_callbacks_*` collections, and the
-# `@require` bookkeeping. (`types_cache` in visit.jl has its own independent
-# lock, on a separate code path.)
+# `dont_watch_pkgs`, `silence_pkgs`, `worker_replay_log`, the `user_callbacks_*`
+# collections, and the `@require` bookkeeping. (`types_cache` in visit.jl has its
+# own independent lock, on a separate code path.)
 const revise_lock = ReentrantLock()
 
 """
@@ -499,11 +536,11 @@ function handle_method_deletion!(siginfo::SigInfo, rex::RelocatableExpr, world::
         end
         @debug "DeleteMethod" _group="Action" time=time() deltainfo=(sig, MethodSummary(m))
         # Delete the corresponding methods
-        for get_workers in workers_functions
-            for p in @invokelatest get_workers()
-                try  # guard against serialization errors if the type isn't defined on the worker
-                    @invokelatest remotecall_impl(Core.eval, p, Main, :(delete_method_by_sig($mt, $sig)))
-                catch
+        let delexpr = :(delete_method_by_sig($mt, $sig))
+            record_worker_replay!(Main, delexpr)
+            for get_workers in workers_functions
+                for p in @invokelatest get_workers()
+                    apply_worker_action(p, Main, delexpr)  # guard against serialization errors if the type isn't defined on the worker
                 end
             end
         end
@@ -591,14 +628,12 @@ function eval_rex(rex_new::RelocatableExpr, exs_infos_old::ExprsInfos, mod::Modu
             if !isexpr(thunk, :thunk)
                 thunk = ex
             end
+            record_worker_replay!(mod, thunk)
             for get_workers in workers_functions
                 if @invokelatest is_master_worker(get_workers)
                     for p in @invokelatest get_workers()
                         @invokelatest(is_master_worker(p)) && continue
-                        try   # don't error if `mod` isn't defined on the worker
-                            @invokelatest remotecall_impl(Core.eval, p, mod, thunk)
-                        catch
-                        end
+                        apply_worker_action(p, mod, thunk)  # don't error if `mod` isn't defined on the worker
                     end
                 end
             end
@@ -1695,8 +1730,15 @@ async_steal_repl_backend() = steal_repl_backend()
 """
     Revise.init_worker(p)
 
-Define methods on worker `p` that Revise needs in order to perform revisions on `p`.
+Define methods on worker `p` that Revise needs in order to perform revisions on `p`,
+and replay onto `p` any revisions already applied on the master this session.
 Revise itself does not need to be running on `p`.
+
+Call this after the relevant packages have been loaded on `p` (e.g. via
+`@everywhere using MyPkg`); otherwise the replayed revisions, which evaluate into
+those modules, are silently skipped and `p` stays at the on-disk state. Replaying
+is what keeps closures serialized across workers (such as `@distributed` bodies)
+in sync after a revision, including for workers added later (issue #637).
 """
 function init_worker(p::AbstractWorker)
     @invokelatest remotecall_impl(Core.eval, p, Main, quote
@@ -1713,6 +1755,20 @@ function init_worker(p::AbstractWorker)
             isa(m, Method) && Base.delete_method(m)
         end
     end)
+    @invokelatest(is_master_worker(p)) && return nothing
+    actions = lock(revise_lock) do
+        copy(worker_replay_log)
+    end
+    # Unlike the best-effort propagation during `revise`, this is an explicit
+    # synchronization point: wait for each action so the worker is fully caught up
+    # before `init_worker` returns and the caller starts dispatching work to it.
+    for (mod, expr) in actions
+        try
+            @invokelatest wait(remotecall_impl(Core.eval, p, mod, expr))
+        catch  # e.g. `mod` not loaded on the worker yet
+        end
+    end
+    return nothing
 end
 
 init_worker(p::Int) = init_worker(DistributedWorker(p))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3487,6 +3487,48 @@ end
         rmprocs(favorite_proc, boring_proc; waitfor=10)
     end
 
+    do_test("Distributed late worker") && @testset "Distributed late worker" begin
+        # A worker added *after* an in-session revision loads the package fresh
+        # from disk and so lacks the freshly-gensym'd closures the master now
+        # produces. Serializing such a closure to it (as `@distributed` bodies do)
+        # would throw `UndefVarError` on deserialization. `Revise.init_worker`
+        # must replay the session's revisions onto the new worker. (issue #637)
+        dirname = randtmp()
+        mkdir(dirname)
+        push!(to_remove, dirname)
+        push!(LOAD_PATH, dirname)
+        modname = "ReviseDist637"
+        dn = joinpath(dirname, modname, "src")
+        mkpath(dn)
+        file = joinpath(dn, modname * ".jl")
+        # `adder` returns an anonymous closure; revising its body re-lowers it and
+        # assigns it a new gensym type name on the master.
+        write(file, "module $modname\nadder() = (x -> x + 1)\nend\n")
+        sleep(mtimedelay)
+        @eval using ReviseDist637
+        sleep(mtimedelay)
+        @test ReviseDist637.adder()(5) == 6
+
+        write(file, "module $modname\nadder() = (x -> x + 10)\nend\n")
+        @yry()
+        @test ReviseDist637.adder()(5) == 15
+
+        # Add a worker only now, after the revision, then bring it up to date.
+        newproc = only(addprocs(1))
+        try
+            Distributed.remotecall_eval(Main, [newproc], :(push!(LOAD_PATH, $dirname)))
+            Distributed.remotecall_eval(Main, [newproc], :(using ReviseDist637))
+            Revise.init_worker(newproc)
+            # The master-created closure must deserialize on the new worker.
+            cl = ReviseDist637.adder()
+            @test remotecall_fetch(cl, newproc, 5) == 15
+        finally
+            rmprocs(newproc; waitfor=10)
+        end
+        rm_precompile(modname)
+        pop!(LOAD_PATH)
+    end
+
     do_test("Git") && @testset "Git" begin
         loc = Base.find_package("Revise")
         if occursin("dev", loc)


### PR DESCRIPTION
Revise propagates each revision's lowered thunk to the workers that exist at revision time, keeping their gensym'd closures in sync with the master. A worker added *afterward* loads the package fresh from disk and never receives those revisions, so serializing a revised closure to it (as an `@distributed` body does) throws `UndefVarError` on deserialization.

Record the session's revision actions (eval thunks and method deletions) on the master, and have `init_worker` replay them onto a new worker after installing its deletion helpers, waiting for each so the worker is fully caught up before returning. The log is recorded only while a Distributed-like library is loaded and this process is the master, and both reads and writes go through `revise_lock`.

Fixes #637