### PR TITLE
Handle duplicate macro-defined methods on deletion

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -527,7 +527,13 @@ function handle_method_deletion!(siginfo::SigInfo, rex::RelocatableExpr, world::
                 line = firstline(rex)
                 ld = map(pr->linediff(line, pr[1]), locdefs)
                 idx = argmin(ld)
-                @assert ld[idx] < typemax(eltype(ld))
+                if ld[idx] === typemax(eltype(ld))
+                    # No `locdefs` entry shares a file with `rex`. This happens when the
+                    # method's recorded location comes from a macro rather than the source
+                    # file (e.g. `@views @timing function ... end`), so line matching can't
+                    # identify the reference to drop. Drop the last one, matching `eval_rex`. (#668)
+                    idx = length(locdefs)
+                end
                 deleteat!(locdefs, idx)
                 return nothing
             else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2076,6 +2076,48 @@ end
         end
     end
 
+    do_test("Duplicate macro-defined methods") && @testset "Duplicate macro-defined methods" begin
+        # issue #668: two definitions sharing one signature, where the method's recorded
+        # location comes from a macro (a different file than the source). Deleting one of
+        # them must not fail with `AssertionError: ld[idx] < typemax(eltype(ld))`.
+        testdir = newtestdir()
+        dn = joinpath(testdir, "Dup668", "src"); mkpath(dn)
+        fn = joinpath(dn, "Dup668.jl")
+        # `@deffoo` stamps the method body with a LineNumberNode from a phantom file,
+        # mimicking what macros like `@views`/`@timing` do to a wrapped function.
+        write(fn, """
+            __precompile__(false)
+            module Dup668
+            macro deffoo(val)
+                esc(Expr(:function, :(foo()),
+                         Expr(:block, LineNumberNode(99, Symbol("phantom.jl")), val)))
+            end
+            @deffoo 1
+            @deffoo 2
+            end""")
+        sleep(mtimedelay)
+        using Dup668
+        sleep(mtimedelay)
+        @test Dup668.foo() == 2
+        key = Revise.MethodInfoKey(nothing, first(methods(Dup668.foo)).sig)
+        # Remove the first (duplicate) definition, leaving a single method.
+        write(fn, """
+            __precompile__(false)
+            module Dup668
+            macro deffoo(val)
+                esc(Expr(:function, :(foo()),
+                         Expr(:block, LineNumberNode(99, Symbol("phantom.jl")), val)))
+            end
+            @deffoo 2
+            end""")
+        @yry()
+        @test isempty(Revise.queue_errors)
+        @test Dup668.foo() == 2
+        @test length(CodeTracking.method_info[key]) == 1
+
+        rm_precompile("Dup668")
+    end
+
     do_test("revise_file_now") && @testset "revise_file_now" begin
         # Very rarely this is used for debugging
         testdir = newtestdir()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2435,6 +2435,7 @@ end
             g(x} = 2
             end
             """)
+        sleep(mtimedelay)
         @test try
             revise(throw=true)
             false


### PR DESCRIPTION
When two definitions share one signature and the method's recorded location lives in a different file than the source (as happens for macro-wrapped definitions such as `@views @timing function ... end`), `handle_method_deletion!` could not line-match the reference to drop: every `linediff` returns `typemax`, and the hard assertion failed, aborting the entire revision.

This applies the same change made in 3c6062d8 for `eval_new!` to also handle this case. Adds a test capturing the issue.

Fixes #668