### PR TITLE
Survive sig-extraction errors in manifest watcher

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -136,6 +136,23 @@ function maybe_extract_sigs!(fi::FileInfo)
 end
 maybe_extract_sigs!(pkgdata::PkgData, file::AbstractString) = maybe_extract_sigs!(fileinfo(pkgdata, file))
 
+# Signature extraction lowers and partially evaluates each top-level expression. For
+# macro-generated code this can be fragile to re-lowering: JLLWrappers builds a `let`
+# block that defines and immediately calls gensym'd closures, and re-`:sigs` after the
+# package is already loaded can leave the closure's call method undefined for the freshly
+# minted closure type (issue #706). The package is already loaded and correct, so on
+# failure record the error the same way `revise()` does and keep going, rather than
+# letting it abort the manifest watcher.
+function maybe_extract_sigs_or_queue_error!(pkgdata::PkgData, file::AbstractString, fi::FileInfo)
+    try
+        maybe_extract_sigs!(fi)
+    catch err
+        isa(err, InterruptException) && rethrow(err)
+        @lock revise_lock queue_errors[(pkgdata, file)] = (err, catch_backtrace())
+    end
+    return fi
+end
+
 is_not_populated(fi::FileInfo) =
     (isempty(fi.mod_exs_infos) && !fi.parsed[]) && (!isempty(fi.cachefile) || !isempty(fi.cacheexprs))
 
@@ -523,7 +540,7 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
             end
             fi
         end
-        maybe_extract_sigs!(fi)
+        maybe_extract_sigs_or_queue_error!(pkgdata, file, fi)
         @lock revise_lock push!(revision_queue, (pkgdata, file))
         push!(files, file)
         mustnotify = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4075,6 +4075,32 @@ do_test("Switching free/dev") && @testset "Switching free/dev" begin
     push!(to_remove, depot)
 end
 
+do_test("Manifest re-extraction errors") && @testset "Manifest re-extraction errors" begin
+    # When a package's directory changes (e.g. a version bump), `switch_basepath`
+    # eagerly re-extracts signatures. For some macro-generated top-level code this can
+    # fail on re-lowering (issue #706, JLLWrappers' gensym'd closures). Such a failure
+    # must be recorded rather than abort the manifest watcher.
+    mod = Module(:Issue706)
+    Core.eval(mod, :(using Base))
+    # A method whose *signature* needs a throwing call, so extraction throws in `:sigs`.
+    badex = :(foo(::Val{error("issue 706 sigs failure")}) = 1)
+    mkfi() = begin
+        mei = Revise.ModuleExprsInfos(mod)
+        mei[mod][Revise.RelocatableExpr(badex)] = nothing
+        Revise.FileInfo(mei)
+    end
+    id = Base.PkgId(Base.UUID("00000000-0000-0000-0000-000000000706"), "Issue706")
+    pkgdata = Revise.PkgData(id, "/nonexistent/Issue706")
+    file = "src/Issue706.jl"
+    delete!(Revise.queue_errors, (pkgdata, file))
+    # Unguarded extraction throws ...
+    @test_throws Exception Revise.maybe_extract_sigs!(mkfi())
+    # ... but the resilient helper records the error instead of throwing.
+    @test (Revise.maybe_extract_sigs_or_queue_error!(pkgdata, file, mkfi()); true)
+    @test haskey(Revise.queue_errors, (pkgdata, file))
+    delete!(Revise.queue_errors, (pkgdata, file))   # leave global state clean
+end
+
 do_test("Switching environments") && @testset "Switching environments" begin
     old_project = Base.active_project()
 


### PR DESCRIPTION
When a package's directory changes (e.g. a version bump), `switch_basepath` eagerly re-extracts signatures from the new source. Macro-generated top-level code can be fragile to re-lowering: JLLWrappers builds a `let` block that defines and immediately calls gensym'd closures, and re-`:sigs` of an already-loaded package can leave the closure's call method undefined for the freshly minted closure type, throwing a `MethodError`. That error propagated out of the manifest watcher and aborted it with a bare `@error "Error watching manifest"`.

Record such a failure in `queue_errors` (reported via `Revise.errors()`) the same way the main `revise()` loop already does, and keep watching. The package is already loaded and correct; the lost signatures only affect later navigation or revision of that file.

This PR focuses on how the error is handled by Revise. I'll also file a separate issue with LoweredCodeUtils and attempt to fix the underlying cause.

Fixes #706.