### PR TITLE
Track packages baked into a system image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,18 @@ This file describes only major changes, and does not include bug fixes,
 cleanups, or minor enhancements.
 
 <!-- links start -->
+[Revise 3.15]: https://github.com/timholy/Revise.jl/compare/v3.14.5...v3.15.0
 [Revise 3.13]: https://github.com/timholy/Revise.jl/compare/v3.12.3...v3.13.0
 <!-- links end -->
+
+## [Revise 3.15]
+
+- **Track packages baked into a system image**: `Revise.track(SomePackage)` now works
+  for a package compiled into the running system image (e.g. one built with
+  PackageCompiler.jl). Such a package is already loaded at startup, so Revise's usual
+  package callback never fires; calling `Revise.track` on it starts watching the
+  package and applies any source edits made since the image was built.
+  (https://github.com/timholy/Revise.jl/pull/688)
 
 ## [Revise 3.13]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.14.5"
+version = "3.15.0"
 
 [workspace]
 projects = ["docs", "test"]

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -65,6 +65,7 @@ MethodSummary
 Revise.watch_package
 Revise.parse_pkg_files
 Revise.init_watching
+Revise.update_pkgversion!
 ```
 
 ### Monitoring for changes

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -2,11 +2,18 @@
     Revise.track(Base; revise_throw::Bool=!isinteractive())
     Revise.track(Core.Compiler; revise_throw::Bool=!isinteractive())
     Revise.track(stdlib; revise_throw::Bool=!isinteractive())
+    Revise.track(SysimagePackage; revise_throw::Bool=!isinteractive())
 
-Track updates to the code in Julia's `base` directory, `base/compiler`, or one of its
-standard libraries. Calls `revise()` after tracking to ensure that any changes
-detected during tracking are applied immediately. Optionally, if `revise_throw` is
-`true`, `revise()` will throw if any exceptions are encountered while revising.
+Track updates to the code in Julia's `base` directory, `base/compiler`, one of its
+standard libraries, or a package baked into the running system image (e.g. one
+compiled with PackageCompiler.jl). Calls `revise()` after tracking to ensure that any
+changes detected during tracking are applied immediately. Optionally, if `revise_throw`
+is `true`, `revise()` will throw if any exceptions are encountered while revising.
+
+A package compiled into a system image is already loaded at startup, so Revise's
+usual package callback never fires and any source edits made since the image was
+built go unnoticed. Calling `Revise.track` on such a package starts watching it and
+applies any pending edits.
 """
 function track(mod::Module; modified_files=revision_queue, revise_throw::Bool=!isinteractive())
     id = pkgidid_for_mod(mod)
@@ -113,7 +120,30 @@ function _track(id::PkgId, modname::Symbol; modified_files=revision_queue)
         track_subdir_from_git!(pkgdata, compilerdir; modified_files=modified_files)
         # insertion into pkgdatas is done by track_subdir_from_git!
     else
-        error("no Revise.track recipe for module ", modname)
+        # issue #685: a package compiled into a system image (e.g. with
+        # PackageCompiler.jl) is already loaded when the session starts, so the
+        # `using`/`import` package callback that normally sets up watching never
+        # fired, and Julia never checked whether the on-disk source is newer than
+        # the baked-in code. Set up watching now and queue any source file modified
+        # since the package was precompiled. We use the precompile cache file's
+        # mtime as the reference point; for a sysimage package the cache file
+        # remains in the depot after the build.
+        origin = get(Base.pkgorigins, id, nothing)
+        cachepath = origin === nothing ? nothing : origin.cachepath
+        if cachepath === nothing || isempty(cachepath)
+            error("no Revise.track recipe for module ", modname)
+        end
+        pkgdata = watch_package(id)
+        pkgdata === nothing && return nothing
+        reftime = mtime(cachepath)
+        @lock revise_lock begin
+            for rpath in srcfiles(pkgdata)
+                fullpath = joinpath(basedir(pkgdata), rpath)
+                if mtime(fullpath) > reftime
+                    push!(modified_files, (pkgdata, rpath))
+                end
+            end
+        end
     end
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3340,6 +3340,48 @@ end
 
     end
 
+    do_test("Track sysimage package") && @testset "Track sysimage package" begin
+        # issue #685: a package baked into a system image (e.g. with PackageCompiler.jl)
+        # is already loaded at startup, so the `using` callback never fires and Revise
+        # has no record of it. `Revise.track` should start watching it and apply any
+        # edits made since it was precompiled. We reproduce the sysimage state by
+        # loading the package normally and then dropping Revise's record of it, leaving
+        # a valid `Base.pkgorigins` cache entry whose mtime predates the source edit.
+        testdir = newtestdir()
+        dn = joinpath(testdir, "TrackSysimg685", "src")
+        mkpath(dn)
+        write(joinpath(dn, "TrackSysimg685.jl"), """
+            module TrackSysimg685
+            f685() = 1
+            end
+            """)
+        sleep(mtimedelay)
+        @eval using TrackSysimg685
+        @latestworld
+        @test TrackSysimg685.f685() == 1
+        id = Base.PkgId(TrackSysimg685)
+        @lock Revise.revise_lock delete!(Revise.pkgdatas, id)
+        sleep(mtimedelay)
+        write(joinpath(dn, "TrackSysimg685.jl"), """
+            module TrackSysimg685
+            f685() = 2
+            end
+            """)
+        Revise.track(TrackSysimg685)
+        @latestworld
+        @test TrackSysimg685.f685() == 2
+
+        # A package with no precompile cache cannot be tracked this way; fail with a
+        # clear message rather than a `KeyError` (PR #688 review). Drive `_track`
+        # directly with a synthetic, never-loaded package id: a module defined here
+        # would resolve to `Main`, which the testsets above have already tracked.
+        fakeid = Base.PkgId(Base.UUID("00000000-0000-0000-0000-000000000685"), "NotALoadedPkg685")
+        @test_throws "no Revise.track recipe" Revise._track(fakeid, :NotALoadedPkg685)
+
+        rm_precompile("TrackSysimg685")
+        pop!(LOAD_PATH)
+    end
+
     do_test("Auto-track user scripts") && @testset "Auto-track user scripts" begin
         srcfile = joinpath(tempdir(), randtmp()*".jl")
         push!(to_remove, srcfile)


### PR DESCRIPTION
A package compiled into a system image (e.g. with PackageCompiler.jl) is already loaded when the session starts, so Revise's `using`/`import` package callback never fires and edits to its source made since the image was built go unnoticed. `Revise.track(SomePackage)` now starts watching such a package and queues any source file whose mtime postdates the precompile cache.

A module that lacks a precompile cache (e.g. one defined at the REPL) still fails with the clear "no Revise.track recipe" message rather than a bare KeyError.

Fixes #685.
Supersedes #688 (credit to @ktdq)