### PR TITLE
Watch directories via buffered watch_folder

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -783,6 +783,11 @@ function init_watching(pkgdata::PkgData, files=srcfiles(pkgdata))
     end
     for dirfull in udirs
         if !watching_files[]
+            # Register the buffered directory monitor now, before the watcher task
+            # runs, so events are queued from the moment we start tracking and the
+            # startup gap is closed. Skipped on polling/non-notifying filesystems,
+            # which never deliver notifications.
+            polling_files[] || nonnotifying_path(dirfull) || watch_folder(dirfull, 0)
             dwatcher = TaskThunk(revise_dir_queued, (dirfull,))
             schedule(Task(dwatcher))
         end
@@ -841,6 +846,10 @@ This is generally called via a [`Revise.TaskThunk`](@ref).
                 end
                 break
             end
+            # Reappeared: the directory was removed and recreated, so the existing
+            # monitor may be watching a stale inode. Drop it; the next
+            # `wait_changed_dir` re-registers a fresh one.
+            unwatch_folder(dirname)
         end
 
         latestfiles, stillwatching = watch_files_via_dir(dirname)  # will block here until file(s) change
@@ -861,6 +870,7 @@ This is generally called via a [`Revise.TaskThunk`](@ref).
             end
         end
     end
+    unwatch_folder(dirname)  # stop the OS watch now that we no longer watch this dir
     return
 end
 

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -330,13 +330,36 @@ function eval_require_now(pkgdata::PkgData, fileidx::Int, filekey::String, sourc
     return ret
 end
 
-function watch_files_via_dir(dirname::AbstractString)
+# Block until `dirname` reports filesystem activity.
+#
+# On notifying filesystems this uses a *persistent, buffered* `FolderMonitor`
+# (`watch_folder`): the OS watch stays registered between calls and queues every
+# event, so a change that lands while we are busy enqueueing a previous one is
+# retained rather than dropped. This is the crucial difference from `watch_file`,
+# which arms a fresh one-shot monitor per call and silently loses anything that
+# occurs in the gap between calls -- a dominant source of missed revisions on
+# macOS FSEvents under load.
+#
+# On polling/non-notifying filesystems we keep the existing directory poll.
+function wait_changed_dir(dirname::AbstractString)
+    if polling_files[] || nonnotifying_path(dirname)
+        wait_changed(dirname)  # unchanged poll behavior
+        return
+    end
     try
-        wait_changed(dirname)  # this will block until there is a modification
+        watch_folder(dirname)                          # block for the next buffered event
+        while !last(watch_folder(dirname, 0)).timedout # drain a burst delivered in one wakeup
+        end
     catch e
+        e isa EOFError && return                       # monitor torn down; let caller re-check state
         # issue #459
         (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
     end
+    return
+end
+
+function watch_files_via_dir(dirname::AbstractString)
+    wait_changed_dir(dirname)  # block until the directory changes (buffered on notifying filesystems)
     latestfiles = Pair{String,PkgId}[]
     # Snapshot the tracked files under the lock. We then do the (potentially
     # blocking) filesystem checks below without holding it, reacquiring only to


### PR DESCRIPTION
The directory watcher woke on `watch_file(dir)`, which arms a fresh one-shot `FileMonitor` per event and tears it down immediately. It only observes changes that occur while a task is blocked inside it; anything landing in the gap between calls is unbuffered and lost. Under macOS FSEvents on loaded CI this intermittently drops a file change, leaving a revision unqueued — e.g. the empty-`logs` `BoundsError` seen in the "Revision errors" testset on #1056's macOS-pre runner.

Switch the directory wakeup to `watch_folder`, whose persistent `FolderMonitor` queues every event whether or not a task is waiting, so a change arriving between calls is retained. The monitor is registered eagerly in `init_watching` to close the startup gap and relinquished with `unwatch_folder` on teardown / directory recreation (stale-inode safety). Polling and non-notifying paths are unchanged.

Diagnostic note: `watch_folder` provably eliminates the between-calls loss class and removes the per-call stream-churn that amplifies FSEvents drops; it is not a hard guarantee against a genuine OS-level drop. This PR keeps the existing ctime identification and `mtimedelay` test timing untouched — reducing those is a deliberate follow-up once this proves green on macOS CI.