### PR TITLE
Suppress "Replacing docs" noise in forced revision

### DIFF
--- a/src/logging.jl
+++ b/src/logging.jl
@@ -42,6 +42,26 @@ end
 
 CoreLogging.catch_exceptions(::ReviseLogger) = false
 
+# Wrap a logger, dropping the `Base.Docs` "Replacing docs for ..." warnings while
+# forwarding everything else. `revise(mod; force=true)` re-evaluates every
+# docstring in `mod`, and `Base.Docs` warns on each rewrite (issue #975); for a
+# large package this is pages of noise about an entirely expected action.
+struct SuppressReplacingDocsLogger{L<:AbstractLogger} <: AbstractLogger
+    logger::L
+end
+
+CoreLogging.min_enabled_level(l::SuppressReplacingDocsLogger) = CoreLogging.min_enabled_level(l.logger)
+CoreLogging.shouldlog(l::SuppressReplacingDocsLogger, level, _module, group, id) =
+    CoreLogging.shouldlog(l.logger, level, _module, group, id)
+CoreLogging.catch_exceptions(l::SuppressReplacingDocsLogger) = CoreLogging.catch_exceptions(l.logger)
+function CoreLogging.handle_message(l::SuppressReplacingDocsLogger, level, msg, _module,
+                                    group, id, file, line; kwargs...)
+    if _module === Base.Docs && occursin("Replacing docs for", string(msg))
+        return nothing
+    end
+    return CoreLogging.handle_message(l.logger, level, msg, _module, group, id, file, line; kwargs...)
+end
+
 function Base.show(io::IO, l::LogRecord; kwargs...)
     verbose = get(io, :verbose, false)::Bool
     tmin = get(io, :time_min, nothing)::Union{Float64, Nothing}

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1278,19 +1278,23 @@ function revise(mod::Module; force::Bool=true)
     end
     revise()
     force || return true
-    for i = 1:length(srcfiles(pkgdata))
-        fi = fileinfo(pkgdata, i)
-        for (mod, exs_infos) in fi.mod_exs_infos
-            for def_rex in keys(exs_infos)
-                ex = def_rex.ex
-                exuw = unwrap(ex)
-                isexpr(exuw, :call) && is_some_include(exuw.args[1]) && continue
-                try
-                    Core.eval(mod, ex)
-                catch err
-                    @show mod
-                    display(ex)
-                    rethrow(err)
+    # issue #975: re-evaluating every definition rewrites each docstring, and
+    # `Base.Docs` warns on every rewrite; suppress that expected noise.
+    with_logger(SuppressReplacingDocsLogger(current_logger())) do
+        for i = 1:length(srcfiles(pkgdata))
+            fi = fileinfo(pkgdata, i)
+            for (mod, exs_infos) in fi.mod_exs_infos
+                for def_rex in keys(exs_infos)
+                    ex = def_rex.ex
+                    exuw = unwrap(ex)
+                    isexpr(exuw, :call) && is_some_include(exuw.args[1]) && continue
+                    try
+                        Core.eval(mod, ex)
+                    catch err
+                        @show mod
+                        display(ex)
+                        rethrow(err)
+                    end
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1334,6 +1334,34 @@ end
         pop!(LOAD_PATH)
     end
 
+    do_test("Forced revision docstrings (issue #975)") && @testset "Forced revision docstrings (issue #975)" begin
+        testdir = newtestdir()
+        dn = joinpath(testdir, "ForceDocstring", "src")
+        mkpath(dn)
+        write(joinpath(dn, "ForceDocstring.jl"), """
+            module ForceDocstring
+            "f" f() = 1
+            "g" g() = 1
+            end
+            """)
+        sleep(mtimedelay)
+        @eval using ForceDocstring
+        sleep(mtimedelay)
+        @test ForceDocstring.f() == 1
+        # `revise(mod; force=true)` re-evaluates every definition, which rewrites
+        # each docstring; `Base.Docs` warns on each rewrite unless we suppress it.
+        logs, _ = Test.collect_test_logs() do
+            revise(ForceDocstring)
+        end
+        @latestworld
+        @test !any(r -> occursin("Replacing docs", r.message), logs)
+        @test ForceDocstring.f() == 1
+        @test ForceDocstring.g() == 1
+
+        rm_precompile("ForceDocstring")
+        pop!(LOAD_PATH)
+    end
+
     do_test("doc expr signature") && @testset "Docstring attached to signatures" begin
         md = Revise.ModuleExprsInfos(Main)
         Revise.parse_source!(md, """


### PR DESCRIPTION
`revise(mod; force=true)` re-evaluates every definition in `mod`, which rewrites each docstring. `Base.Docs` warns on every docstring rewrite, so for a large package this can produce pages of warnings, all of which are expected.

The fix: wrap the forced-eval loop in a logger that drops those specific `Base.Docs` warnings while forwarding everything else.

Fixes #975