### PR TITLE
Use `Base.is_stdlib` instead of a hardcoded list

### DIFF
--- a/src/loading.jl
+++ b/src/loading.jl
@@ -128,7 +128,7 @@ function modulefiles(mod::Module)
         parentfile = String(first(methods(getfield(mod, :eval))).file)
     end
     id = PkgId(mod)
-    if id.name == "Base" || Symbol(id.name) ∈ stdlib_names
+    if id.name == "Base" || Base.is_stdlib(id)
         parentfile = normpath(Base.find_source_file(parentfile))
         if !startswith(parentfile, juliadir)
             parentfile = replace(parentfile, fallback_juliadir()=>juliadir)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -45,7 +45,7 @@ end
 function _track(id::PkgId, modname::Symbol; modified_files=revision_queue)
     haspkgdata(id) && return nothing  # already tracked
     isbase = modname === :Base
-    isstdlib = !isbase && modname ∈ stdlib_names
+    isstdlib = !isbase && Base.is_stdlib(id)
     if isbase || isstdlib
         # Test whether we know where to find the files
         if isbase
@@ -238,17 +238,6 @@ function track_subdir_from_git!(pkgdata::PkgData, subdir::AbstractString; commit
     end
     return nothing
 end
-
-# For tracking Julia's own stdlibs
-const stdlib_names = Set([
-    :Base64, :CRC32c, :Dates, :DelimitedFiles, :Distributed,
-    :FileWatching, :Future, :InteractiveUtils, :Libdl,
-    :LibGit2, :LinearAlgebra, :Logging, :Markdown, :Mmap,
-    :OldPkg, :Pkg, :Printf, :Profile, :Random, :REPL,
-    :Serialization, :SHA, :SharedArrays, :Sockets, :SparseArrays,
-    :Statistics, :SuiteSparse, :Test, :Unicode, :UUIDs,
-    :TOML, :Artifacts, :LibCURL_jll, :LibCURL, :MozillaCACerts_jll,
-    :Downloads, :Tar, :ArgTools, :NetworkOptions, :PCRE2_jll, :Zlib_jll])
 
 # This replacement is needed because the path written during compilation differs from
 # the git source path


### PR DESCRIPTION
`stdlib_names` was a hand-maintained `Set` of stdlib module names, and it needed frequent updating. All Julia versions back to at least 1.10 support `Base.is_stdlib(::PkgId)`, so let's use it.

Closes #929.