### PR TITLE
Precompile the REPL-backend-wait startup task

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1800,6 +1800,22 @@ init_worker(p::Int) = init_worker(DistributedWorker(p))
 
 active_repl_backend_available() = isdefined(Base, :active_repl_backend) && Base.active_repl_backend !== nothing
 
+# Wait for the REPL backend to come up, then register `revise_first` on it.
+# #719: this runs async in case Revise is loaded from startup.jl, before the
+# backend exists. issue #900: keep this a named function (not an anonymous
+# `@async` closure) so it has a stable, precompilable signature.
+function wait_for_repl_backend()
+    iter = 0
+    while !active_repl_backend_available() && iter < 20
+        sleep(0.05)
+        iter += 1
+    end
+    if active_repl_backend_available()
+        push!(Base.active_repl_backend.ast_transforms, revise_first)
+    end
+    return nothing
+end
+
 function __init__()
     ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
     run_on_worker = get(ENV, "JULIA_REVISE_WORKER_ONLY", "0")
@@ -1884,18 +1900,11 @@ function __init__()
         if active_repl_backend_available()
             push!(Base.active_repl_backend.ast_transforms, revise_first)
         else
-            # wait for active_repl_backend to exist
-            # #719: do this async in case Revise is being loaded from startup.jl
-            t = @async begin
-                iter = 0
-                while !active_repl_backend_available() && iter < 20
-                    sleep(0.05)
-                    iter += 1
-                end
-                if active_repl_backend_available()
-                    push!(Base.active_repl_backend.ast_transforms, revise_first)
-                end
-            end
+            # wait for active_repl_backend to exist. Schedule the named function
+            # directly (rather than `@async`, which wraps it in an anonymous
+            # closure) so the task body carries a stable, precompilable signature.
+            t = Task(wait_for_repl_backend)
+            schedule(t)
             isdefined(Base, :errormonitor) && Base.errormonitor(t)
         end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -90,6 +90,7 @@ function _precompile_()
     end
     @warnpcfail precompile(Tuple{typeof(Revise.iswritable), String})
     @warnpcfail precompile(Tuple{typeof(Revise.active_repl_backend_available)})
+    @warnpcfail precompile(Tuple{typeof(wait_for_repl_backend)})
     @warnpcfail precompile(Tuple{typeof(pkg_fileinfo), PkgId})
     @warnpcfail precompile(Tuple{typeof(push!), WatchList, Pair{String,PkgId}})
     @warnpcfail precompile(Tuple{typeof(pushex!), ExprsInfos, Expr})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2845,6 +2845,41 @@ end
         end
     end
 
+    do_test("startup precompilation") && @testset "startup precompilation" begin
+        # issue #900: simply loading Revise and exiting must not force runtime
+        # compilation of any Revise-owned method. The REPL-backend-wait task is
+        # the easiest such method to regress: if it reverts to an anonymous
+        # `@async` closure it can no longer be precompiled and reappears in the
+        # trace (along with its `sleep`/`iszero` callees). `-i` without a tty
+        # leaves the REPL backend unavailable, so `__init__` takes exactly that
+        # async wait path. We tolerate Base-owned startup compilation (finalizers
+        # and the like) and only insist that nothing Revise-owned compiles.
+        #
+        # Use a bare executable (not `Base.julia_cmd()`) with pkgimages enabled:
+        # under coverage the parent runs with `--pkgimages=no`, which bypasses the
+        # precompile image entirely and would make everything compile at load,
+        # defeating the test. The scenario #900 cares about is the normal one,
+        # with native code cached in the pkgimage.
+        julia = Base.julia_cmd().exec[1]
+        proj = dirname(Base.active_project())
+        loadfile = tempname()
+        write(loadfile, "using Revise\n")
+        tracefile = tempname()
+        code = "exit()"
+        try
+            run(pipeline(`$julia --startup-file=no --project=$proj --pkgimages=yes -i -L $loadfile --trace-compile=$tracefile -e $code`;
+                         stdin=devnull, stdout=devnull, stderr=devnull))
+            # `--trace-compile` only creates the file once something compiles; an
+            # absent file therefore means nothing compiled at all, which is the
+            # best possible outcome here.
+            trace = isfile(tracefile) ? read(tracefile, String) : ""
+            @test !occursin("Revise.", trace)
+        finally
+            rm(loadfile; force=true)
+            rm(tracefile; force=true)
+        end
+    end
+
     # Struct revision tests require __bpart__[] = true. Enable it based on the Julia version
     # alone: the LocalPreferences setting (which defaults to false for end users) should not
     # suppress these tests on CI.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2845,41 +2845,6 @@ end
         end
     end
 
-    do_test("startup precompilation") && @testset "startup precompilation" begin
-        # issue #900: simply loading Revise and exiting must not force runtime
-        # compilation of any Revise-owned method. The REPL-backend-wait task is
-        # the easiest such method to regress: if it reverts to an anonymous
-        # `@async` closure it can no longer be precompiled and reappears in the
-        # trace (along with its `sleep`/`iszero` callees). `-i` without a tty
-        # leaves the REPL backend unavailable, so `__init__` takes exactly that
-        # async wait path. We tolerate Base-owned startup compilation (finalizers
-        # and the like) and only insist that nothing Revise-owned compiles.
-        #
-        # Use a bare executable (not `Base.julia_cmd()`) with pkgimages enabled:
-        # under coverage the parent runs with `--pkgimages=no`, which bypasses the
-        # precompile image entirely and would make everything compile at load,
-        # defeating the test. The scenario #900 cares about is the normal one,
-        # with native code cached in the pkgimage.
-        julia = Base.julia_cmd().exec[1]
-        proj = dirname(Base.active_project())
-        loadfile = tempname()
-        write(loadfile, "using Revise\n")
-        tracefile = tempname()
-        code = "exit()"
-        try
-            run(pipeline(`$julia --startup-file=no --project=$proj --pkgimages=yes -i -L $loadfile --trace-compile=$tracefile -e $code`;
-                         stdin=devnull, stdout=devnull, stderr=devnull))
-            # `--trace-compile` only creates the file once something compiles; an
-            # absent file therefore means nothing compiled at all, which is the
-            # best possible outcome here.
-            trace = isfile(tracefile) ? read(tracefile, String) : ""
-            @test !occursin("Revise.", trace)
-        finally
-            rm(loadfile; force=true)
-            rm(tracefile; force=true)
-        end
-    end
-
     # Struct revision tests require __bpart__[] = true. Enable it based on the Julia version
     # alone: the LocalPreferences setting (which defaults to false for end users) should not
     # suppress these tests on CI.
@@ -5284,6 +5249,33 @@ end
 
 do_test("Import in empty environment (issue #532)") && @testset "Import in empty environment (issue #532)" begin
     load_in_empty_project_test();
+end
+
+do_test("startup precompilation") && @testset "startup precompilation" begin
+    # issue #900: loading Revise and exiting must not force runtime compilation
+    # of any Revise-owned method; the whole load path should be covered by
+    # `src/precompile.jl`. `-i` without a tty exercises the REPL-backend-wait
+    # branch of `__init__`. Use a bare executable with pkgimages enabled (not
+    # `Base.julia_cmd()`): under coverage the parent runs `--pkgimages=no`,
+    # which bypasses the precompile image and makes everything compile at load.
+    julia = Base.julia_cmd().exec[1]
+    proj = dirname(Base.active_project())
+    loadfile = tempname()
+    write(loadfile, "using Revise\n")
+    tracefile = tempname()
+    code = "exit()"
+    try
+        run(pipeline(`$julia --startup-file=no --project=$proj --pkgimages=yes -i -L $loadfile --trace-compile=$tracefile -e $code`;
+                        stdin=devnull, stdout=devnull, stderr=devnull))
+        # `--trace-compile` only creates the file once something compiles; an
+        # absent file therefore means nothing compiled at all, which is the
+        # best possible outcome here.
+        trace = isfile(tracefile) ? read(tracefile, String) : ""
+        @test !occursin("Revise.", trace)
+    finally
+        rm(loadfile; force=true)
+        rm(tracefile; force=true)
+    end
 end
 
 # Issue #961: when an indirect dep has no precompile cache and Julia is started


### PR DESCRIPTION
When Revise is loaded before the REPL backend exists (e.g. from startup.jl), __init__ spawns a task that polls until the backend is up and then registers `revise_first`. This task was an anonymous `@async` closure, whose gensym type cannot be named in a precompile directive, so it — and its `sleep`/`iszero(::Float64)` callees — were recompiled at every interactive startup.

Lift the closure into a named function, schedule it directly with `Task`/`schedule` (so `@async` does not re-wrap it in an anonymous closure), and add a precompile directive for it. After this, loading Revise and exiting forces no Revise-owned compilation on 1.10, 1.11, or 1.12. A subprocess `--trace-compile` test guards against regression.

Fixes #900