### PR TITLE
Skip the struct-revision walk for unchanged types

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -642,3 +642,175 @@ function skip_declare_const(interp::Interpreter, frame::Frame, stmt::Expr)
     name isa Symbol || return false
     return @invokelatest isdefined(mod_arg, name)
 end
+
+## Prediction of type preservation (issue #1022)
+#
+# Before deletions are applied, `revise` asks whether the new source re-creates
+# each old type unchanged. If so, the subtype-tree walk in
+# `handle_type_deletion!` is unnecessary. Problems arise from `struct`
+# definitions like those in #1022, which disguise the fact that the type is
+# unchanged and only surrounding code is changed. We fix this with a two-phase
+# evaluation: first, a limited evaluation that reconstructs (from the lowered
+# code) the *proposed* new type (henceforth called the "prediction"). This
+# prediction is compared for type-equivalence against the existing type; if they
+# are equivalent, type-deletion is skipped. Constructing the prediction builds
+# only throwaway objects and never publishes a binding; the point is to determine
+# whether the deletion is necessary, and if not we can trust the ordinary
+# mechanisms to do the right thing.
+#
+# The prediction interprets only the lowered statements that feed
+# `Core._typebody!` calls, plus `eval` calls (whose contents may define types
+# via metaprogramming). This is implemented by mimicking the larger pipeline
+# above: a new set of `isrequired` rules plus a focused line-stepper.
+
+# `true` when `stmt` is (or wraps, as the RHS of an assignment) a call to
+# `Core._typebody!`, following SSA chains to resolve the callee.
+function is_typebody_stmt(@nospecialize(stmt), code::Vector{Any})
+    isa(stmt, Expr) || return false
+    callstmt = stmt
+    if callstmt.head !== :call
+        LoweredCodeUtils.get_lhs_rhs(callstmt) === nothing && return false
+        rhs = LoweredCodeUtils.getrhs(callstmt)
+        isa(rhs, Expr) && rhs.head === :call || return false
+        callstmt = rhs
+    end
+    isempty(callstmt.args) && return false
+    callee = callstmt.args[1]
+    while isa(callee, Core.SSAValue) || isa(callee, JuliaInterpreter.SSAValue)
+        callee = code[callee.id]
+    end
+    if isa(callee, GlobalRef)
+        return callee.mod === Core && callee.name === :_typebody!
+    end
+    isa(callee, QuoteNode) && (callee = callee.value)
+    return @static(isdefined(Core, :_typebody!) ? true : false) && callee === Core._typebody!
+end
+
+# Statement filter for the prediction pass: only `_typebody!` calls, `eval` calls,
+# and `:toplevel` blocks (and, via `lines_required!`, their dependencies) run.
+function predict_predicate(@nospecialize(stmt), code::Vector{Any})
+    isa(stmt, Expr) || return (false, false)
+    haseval = matches_eval(stmt)
+    isreq = haseval | (stmt.head === :toplevel) | is_typebody_stmt(stmt, code)
+    return (isreq, haseval)
+end
+
+# Execute `Core._typebody!` — its effects are confined to the throwaway partial type
+# created by `_structtype` earlier in the frame — and record in `predictions` whether
+# evaluating this definition will preserve the existing binding. Returns the value to
+# assign to the statement's SSA slot.
+#
+# The two branches below reflect a difference in lowering. Struct definitions pass a
+# `prev` argument (the existing type if `Core._equiv_typedef` judged the headers
+# equivalent, `false` otherwise), and `_typebody!(prev, partial, ftypes)` returns
+# `prev` exactly when evaluation would reuse the existing type — so `result ===
+# existing` is the complete test. Abstract and primitive types lower to the
+# 2-argument form with `prev` always `false` (so `result` is always the partial);
+# their lowering instead gates the `const` on `Core._equiv_typedef`, so calling that
+# directly replicates the test evaluation would perform.
+function record_typebody_prediction!(predictions::TypePredictions, interp::Interpreter, frame::Frame, callstmt::Expr)
+    prev = lookup(interp, frame, callstmt.args[2])
+    partial = lookup(interp, frame, callstmt.args[3])
+    partial isa Type || error("unexpected _typebody! argument ", partial)
+    tn = (Base.unwrap_unionall(partial)::DataType).name
+    existing = @invokelatest(isdefinedglobal(tn.module, tn.name)) ?
+               @invokelatest(getglobal(tn.module, tn.name)) : nothing
+    if length(callstmt.args) >= 4
+        ftypes = lookup(interp, frame, callstmt.args[4])::Core.SimpleVector
+        result = Core._typebody!(prev, partial, ftypes)
+        preserved = existing isa Type && result === existing
+    else
+        result = Core._typebody!(prev, partial)
+        preserved = existing isa Type &&
+            @static(isdefined(Core, :_equiv_typedef) ? true : false) &&
+            Core._equiv_typedef(existing, partial)
+    end
+    predictions.preserved[(tn.module, tn.name)] = preserved
+    return result
+end
+
+# Record a prediction for every type `ex` would define, without publishing any
+# binding or defining any method. Throws on lowering or execution failure; the
+# caller treats a throw as "no prediction", leaving the pessimistic deletion path
+# in force (correct, just unoptimized).
+function predict_typebodies!(predictions::TypePredictions, mod::Module, ex::Expr)
+    # The walk requires the Julia 1.12+ struct-lowering protocol, in which
+    # `_typebody!(prev, partial, ...)` carries a `prev` argument and the binding is
+    # published only by a subsequent `const`/`declare_const`. Older lowering binds
+    # the type through statements this walk executes, so prediction would not be
+    # non-destructive there; report "no prediction" instead.
+    @static VERSION >= v"1.12.0-DEV.2047" || return predictions
+    lwr = Meta.lower(mod, ex)
+    isa(lwr, Expr) || return predictions
+    if lwr.head === :error || lwr.head === :incomplete
+        throw(LoweringException(lwr))
+    end
+    lwr.head === :thunk || return predictions
+    src = lwr.args[1]::CodeInfo
+    any(stmt -> predict_predicate(stmt, src.code)[1], src.code) || return predictions
+    frame = Frame(mod, src)
+    isrequired, _ = minimal_evaluation!(predict_predicate, frame, :sigs)
+    interp = Compiled()
+    pc = frame.pc
+    while true
+        stmt = pc_expr(frame, pc)
+        if !isrequired[pc]
+            pc = next_or_nothing!(frame)
+        elseif isa(stmt, Expr)
+            head = stmt.head
+            if head === :const || head === :method || head === :thunk
+                # `:const` would publish a binding; `:method`/`:thunk` would define
+                # methods ahead of the deletion phase. None of these feed a
+                # `_typebody!` call, so skipping is safe; if one is nevertheless a
+                # dependency, evaluation fails and the caller falls back to the
+                # pessimistic path.
+                pc = next_or_nothing!(frame)
+            elseif head === :toplevel
+                for a in stmt.args
+                    a isa Expr || continue
+                    predict_typebodies!(predictions, mod, a)
+                end
+                assign_this!(frame, nothing)
+                pc = next_or_nothing!(frame)
+            else
+                callstmt = stmt
+                if head !== :call
+                    rhs = LoweredCodeUtils.get_lhs_rhs(stmt) === nothing ? nothing :
+                          LoweredCodeUtils.getrhs(stmt)
+                    callstmt = isa(rhs, Expr) && rhs.head === :call ? rhs : nothing
+                end
+                if callstmt === nothing
+                    pc = step_expr!(interp, frame, stmt, true)
+                else
+                    f = lookup(frame, callstmt.args[1])
+                    if @static(isdefined(Core, :_typebody!) ? true : false) && f === Core._typebody! && length(callstmt.args) >= 3
+                        assign_this!(frame, record_typebody_prediction!(predictions, interp, frame, callstmt))
+                        pc = next_or_nothing!(frame)
+                    elseif @static(isdefined(Core, :declare_const) ? true : false) && f === Core.declare_const
+                        pc = next_or_nothing!(frame)
+                    elseif f === Core.eval
+                        evalmod = lookup(interp, frame, callstmt.args[2])
+                        evalex = lookup(interp, frame, callstmt.args[3])
+                        if evalmod isa Module && evalex isa Expr
+                            for (newmod, newex) in ExprSplitter(evalmod, evalex)
+                                if is_doc_expr(newex)
+                                    newex = newex.args[4]
+                                end
+                                newex = unwrap(newex)
+                                newex isa Expr && predict_typebodies!(predictions, newmod, newex)
+                            end
+                        end
+                        assign_this!(frame, nothing)
+                        pc = next_or_nothing!(frame)
+                    else
+                        pc = step_expr!(interp, frame, stmt, true)
+                    end
+                end
+            end
+        else
+            pc = step_expr!(interp, frame, stmt, true)
+        end
+        pc === nothing && break
+    end
+    return predictions
+end

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1246,6 +1246,21 @@ function revise(; throw::Bool=false)
         # won't get redefined first and deleted second.
         revision_errors = Tuple{PkgData,String}[]
         queue = sort!(collect(revision_queue); lt=pkgfileless)
+        # A watcher task can queue a `PkgData` that has since been replaced in
+        # `pkgdatas` (e.g., by `Revise.track` of a package whose record had been
+        # dropped, as for packages baked into a sysimage — issue #685). If both the
+        # stale and the current record are queued for the same file, keep only the
+        # current one: each holds its own copy of the file's old signatures, and
+        # processing both would delete the same methods twice.
+        keep = trues(length(queue))
+        for (i, (pkgdata, file)) in enumerate(queue)
+            current = get(pkgdatas, PkgId(pkgdata), nothing)
+            (current === nothing || current === pkgdata) && continue
+            if any(((qpkgdata, qfile),) -> qpkgdata === current && qfile == file, queue)
+                keep[i] = false
+            end
+        end
+        queue = queue[keep]
         finished = eltype(revision_queue)[]
         mod_exs_infos = ModuleExprsInfos[]
         interrupt = false

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -482,7 +482,8 @@ end
 
 function delete_missing!(
         exs_infos_old::ExprsInfos, exs_infos_new::ExprsInfos,
-        reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt
+        reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt,
+        predictions::TypePredictions = TypePredictions(),
     )
     with_logger(_debug_logger) do
         for (rex, exinfos) in exs_infos_old
@@ -491,9 +492,23 @@ function delete_missing!(
             exinfos === nothing && continue
             for exinfo in exinfos
                 if exinfo isa SigInfo
+                    # Method deletions are never skipped on the strength of a
+                    # prediction: a textually identical signature may dispatch on a
+                    # type that is itself being redefined, in which case the new
+                    # method is distinct from the old one and the old one must go.
                     handle_method_deletion!(exinfo, rex, world)
                 elseif __bpart__[]
-                    handle_type_deletion!(exinfo::TypeInfo, reeval_list, handled_types, world)
+                    typeinfo = exinfo::TypeInfo
+                    oldtype = prediction_preserves_type(predictions, typeinfo, world)
+                    if oldtype !== nothing
+                        # The new source redefines this type equivalently, so
+                        # evaluation will keep the existing binding and the
+                        # subtype-tree walk is unnecessary (issue #1022). The
+                        # prediction is re-checked after evaluation; see `revise`.
+                        push!(predictions.skipped, (typeinfo, oldtype))
+                        continue
+                    end
+                    handle_type_deletion!(typeinfo, reeval_list, handled_types, world)
                 end
             end
         end
@@ -501,16 +516,67 @@ function delete_missing!(
     return exs_infos_old
 end
 
+# Return the existing type when `predictions` says the new code redefines
+# `typeinfo`'s type equivalently (so its deletion walk can be skipped), else `nothing`.
+function prediction_preserves_type(predictions::TypePredictions, typeinfo::TypeInfo, world::UInt)
+    tn = typeinfo.typname
+    get(predictions.preserved, (tn.module, tn.name), false) || return nothing
+    Base.invoke_in_world(world, isdefinedglobal, tn.module, tn.name) || return nothing
+    existing = Base.invoke_in_world(world, getglobal, tn.module, tn.name)
+    existing isa Type || return nothing
+    return existing
+end
+
 const empty_exs_infos = ExprsInfos()
 function delete_missing!(
         mod_exs_infos_old::ModuleExprsInfos, mod_exs_infos_new::ModuleExprsInfos,
-        reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt
+        reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt,
+        predictions::TypePredictions = TypePredictions(),
     )
     for (mod, exs_infos_old) in mod_exs_infos_old
         exs_infos_new = get(mod_exs_infos_new, mod, empty_exs_infos)
-        delete_missing!(exs_infos_old, exs_infos_new, reeval_list, handled_types, world)
+        delete_missing!(exs_infos_old, exs_infos_new, reeval_list, handled_types, world, predictions)
     end
     return mod_exs_infos_old
+end
+
+# `true` if diffing old against new will delete at least one expression that defined
+# a type. This gates the prediction pass: when no type deletion is pending, there is
+# nothing for a prediction to save.
+function has_pending_type_deletion(mod_exs_infos_new::ModuleExprsInfos, mod_exs_infos_old::ModuleExprsInfos)
+    for (mod, exs_infos_old) in mod_exs_infos_old
+        exs_infos_new = get(mod_exs_infos_new, mod, empty_exs_infos)
+        for (rex, exinfos) in exs_infos_old
+            haskey(exs_infos_new, rex) && continue
+            exinfos === nothing && continue
+            any(exinfo -> exinfo isa TypeInfo, exinfos) && return true
+        end
+    end
+    return false
+end
+has_pending_type_deletion(@nospecialize(mod_exs_infos_new), mod_exs_infos_old::ModuleExprsInfos) = false
+
+# Run the type-preservation prediction over every expression the evaluation phase
+# will (re)evaluate, i.e., the new rexes. Best-effort: any error leaves the affected
+# types unpredicted, keeping the pessimistic deletion path in force.
+function predict_changes!(
+        predictions::TypePredictions,
+        mod_exs_infos_new::ModuleExprsInfos, mod_exs_infos_old::ModuleExprsInfos,
+    )
+    for (mod, exs_infos_new) in mod_exs_infos_new
+        exs_infos_old = get(mod_exs_infos_old, mod, empty_exs_infos)
+        for rex in keys(exs_infos_new)
+            haskey(exs_infos_old, rex) && continue
+            ex = rex.ex
+            try
+                predict_typebodies!(predictions, mod, ex)
+            catch err
+                isa(err, InterruptException) && rethrow(err)
+                @debug "PredictFailed" _group="Action" time=time() deltainfo=(mod, ex, err)
+            end
+        end
+    end
+    return predictions
 end
 
 function handle_method_deletion!(siginfo::SigInfo, rex::RelocatableExpr, world::UInt)
@@ -928,11 +994,10 @@ function revise_file_queued(pkgdata::PkgData, file)
     return
 end
 
-# Because we delete first, we have to make sure we've parsed the file
-function handle_deletions(
-        pkgdata::PkgData, file::AbstractString,
-        reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt
-    )
+# Parse the file's current contents and look up the exprs Revise has on record for
+# it. Returns `(mod_exs_infos_new, mod_exs_infos_old, fileok)`. Safe to call from a
+# pre-deletion pass: any mutation of `pkgdata` is limited to lazily filling caches.
+function parse_for_revision(pkgdata::PkgData, file::AbstractString)
     fi = maybe_parse_from_cache!(pkgdata, file)
     maybe_extract_sigs!(fi)
     mod_exs_infos_old = fi.mod_exs_infos
@@ -948,10 +1013,31 @@ function handle_deletions(
     topmod = first(keys(mod_exs_infos_old))
     fileok = file_exists(String(filep)::String)
     mod_exs_infos_new = fileok ? parse_source(filep, topmod) : ModuleExprsInfos(topmod)
+    return mod_exs_infos_new, mod_exs_infos_old, fileok
+end
+
+# Apply deletions for `(pkgdata, file)` from the results of `parse_for_revision`.
+# Mutates `reeval_list`, `handled_types`, `predictions.skipped`, and — when the file
+# no longer exists — `pkgdata` and the watch lists.
+function delete_for_revision(
+        pkgdata::PkgData, file::AbstractString,
+        @nospecialize(mod_exs_infos_new), mod_exs_infos_old::ModuleExprsInfos, fileok::Bool,
+        reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt,
+        predictions::TypePredictions,
+    )
     if mod_exs_infos_new !== nothing && mod_exs_infos_new !== DoNotParse()
-        delete_missing!(mod_exs_infos_old, mod_exs_infos_new, reeval_list, handled_types, world)
+        delete_missing!(mod_exs_infos_old, mod_exs_infos_new::ModuleExprsInfos, reeval_list, handled_types, world, predictions)
     end
     if !fileok
+        idx = fileindex(pkgdata, file)
+        filep = pkgdata.info.files[idx]
+        if isa(filep, AbstractString)
+            if file ≠ "."
+                filep = normpath(basedir(pkgdata), file)
+            else
+                filep = normpath(basedir(pkgdata))
+            end
+        end
         @warn("$filep no longer exists, deleted all methods")
         deleteat!(pkgdata.fileinfos, idx)
         deleteat!(pkgdata.info.files, idx)
@@ -961,6 +1047,18 @@ function handle_deletions(
             delete!(wl.file_ctimes, file)
         end
     end
+    return nothing
+end
+
+# Because we delete first, we have to make sure we've parsed the file
+function handle_deletions(
+        pkgdata::PkgData, file::AbstractString,
+        reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt,
+        predictions::TypePredictions = TypePredictions(),
+    )
+    mod_exs_infos_new, mod_exs_infos_old, fileok = parse_for_revision(pkgdata, file)
+    delete_for_revision(pkgdata, file, mod_exs_infos_new, mod_exs_infos_old, fileok,
+                        reeval_list, handled_types, world, predictions)
     return mod_exs_infos_new, mod_exs_infos_old
 end
 
@@ -1151,12 +1249,48 @@ function revise(; throw::Bool=false)
         finished = eltype(revision_queue)[]
         mod_exs_infos = ModuleExprsInfos[]
         interrupt = false
+
+        # Parse every queued file, then predict which already-defined types the new
+        # code re-creates unchanged (e.g., a `@kwdef` struct whose only edit is a
+        # default value — issue #1022). The prediction must precede `delete_missing!`,
+        # which consults it to skip the expensive subtype-tree walk, and it must span
+        # all queued files so a type moved between files is still recognized. It runs
+        # only when a type deletion is actually pending, and only under `__bpart__[]`
+        # (the consumer of the walk it can skip).
+        predictions = TypePredictions()
+        parsed = Tuple{PkgData,String,Any,ModuleExprsInfos,Bool}[]
+        pending_type_deletion = false
         for (pkgdata, file) in queue
             try
-                mod_exs_infos_new, _ = handle_deletions(pkgdata, file, reeval_list, handled_types, world)
+                mod_exs_infos_new, mod_exs_infos_old, fileok = parse_for_revision(pkgdata, file)
                 mod_exs_infos_new === DoNotParse() && continue
-                push!(mod_exs_infos, mod_exs_infos_new)
-                push!(finished, (pkgdata, file))
+                pending_type_deletion |= __bpart__[] && has_pending_type_deletion(mod_exs_infos_new, mod_exs_infos_old)
+                push!(parsed, (pkgdata, file, mod_exs_infos_new, mod_exs_infos_old, fileok))
+            catch err
+                throw && Base.throw(err)
+                interrupt |= isa(err, InterruptException)
+                push!(revision_errors, (pkgdata, file))
+                queue_errors[(pkgdata, file)] = (err, catch_backtrace())
+            end
+        end
+        if pending_type_deletion
+            with_logger(_debug_logger) do
+                for (pkgdata, file, mod_exs_infos_new, mod_exs_infos_old, fileok) in parsed
+                    mod_exs_infos_new isa ModuleExprsInfos || continue
+                    predict_changes!(predictions, mod_exs_infos_new, mod_exs_infos_old)
+                end
+            end
+        end
+
+        # Apply the deletions
+        for (pkgdata, file, mod_exs_infos_new, mod_exs_infos_old, fileok) in parsed
+            try
+                delete_for_revision(pkgdata, file, mod_exs_infos_new, mod_exs_infos_old, fileok,
+                                    reeval_list, handled_types, world, predictions)
+                if mod_exs_infos_new !== nothing
+                    push!(mod_exs_infos, mod_exs_infos_new)
+                    push!(finished, (pkgdata, file))
+                end
             catch err
                 throw && Base.throw(err)
                 interrupt |= isa(err, InterruptException)
@@ -1221,6 +1355,21 @@ function revise(; throw::Bool=false)
 
         # Do binding redefinitions
         if __bpart__[]
+            # Verify the predictions that suppressed deletion walks: they were made
+            # before any queued change was applied, so a same-revision change to a
+            # binding the type's structure depends on (a field-type alias, a
+            # supertype, a parameter bound) can falsify them. If the binding moved
+            # anyway, run the walk now — `world` still resolves the old type. Relative
+            # to a pre-evaluation walk, signature extraction for files that have not
+            # yet been parsed sees the new binding, so methods in such files may
+            # escape re-evaluation.
+            for (typeinfo, oldtype) in predictions.skipped
+                tn = typeinfo.typname
+                current = @invokelatest(isdefinedglobal(tn.module, tn.name)) ?
+                          @invokelatest(getglobal(tn.module, tn.name)) : nothing
+                current === oldtype && continue
+                handle_type_deletion!(typeinfo, reeval_list, handled_types, world)
+            end
             redefine_bindings!(revision_errors, reeval_list, world)
         end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -174,6 +174,29 @@ function replace_extended_data(siginfo::SigInfo, owner::Symbol, @nospecialize(da
 end
 
 const ExprsInfos = OrderedDict{RelocatableExpr,Union{Nothing,Vector{Union{SigInfo,TypeInfo}}}}
+
+# `TypePredictions`
+#
+# Per-revision record of whether the incoming source preserves each type it
+# (re)defines, built by `predict_changes!` before any deletions are applied.
+#
+# - `preserved[(mod, name)]` is `true` when evaluating the new code is predicted to
+#   keep the existing binding `mod.name`: the new definition is equivalent per the
+#   runtime's own `Core._equiv_typedef`/`Core._typebody!` checks, so evaluation
+#   reuses the existing type and the `const` re-assert leaves the binding partition
+#   untouched. `delete_missing!` consults this to skip the expensive subtype-tree
+#   walk in `handle_type_deletion!` (issue #1022).
+# - `skipped` records every `(typeinfo, oldtype)` whose deletion walk was skipped on
+#   the strength of a prediction. Predictions are made before any queued change is
+#   applied, so a same-revision change to a binding the type's structure depends on
+#   (a field-type alias, a supertype, a parameter bound) can falsify them; `revise`
+#   re-checks each entry after evaluation and runs the walk late for stale ones.
+struct TypePredictions
+    preserved::Dict{Tuple{Module,Symbol},Bool}
+    skipped::Vector{Tuple{TypeInfo,Type}}
+end
+TypePredictions() = TypePredictions(Dict{Tuple{Module,Symbol},Bool}(), Tuple{TypeInfo,Type}[])
+
 const DepDictVals = Tuple{Module,RelocatableExpr}
 const DepDict = Dict{Symbol,Set{DepDictVals}}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3683,13 +3683,26 @@ end
         @latestworld
         @test TrackSysimg685.f685() == 1
         id = Base.PkgId(TrackSysimg685)
-        @lock Revise.revise_lock delete!(Revise.pkgdatas, id)
+        old_pkgdata = @lock Revise.revise_lock begin
+            pd = Revise.pkgdatas[id]
+            delete!(Revise.pkgdatas, id)
+            pd
+        end
         sleep(mtimedelay)
-        write(joinpath(dn, "TrackSysimg685.jl"), """
+        fn685 = joinpath(dn, "TrackSysimg685.jl")
+        write(fn685, """
             module TrackSysimg685
             f685() = 2
             end
             """)
+        # In file-watching mode, the watcher task still holds the dropped record and
+        # queues it when the file changes; `track` then queues the replacement record
+        # for the same file. Each record carries its own copy of the file's old
+        # signatures, so processing both would delete `f685` twice. Push the stale
+        # entry explicitly so the duplicate pair is exercised deterministically
+        # rather than only when the watcher wins the race.
+        @lock Revise.revise_lock push!(Revise.revision_queue,
+                                       (old_pkgdata, relpath(fn685, old_pkgdata)))
         Revise.track(TrackSysimg685)
         @latestworld
         @test TrackSysimg685.f685() == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3168,6 +3168,235 @@ end
         end
     end
 
+    if Revise.__bpart__[] && do_test("struct revision (issue #1022)")
+        @testset "struct revision (issue #1022)" begin
+            # Editing only the default value of a `@kwdef` struct (or any other change
+            # that re-creates a type with identical structure) must not trigger the
+            # expensive struct-revision path: no `DeleteType` walk runs and the
+            # binding is preserved. Genuine changes to fields, types, or mutability
+            # still go through full revision.
+            testdir = newtestdir()
+            try
+                rlogger = Revise.debug_logger()
+                deletetype_logs() = filter(r -> r.level == Debug && r.group == "Action" &&
+                                                r.message == "DeleteType", rlogger.logs)
+                dn = joinpath(testdir, "Revise1022", "src")
+                mkpath(dn)
+                fn = joinpath(dn, "Revise1022.jl")
+                pkg_code_v1 = """
+                    module Revise1022
+                    Base.@kwdef struct Blah
+                        x = 4
+                    end
+                    # Dispatches on Blah but is otherwise untouched by the revisions below;
+                    # it keeps working as long as the Blah binding is preserved.
+                    useblah(b::Blah) = b.x + 1
+                    # The `if` block keeps the abstract type and the struct in a single
+                    # expression, so revision interprets (rather than `Core.eval`s) it and
+                    # registers a `TypeInfo` for the abstract type too. Editing the default
+                    # then exercises preservation prediction for both.
+                    if true
+                        abstract type AbstractWrapped end
+                        Base.@kwdef struct Wrapped <: AbstractWrapped
+                            w::Int = 1
+                        end
+                    end
+                    end
+                    """
+                write(fn, pkg_code_v1)
+                sleep(mtimedelay)
+                @eval using Revise1022
+                sleep(mtimedelay)
+                T_v1 = Revise1022.Blah
+                W_v1 = Revise1022.Wrapped
+                AW_v1 = Revise1022.AbstractWrapped
+                @test Revise1022.Blah().x == 4
+                @test Revise1022.useblah(Revise1022.Blah()) == 5
+
+                # Revision 1: change only default values — bindings must be preserved,
+                # and no DeleteType walk may run
+                empty!(rlogger.logs)
+                pkg_code_v2 = replace(pkg_code_v1, "x = 4" => "x = 5", "w::Int = 1" => "w::Int = 2")
+                write(fn, pkg_code_v2)
+                @yry()
+                @test @invokelatest(getfield(Revise1022, :Blah)) === T_v1
+                @test @invokelatest(getfield(Revise1022, :Wrapped)) === W_v1
+                @test @invokelatest(Revise1022.Blah()).x == 5
+                @test @invokelatest(Revise1022.Wrapped()).w == 2
+                @test isempty(deletetype_logs())
+                @test @invokelatest(Revise1022.useblah(Revise1022.Blah())) == 6
+
+                # Revision 2: another default-only edit. The `if` block was interpreted in
+                # `:eval` mode by revision 1, so the abstract type now has a `TypeInfo` on
+                # record and its preservation must also be predicted (via `_equiv_typedef`).
+                empty!(rlogger.logs)
+                pkg_code_v3 = replace(pkg_code_v2, "w::Int = 2" => "w::Int = 3")
+                write(fn, pkg_code_v3)
+                @yry()
+                @test @invokelatest(getfield(Revise1022, :Wrapped)) === W_v1
+                @test @invokelatest(getfield(Revise1022, :AbstractWrapped)) === AW_v1
+                @test @invokelatest(Revise1022.Wrapped()).w == 3
+                @test isempty(deletetype_logs())
+
+                # Revision 3: add a field — the full struct-revision path must run
+                empty!(rlogger.logs)
+                pkg_code_v4 = replace(pkg_code_v3,
+                    "x = 5" => "x = 5\n        y::Int = 7",
+                    "useblah(b::Blah) = b.x + 1" => "useblah(b::Blah) = b.x + b.y")
+                write(fn, pkg_code_v4)
+                @yry()
+                T_v4 = @invokelatest getfield(Revise1022, :Blah)
+                @test T_v4 !== T_v1
+                @test :y in fieldnames(T_v4)
+                @test @invokelatest(Revise1022.useblah(Revise1022.Blah())) == 12  # 5 + 7
+                @test !isempty(deletetype_logs())
+
+                # Revision 4: change a field type — the full struct-revision path must run
+                empty!(rlogger.logs)
+                pkg_code_v5 = replace(pkg_code_v4, "y::Int = 7" => "y::Float64 = 7.0")
+                write(fn, pkg_code_v5)
+                @yry()
+                T_v5 = @invokelatest getfield(Revise1022, :Blah)
+                @test T_v5 !== T_v4
+                @test fieldtype(T_v5, :y) === Float64
+                @test !isempty(deletetype_logs())
+            finally
+                rm_precompile("Revise1022")
+                pop!(LOAD_PATH)
+            end
+
+            # Changing a field's `const` or `@atomic` annotation changes the type even
+            # though the field names and types are identical; preservation must not be
+            # predicted (`Core._equiv_typedef` compares these flags, so delegating the
+            # equivalence check to the runtime gets them right).
+            testdir = newtestdir()
+            try
+                dn = joinpath(testdir, "ReviseFieldFlags", "src")
+                mkpath(dn)
+                fn = joinpath(dn, "ReviseFieldFlags.jl")
+                pkg_code_v1 = """
+                    module ReviseFieldFlags
+                    mutable struct MC
+                        x::Int
+                    end
+                    MC() = MC(0)
+                    mutable struct MA
+                        y::Int
+                    end
+                    MA() = MA(0)
+                    end
+                    """
+                write(fn, pkg_code_v1)
+                sleep(mtimedelay)
+                @eval using ReviseFieldFlags
+                sleep(mtimedelay)
+                MC_v1, MA_v1 = ReviseFieldFlags.MC, ReviseFieldFlags.MA
+                @test !isconst(MC_v1, 1)
+                @test !Base.isfieldatomic(MA_v1, 1)
+
+                pkg_code_v2 = replace(pkg_code_v1, "x::Int" => "const x::Int",
+                                                   "y::Int" => "@atomic y::Int")
+                write(fn, pkg_code_v2)
+                @yry()
+                MC_v2 = @invokelatest getfield(ReviseFieldFlags, :MC)
+                @test MC_v2 !== MC_v1
+                @test isconst(MC_v2, 1)
+                MA_v2 = @invokelatest getfield(ReviseFieldFlags, :MA)
+                @test MA_v2 !== MA_v1
+                @test Base.isfieldatomic(MA_v2, 1)
+            finally
+                rm_precompile("ReviseFieldFlags")
+                pop!(LOAD_PATH)
+            end
+
+            # Preservation predictions run before any of the queued changes are applied,
+            # so a same-revision change to a binding the struct's structure depends on
+            # (here, a `const` field-type alias) makes the prediction stale: evaluation
+            # redefines the struct after all. The post-evaluation check must catch this
+            # and run the deletion walk late, so that dependent methods (`dist`) are
+            # still re-evaluated for the new type.
+            testdir = newtestdir()
+            try
+                dn = joinpath(testdir, "ReviseStale", "src")
+                mkpath(dn)
+                fn = joinpath(dn, "ReviseStale.jl")
+                pkg_code_v1 = """
+                    module ReviseStale
+                    const Coord = Float32
+                    Base.@kwdef struct Pt
+                        x::Coord = 0
+                    end
+                    dist(p::Pt) = Float64(p.x)
+                    end
+                    """
+                write(fn, pkg_code_v1)
+                sleep(mtimedelay)
+                @eval using ReviseStale
+                sleep(mtimedelay)
+                P_v1 = ReviseStale.Pt
+                @test ReviseStale.dist(ReviseStale.Pt()) === 0.0
+
+                pkg_code_v2 = replace(pkg_code_v1, "const Coord = Float32" => "const Coord = Float64",
+                                                   "x::Coord = 0" => "x::Coord = 1")
+                write(fn, pkg_code_v2)
+                @yry()
+                P_v2 = @invokelatest getfield(ReviseStale, :Pt)
+                @test P_v2 !== P_v1
+                @test fieldtype(P_v2, :x) === Float64
+                @test @invokelatest(ReviseStale.dist(@invokelatest(ReviseStale.Pt()))) === 1.0
+            finally
+                rm_precompile("ReviseStale")
+                pop!(LOAD_PATH)
+            end
+
+            # Moving an unchanged struct between files deletes it from one file's exprs
+            # and re-creates it from another's. Predictions span all queued files, so
+            # the move is recognized as preserving and skips the deletion walk.
+            testdir = newtestdir()
+            try
+                rlogger = Revise.debug_logger()
+                dn = joinpath(testdir, "ReviseMove", "src")
+                mkpath(dn)
+                write(joinpath(dn, "ReviseMove.jl"), """
+                    module ReviseMove
+                    include("types.jl")
+                    include("methods.jl")
+                    end
+                    """)
+                write(joinpath(dn, "types.jl"), """
+                    struct Movable
+                        x::Int
+                    end
+                    """)
+                write(joinpath(dn, "methods.jl"), """
+                    usemovable(m::Movable) = m.x + 1
+                    """)
+                sleep(mtimedelay)
+                @eval using ReviseMove
+                sleep(mtimedelay)
+                M_v1 = ReviseMove.Movable
+                @test ReviseMove.usemovable(ReviseMove.Movable(1)) == 2
+
+                empty!(rlogger.logs)
+                write(joinpath(dn, "types.jl"), "\n")
+                write(joinpath(dn, "methods.jl"), """
+                    struct Movable
+                        x::Int
+                    end
+                    usemovable(m::Movable) = m.x + 1
+                    """)
+                @yry()
+                @test @invokelatest(getfield(ReviseMove, :Movable)) === M_v1
+                @test @invokelatest(ReviseMove.usemovable(@invokelatest(ReviseMove.Movable(1)))) == 2
+                @test isempty(filter(r -> r.level == Debug && r.group == "Action" &&
+                                          r.message == "DeleteType", rlogger.logs))
+            finally
+                rm_precompile("ReviseMove")
+                pop!(LOAD_PATH)
+            end
+        end
+    end
+
     do_test("get_def") && @testset "get_def" begin
         testdir = newtestdir()
         dn = joinpath(testdir, "GetDef", "src")


### PR DESCRIPTION
This is a replacement for #1038. I was unhappy with how intrusive that was; this is still intrusive at the level of the `packagedef` orchestration (`revise()` pipeline), but the intrusive changes to types, lowering, and `visit` are essentially gone with this implementation. The key realization was that this really shouldn't require anything beyond a type-equivalence check; the only thing that makes it complicated is that disentangling the type from surrounding code can't be robust without lowering. So the "predict" mechanism from #1038 is retained, but the rest is far more straightforward while also being more correct (e.g., leaning on Julia internals for the type-equivalence machinery rather than trying to decide it within Revise). I think the overall line-count may be larger, but that's mostly due to expanded tests which capture a couple of bugs in the implementation of #1038.

I plan to merge this version as soon as tests pass. Below is the full commit message.

Closes #1038.

----

Editing only the default value inside a `@kwdef` struct used to trigger the full struct-revision path, walking the entire subtype tree of `Any` and re-evaluating every dependent. This is a lot of overhead for something that could be implemented as a simple method redefinition.

Before applying deletions, `revise` now predicts which already-defined types the new source re-creates unchanged, and skips `handle_type_deletion!` for those. The prediction interprets only the lowered statements feeding each `Core._typebody!` call (plus `eval` calls, so metaprogrammed definitions are covered), skipping anything that would publish a binding or define a method. If they check out as equivalent to the existing type, the deletion is skipped; if not, the deletion proceeds as normal. When deletion is omitted, the normal "is the redefined type equivalent?" machinery works as usual.

Because predictions are made before any queued change is applied, a same-revision change to a binding that the type's structure depends on (a field-type alias, a supertype, a parameter bound) can falsify them. Each skipped deletion is therefore re-checked after evaluation.

The prediction pass runs only when a type deletion is actually pending, only on Julia 1.12+ (`__bpart__[]`), and spans all queued files so a type moved between files is still recognized.

Fixes #1022