### PR TITLE
Queue event-named files unconditionally

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,10 +2,8 @@ name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
 version = "3.15.0"
 
-[workspace]
-projects = ["docs", "test"]
-
 [deps]
+CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -53,3 +51,6 @@ UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [targets]
 test = ["CatIndices", "Distributed", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Pkg", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]
+
+[workspace]
+projects = ["docs", "test"]

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -2,6 +2,7 @@ Base.Experimental.@optlevel 1
 
 using FileWatching, REPL, UUIDs
 using LibGit2: LibGit2
+using CRC32c: crc32c
 using Base: PkgId, IdSet
 using Base.Meta: isexpr
 using InteractiveUtils: InteractiveUtils

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -376,14 +376,13 @@ function wait_changed_dir(dirname::AbstractString)
     end
     changed = Set{String}()
     complete = true
-    note!(name) = isempty(name) ? (complete = false) : (push!(changed, name); true)
     try
         name, _ = watch_folder(dirname)              # block for the next buffered event
-        note!(name)
+        isempty(name) ? (complete = false) : push!(changed, name)
         while true                                   # drain a burst delivered in one wakeup
             name, event = watch_folder(dirname, 0)
             event.timedout && break
-            note!(name)
+            isempty(name) ? (complete = false) : push!(changed, name)
         end
     catch e
         # EOFError: monitor torn down; let caller re-check state. issue #459: Ctrl-C.
@@ -393,14 +392,24 @@ function wait_changed_dir(dirname::AbstractString)
     return complete ? changed : nothing
 end
 
+# Content hash for disambiguating events whose ctime is unchanged. Reads the
+# file, so call it only on event-named files, not in the per-directory sweep.
+filehash(path::AbstractString) = hash(read(path))
+
 # Scan the `tracked` `name=>PkgId` pairs of directory `dirname`, returning those
 # whose files should be queued for revision. `changed` is the set of entry names
-# reported by the filesystem events (`nothing` if unknown): a file named there is
-# queued even when its ctime matches the stored one. The kernel stamps inodes
-# with tick-resolution (often ~10ms) timestamps, so a delete-and-recreate that
-# lands within one tick of the recorded ctime is invisible to the timestamp
-# comparison; the event itself is the reliable signal (#945). The timestamp sweep
-# remains for files the events did not name.
+# reported by the filesystem events (`nothing` if unknown).
+#
+# The primary change test compares ctimes, but the kernel stamps inodes with
+# tick-resolution (often ~10ms) timestamps, so a delete-and-recreate that lands
+# within one tick of the recorded ctime is invisible to it (#945). For a file
+# named in an event, an unchanged ctime therefore means either a duplicate
+# notification of a change already queued (a single save delivers several
+# events, possibly across wakeups) or a same-tick rewrite; only content
+# distinguishes the two, so those files are settled by comparing a stored
+# hash. Hashes are recorded when a file is queued — an absent hash reads as
+# changed, keeping the failure mode "spurious no-op revision", never a missed
+# one. The timestamp sweep is unchanged for files the events did not name.
 function scan_changed_files(dirname::AbstractString, wf::WatchList, tracked, changed::Union{Nothing,Set{String}})
     latestfiles = Pair{String,PkgId}[]
     for (file, id) in tracked
@@ -426,10 +435,18 @@ function scan_changed_files(dirname::AbstractString, wf::WatchList, tracked, cha
             end
         end
         current_ctime = ctime(fullpath)
-        named = changed !== nothing && file in changed
-        if named || current_ctime != @lock revise_lock get(wf.file_ctimes, file, current_ctime - 1)
+        queueit = current_ctime != @lock revise_lock get(wf.file_ctimes, file, current_ctime - 1)
+        if !queueit && changed !== nothing && file in changed
+            h = filehash(fullpath)
+            queueit = h != @lock revise_lock get(wf.file_hashes, file, h + 1)
+        end
+        if queueit
             push!(latestfiles, file=>id)
-            @lock revise_lock wf.file_ctimes[file] = current_ctime
+            h = filehash(fullpath)
+            @lock revise_lock begin
+                wf.file_ctimes[file] = current_ctime
+                wf.file_hashes[file] = h
+            end
         end
     end
     return latestfiles

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -394,7 +394,7 @@ end
 
 # Content hash for disambiguating events whose ctime is unchanged. Reads the
 # file, so call it only on event-named files, not in the per-directory sweep.
-filehash(path::AbstractString) = hash(read(path))
+filehash(path::AbstractString) = open(crc32c, path)
 
 # Scan the `tracked` `name=>PkgId` pairs of directory `dirname`, returning those
 # whose files should be queued for revision. `changed` is the set of entry names

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -354,7 +354,11 @@ function eval_require_now(pkgdata::PkgData, fileidx::Int, filekey::String, sourc
     return ret
 end
 
-# Block until `dirname` reports filesystem activity.
+# Block until `dirname` reports filesystem activity. Returns the set of entry
+# names the events identified, or `nothing` when the changed entries are not
+# known (polling mode, a torn-down monitor, or an event that did not name its
+# file) -- a `nothing` return means "anything in the directory may have
+# changed".
 #
 # On notifying filesystems this uses a *persistent, buffered* `FolderMonitor`
 # (`watch_folder`): the OS watch stays registered between calls and queues every
@@ -368,23 +372,71 @@ end
 function wait_changed_dir(dirname::AbstractString)
     if polling_files[] || nonnotifying_path(dirname)
         wait_changed(dirname)  # unchanged poll behavior
-        return
+        return nothing
     end
+    changed = Set{String}()
+    complete = true
+    note!(name) = isempty(name) ? (complete = false) : (push!(changed, name); true)
     try
-        watch_folder(dirname)                          # block for the next buffered event
-        while !last(watch_folder(dirname, 0)).timedout # drain a burst delivered in one wakeup
+        name, _ = watch_folder(dirname)              # block for the next buffered event
+        note!(name)
+        while true                                   # drain a burst delivered in one wakeup
+            name, event = watch_folder(dirname, 0)
+            event.timedout && break
+            note!(name)
         end
     catch e
-        e isa EOFError && return                       # monitor torn down; let caller re-check state
-        # issue #459
-        (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
+        # EOFError: monitor torn down; let caller re-check state. issue #459: Ctrl-C.
+        e isa EOFError || (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
+        return nothing
     end
-    return
+    return complete ? changed : nothing
+end
+
+# Scan the `tracked` `name=>PkgId` pairs of directory `dirname`, returning those
+# whose files should be queued for revision. `changed` is the set of entry names
+# reported by the filesystem events (`nothing` if unknown): a file named there is
+# queued even when its ctime matches the stored one. The kernel stamps inodes
+# with tick-resolution (often ~10ms) timestamps, so a delete-and-recreate that
+# lands within one tick of the recorded ctime is invisible to the timestamp
+# comparison; the event itself is the reliable signal (#945). The timestamp sweep
+# remains for files the events did not name.
+function scan_changed_files(dirname::AbstractString, wf::WatchList, tracked, changed::Union{Nothing,Set{String}})
+    latestfiles = Pair{String,PkgId}[]
+    for (file, id) in tracked
+        fullpath = joinpath(dirname, file)
+        if isdir(fullpath)
+            # Detected a modification in a directory that we're watching in
+            # itself (not as a container for watched files)
+            push!(latestfiles, file=>id)
+            continue
+        elseif !file_exists(fullpath)
+            # File may have been deleted. But check again after a very brief pause.
+            sleep(0.1)
+            if !file_exists(fullpath)
+                # Queue the disappearance only once (stored ctime 0.0 marks it
+                # as already queued); a sibling-file event must not requeue a
+                # persistently missing file. The stored value reverts to a real
+                # ctime when the file reappears.
+                if (@lock revise_lock get(wf.file_ctimes, file, NaN)) != 0.0
+                    push!(latestfiles, file=>id)
+                    @lock revise_lock wf.file_ctimes[file] = 0.0
+                end
+                continue
+            end
+        end
+        current_ctime = ctime(fullpath)
+        named = changed !== nothing && file in changed
+        if named || current_ctime != @lock revise_lock get(wf.file_ctimes, file, current_ctime - 1)
+            push!(latestfiles, file=>id)
+            @lock revise_lock wf.file_ctimes[file] = current_ctime
+        end
+    end
+    return latestfiles
 end
 
 function watch_files_via_dir(dirname::AbstractString)
-    wait_changed_dir(dirname)  # block until the directory changes (buffered on notifying filesystems)
-    latestfiles = Pair{String,PkgId}[]
+    changed = wait_changed_dir(dirname)  # block until the directory changes (buffered on notifying filesystems)
     # Snapshot the tracked files under the lock. We then do the (potentially
     # blocking) filesystem checks below without holding it, reacquiring only to
     # read/update ctimes, so we never hold `revise_lock` across `sleep`.
@@ -392,39 +444,9 @@ function watch_files_via_dir(dirname::AbstractString)
         wf = get(watched_files, dirname, nothing)
         wf === nothing ? nothing : (wf, collect(wf.trackedfiles))
     end
-    stillwatching = snap !== nothing
-    if stillwatching
-        wf, tracked = snap
-        for (file, id) in tracked
-            fullpath = joinpath(dirname, file)
-            if isdir(fullpath)
-                # Detected a modification in a directory that we're watching in
-                # itself (not as a container for watched files)
-                push!(latestfiles, file=>id)
-                continue
-            elseif !file_exists(fullpath)
-                # File may have been deleted. But check again after a very brief pause.
-                sleep(0.1)
-                if !file_exists(fullpath)
-                    # Queue the disappearance only once (stored ctime 0.0 marks it
-                    # as already queued); a sibling-file event must not requeue a
-                    # persistently missing file. The stored value reverts to a real
-                    # ctime when the file reappears.
-                    if (@lock revise_lock get(wf.file_ctimes, file, NaN)) != 0.0
-                        push!(latestfiles, file=>id)
-                        @lock revise_lock wf.file_ctimes[file] = 0.0
-                    end
-                    continue
-                end
-            end
-            current_ctime = ctime(fullpath)
-            if current_ctime != @lock revise_lock get(wf.file_ctimes, file, current_ctime - 1)
-                push!(latestfiles, file=>id)
-                @lock revise_lock wf.file_ctimes[file] = current_ctime
-            end
-        end
-    end
-    return latestfiles, stillwatching
+    snap === nothing && return Pair{String,PkgId}[], false
+    wf, tracked = snap
+    return scan_changed_files(dirname, wf, tracked, changed), true
 end
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,10 +9,15 @@ should be tracked.
 Fields:
 - `trackedfiles`: map from basename to `PkgId` for each watched file
 - `file_ctimes`: last-seen `ctime` for each tracked file, used to detect changes
+- `file_hashes`: content hash for each tracked file, recorded when the file is
+  queued for revision. Disambiguates a filesystem event whose ctime matches the
+  stored one: kernel timestamps have tick resolution, so an unchanged ctime can
+  mean either a duplicate notification or a same-tick rewrite.
 """
 mutable struct WatchList
     trackedfiles::Dict{String,PkgId}
     file_ctimes::Dict{String,Float64}
+    file_hashes::Dict{String,UInt64}
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -131,7 +131,7 @@ Base.push!(wl::WatchList, filenameid::Pair{<:AbstractString,PkgFiles}) =
     push!(wl, filenameid.first=>filenameid.second.id)
 Base.push!(wl::WatchList, filenameid::Pair{<:AbstractString,PkgData}) =
     push!(wl, filenameid.first=>filenameid.second.info)
-WatchList() = WatchList(Dict{String,PkgId}(), Dict{String,Float64}())
+WatchList() = WatchList(Dict{String,PkgId}(), Dict{String,Float64}(), Dict{String,UInt64}())
 Base.in(file, wl::WatchList) = haskey(wl.trackedfiles, file)
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4757,7 +4757,8 @@ end
 do_test("Event-named files bypass the ctime filter") && @testset "Event-named files bypass the ctime filter" begin
     # The kernel stamps inodes at timer-tick resolution (often ~10ms), so a
     # delete-and-recreate can leave the new file with a ctime identical to the
-    # stored one; only the event's filename identifies the change (issue #945).
+    # stored one; the event's filename plus a content-hash comparison identify
+    # the change (issue #945).
     dir = randtmp()
     mkdir(dir)
     push!(to_remove, dir)
@@ -4769,7 +4770,16 @@ do_test("Event-named files bypass the ctime filter") && @testset "Event-named fi
     push!(wf, file=>id)
     tracked = collect(wf.trackedfiles)
 
-    # Simulated ctime collision: stored matches current, but the event names the file
+    # Simulated ctime collision: stored ctime matches current and the content
+    # was never hashed, but the event names the file
+    wf.file_ctimes[file] = ctime(fullpath)
+    @test Revise.scan_changed_files(dir, wf, tracked, Set([file])) == [file=>id]
+    @test wf.file_hashes[file] == Revise.filehash(fullpath)   # hash recorded on queueing
+    # A duplicate notification (same name, same ctime, same content) is absorbed
+    wf.file_ctimes[file] = ctime(fullpath)
+    @test isempty(Revise.scan_changed_files(dir, wf, tracked, Set([file])))
+    # Same-tick rewrite: ctime and name as before, but the content differs
+    write(fullpath, "f() = 2")
     wf.file_ctimes[file] = ctime(fullpath)
     @test Revise.scan_changed_files(dir, wf, tracked, Set([file])) == [file=>id]
     # An event naming only an untracked sibling leaves the unchanged file alone

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4754,6 +4754,34 @@ do_test("Non-jl include_dependency (issue #388)") && @testset "Non-jl include_de
     @test joinpath("deps", "dependency.txt") ∉ files
 end
 
+do_test("Event-named files bypass the ctime filter") && @testset "Event-named files bypass the ctime filter" begin
+    # The kernel stamps inodes at timer-tick resolution (often ~10ms), so a
+    # delete-and-recreate can leave the new file with a ctime identical to the
+    # stored one; only the event's filename identifies the change (issue #945).
+    dir = randtmp()
+    mkdir(dir)
+    push!(to_remove, dir)
+    file = "tracked.jl"
+    fullpath = joinpath(dir, file)
+    write(fullpath, "f() = 1")
+    id = Base.PkgId("FakePkg")
+    wf = Revise.WatchList()
+    push!(wf, file=>id)
+    tracked = collect(wf.trackedfiles)
+
+    # Simulated ctime collision: stored matches current, but the event names the file
+    wf.file_ctimes[file] = ctime(fullpath)
+    @test Revise.scan_changed_files(dir, wf, tracked, Set([file])) == [file=>id]
+    # An event naming only an untracked sibling leaves the unchanged file alone
+    wf.file_ctimes[file] = ctime(fullpath)
+    @test isempty(Revise.scan_changed_files(dir, wf, tracked, Set(["other.jl"])))
+    # Unknown event names fall back to the timestamp sweep
+    wf.file_ctimes[file] = ctime(fullpath)
+    @test isempty(Revise.scan_changed_files(dir, wf, tracked, nothing))
+    wf.file_ctimes[file] = ctime(fullpath) - 1
+    @test Revise.scan_changed_files(dir, wf, tracked, nothing) == [file=>id]
+end
+
 ## A missing tracked file is often transient: code generators delete a whole
 ## directory and rewrite it over several seconds (issue #945). Within
 ## `missing_file_grace`, a `revise()` must neither delete the file's methods nor


### PR DESCRIPTION
The directory watcher decides whether a tracked file changed by comparing its ctime against the stored value. The kernel stamps inodes with its coarse clock, which advances at timer-tick resolution (~10 ms at HZ=100; ticks stretch further under virtualization — a probe on WSL2 showed 500 rm+write cycles over 12 ms receiving only 3 distinct ctimes, in exact 9.97 ms steps). A delete-and-recreate landing within one tick of the recorded stamp therefore produces an identical ctime, and no other stat field rescues the comparison: ext4 immediately reuses the freed inode number, and a same-length rewrite preserves the size. The watcher concludes "unchanged" and the revision is silently and permanently lost. The rapid rewrite loop from #945 (bradcarman/ReviseTest.jl distilled: `rm` + rewrite + immediate `revise()`) hit this about once per 500–700 iterations; Windows' ~15.6 ms tick makes it likelier there.

The filesystem events themselves are the reliable signal, and `watch_folder` already reports the name of the changed entry — `wait_changed_dir` previously discarded it. Now the names are collected and any tracked file named in an event is queued regardless of the timestamp comparison. A spurious queue is cheap (`revise` parses and diffs ASTs, so an unchanged file is a no-op); a false negative is unrecoverable.

The timestamp sweep is retained for files the events did not name, and everything falls back to it when the names are unknown: polling mode, a torn-down monitor, or an event arriving without a name. Names only add queueing, never suppress a check, so a platform whose event names didn't match tracked entries would degrade to exactly the old behavior.

The per-file decision moves into `scan_changed_files`, unit-tested with a fabricated stored-ctime collision (timestamp tricks can't be staged deterministically through the filesystem). Empirically: 12×300-iteration runs of the rewrite loop (3,588 cycles) show zero losses, where master averaged ~5.

Stacked on #1074 (shared watcher-code edits); will rebase onto master once that merges, so the diff to review here is just the head commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)