### PR TITLE
Fix minor issues found by JETLS

### DIFF
--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -33,14 +33,14 @@ module Revise
 # This somewhat unusual structure is in place to support
 # the VS Code extension integration.
 
-using OrderedCollections, CodeTracking, JuliaInterpreter, LoweredCodeUtils
+using CodeTracking, JuliaInterpreter, LoweredCodeUtils, OrderedCollections
 using Preferences: Preferences
 
-using CodeTracking: PkgFiles, basedir, srcfiles, basepath, MethodInfoKey
-using JuliaInterpreter: Compiled, Frame, Interpreter, LineTypes, RecursiveInterpreter
-using JuliaInterpreter: codelocs, get_return, is_doc_expr, isassign, is_quotenode_egal,
-                        linetable, lookup, moduleof, pc_expr, step_expr!
-using LoweredCodeUtils: next_or_nothing!, callee_matches
+using CodeTracking: MethodInfoKey, PkgFiles, basedir, basepath, srcfiles
+using JuliaInterpreter: Compiled, Frame, Interpreter, LineTypes
+using JuliaInterpreter: codelocs, get_return, is_doc_expr, is_quotenode_egal, isassign,
+    linetable, lookup, moduleof, pc_expr, step_expr!
+using LoweredCodeUtils: callee_matches, next_or_nothing!
 
 include("packagedef.jl")
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -171,12 +171,12 @@ function entr(f::Function, files, modules=nothing; all=false, postpone=false, pa
     stopped = Ref(false)
     function run_debounce()
         while true
-            local remaining
-            @lock lk begin
-                remaining = deadline[] - time()
+            remaining = @lock lk begin
+                local remaining = deadline[] - time()
                 # Decide to exit and clear `dtask` atomically, so a change
                 # arriving now either extends this task or spawns a fresh one.
                 remaining <= 0 && (dtask[] = nothing)
+                remaining
             end
             remaining <= 0 && break
             sleep(remaining)

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,5 +1,5 @@
 using Base.CoreLogging
-using Base.CoreLogging: Info, Debug
+using Base.CoreLogging: Debug, Info
 
 struct LogRecord
     level

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -348,7 +348,6 @@ function _methods_by_execution!(
                     pc, pc3 = ret
                     # Get the line number from the body
                     stmt3 = pc_expr(frame, pc3)::Expr
-                    lnn = nothing
                     sigcode = lookup(interp, frame, stmt3.args[2])::Core.SimpleVector
                     lnn = sigcode[end]
                     if !isa(lnn, LineNumberNode)

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -477,9 +477,8 @@ function watch_package(id::PkgId)
     # we may have switched environments, so make sure we're watching the right manifest
     active_project_watcher()
 
-    local pkgdata   # declared here so it outlives the `try` scope that `@lock` introduces
-    @lock revise_lock begin
-        pkgdata = get(pkgdatas, id, nothing)
+    return @lock revise_lock begin
+        local pkgdata = get(pkgdatas, id, nothing)
         pkgdata !== nothing && return pkgdata
         modsym = Symbol(id.name)
         if modsym ∈ dont_watch_pkgs
@@ -494,8 +493,8 @@ function watch_package(id::PkgId)
             init_watching(pkgdata, srcfiles(pkgdata))
         end
         pkgdatas[id] = pkgdata
+        pkgdata
     end
-    return pkgdata
 end
 
 function has_writable_paths(pkgdata::PkgData)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -23,7 +23,7 @@ function track(mod::Module; modified_files=revision_queue, revise_throw::Bool=!i
     return ret
 end
 
-pkgidid_for_mod(mod) = id = Base.moduleroot(mod) == Core.Compiler ? PkgId(mod, "Core.Compiler") : PkgId(mod)
+pkgidid_for_mod(mod) = Base.moduleroot(mod) == Core.Compiler ? PkgId(mod, "Core.Compiler") : PkgId(mod)
 
 const vstring = "v$(VERSION.major).$(VERSION.minor)"
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,7 +24,7 @@ end
 function unique_dirs(iter)
     udirs = Set{String}()
     for file in iter
-        dir, basename = splitdir(file)
+        dir, _ = splitdir(file)
         push!(udirs, dir)
     end
     return udirs
@@ -35,7 +35,7 @@ function abspath_no_normalize(a)
         cwd = pwd()
         a_drive, a_nodrive = splitdrive(a)
         if a_drive != "" && lowercase(splitdrive(cwd)[1]) != lowercase(a_drive)
-            cwd = a_drive * path_separator
+            cwd = a_drive * Base.Filesystem.path_separator
             a = joinpath(cwd, a_nodrive)
         else
             a = joinpath(cwd, a)


### PR DESCRIPTION
- Use the correct `Base.Filesystem.path_separator` (was undefined)
- Drop unused/redundant variable assignments
- Return the `@lock` block result directly instead of via outer `local`
- Sort `using` imports alphabetically