### PR TITLE
Detect revised types nested in Union signatures

### DIFF
--- a/src/visit.jl
+++ b/src/visit.jl
@@ -151,6 +151,8 @@ function is_with_oldtypename(@nospecialize(typlike), oldtypename::Core.TypeName)
         return is_with_oldtypename(typeeq_parameter(typlike), oldtypename)
     elseif typlike isa UnionAll
         return is_with_oldtypename(typlike.body, oldtypename)
+    elseif typlike isa Union
+        return is_with_oldtypename(typlike.a, oldtypename) || is_with_oldtypename(typlike.b, oldtypename)
     elseif typlike isa TypeVar
         return is_with_oldtypename(typlike.lb, oldtypename) || is_with_oldtypename(typlike.ub, oldtypename)
     end

--- a/test/test_visit.jl
+++ b/test/test_visit.jl
@@ -106,4 +106,23 @@ let oldtype = TestVisitAbs4
     end
 end
 
+struct TestVisitInner5; x::Int; end
+struct TestVisitOther5; end
+struct TestVisit5; x::Union{TestVisitInner5, TestVisitOther5}; end
+func_test_visit_union5(::Union{TestVisitInner5, TestVisitOther5}) = nothing
+func_test_visit5(::TestVisit5) = nothing
+let oldtype = TestVisitInner5
+    reeval_list = record_invalidations_for_type_deletion(oldtype)
+    @test TestVisit5 in reeval_list
+    for m in methods(TestVisit5)
+        @test m in reeval_list
+    end
+    let m = only(methods(func_test_visit_union5, (TestVisitInner5,)))
+        @test m in reeval_list
+    end
+    let m = only(methods(func_test_visit5, (TestVisit5,)))
+        @test m in reeval_list
+    end
+end
+
 end # test_visit


### PR DESCRIPTION
`is_with_oldtypename` recurses through a method signature or a struct field type to decide whether it references a revised type, so the dependent gets re-evaluated against the new type. It descended into DataType parameters, UnionAll bodies, TypeVar bounds, and TypeEq, but not Union. A signature such as `f(::Union{Foo,Bar})`, or a field of type `Union{Foo,Bar}`, was therefore missed when Foo was revised: the method retained its stale, world-pinned Foo and dispatch on the new Foo failed.

Recurse into the Union components to close the gap.

Fixes #932