### PR TITLE
Return last evaluated expression from includet

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -107,8 +107,9 @@ Revise.get_def
 ### Parsing source code
 
 ```@docs
-Revise.parse_source
-Revise.parse_source!
+Revise.parse_and_maybe_eval_source
+Revise.parse_and_maybe_eval_source!
+Revise.ParseResult
 ```
 
 ### Lowered source code

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1045,8 +1045,8 @@ function parse_for_revision(pkgdata::PkgData, file::AbstractString)
     end
     topmod = first(keys(mod_exs_infos_old))
     fileok = file_exists(String(filep)::String)
-    mod_exs_infos_new = fileok ? parse_source(filep, topmod) : ModuleExprsInfos(topmod)
-    return mod_exs_infos_new, mod_exs_infos_old, fileok
+    pr = fileok ? parse_and_maybe_eval_source(filep, topmod) : ParseResult(ModuleExprsInfos(topmod), true)
+    return pr, mod_exs_infos_old, fileok
 end
 
 # Apply deletions for `(pkgdata, file)` from the results of `parse_for_revision`.
@@ -1061,7 +1061,7 @@ function delete_for_revision(
         reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt,
         predictions::TypePredictions,
     )
-    if mod_exs_infos_new !== nothing && mod_exs_infos_new !== DoNotParse()
+    if mod_exs_infos_new !== nothing
         delete_missing!(mod_exs_infos_old, mod_exs_infos_new::ModuleExprsInfos, reeval_list, handled_types, world, predictions)
     end
     if !fileok && any(!isempty, values(mod_exs_infos_old))
@@ -1085,7 +1085,8 @@ function handle_deletions(
         reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt,
         predictions::TypePredictions = TypePredictions(),
     )
-    mod_exs_infos_new, mod_exs_infos_old, fileok = parse_for_revision(pkgdata, file)
+    pr, mod_exs_infos_old, fileok = parse_for_revision(pkgdata, file)
+    mod_exs_infos_new = (pr.success && !pr.donotparse) ? pr.modexinfos : nothing
     delete_for_revision(pkgdata, file, mod_exs_infos_new, mod_exs_infos_old, fileok,
                         reeval_list, handled_types, world, predictions)
     return mod_exs_infos_new, mod_exs_infos_old
@@ -1423,8 +1424,9 @@ function revise(; throw::Bool=false)
         deferred_missing = Tuple{PkgData,String}[]
         for (pkgdata, file) in queue
             try
-                mod_exs_infos_new, mod_exs_infos_old, fileok = parse_for_revision(pkgdata, file)
-                mod_exs_infos_new === DoNotParse() && continue
+                pr, mod_exs_infos_old, fileok = parse_for_revision(pkgdata, file)
+                pr.donotparse && continue
+                mod_exs_infos_new = pr.success ? pr.modexinfos : nothing
                 if fileok
                     delete!(missing_file_times, (pkgdata, file))
                 else
@@ -1660,10 +1662,11 @@ function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
         file = abspath_no_normalize(file)
     end
     # Set up tracking
-    mod_exs_infos = parse_source(file, mod; mode)
-    if mod_exs_infos !== nothing
+    pr = parse_and_maybe_eval_source(file, mod; mode)
+    if pr.success
+        mod_exs_infos = pr.modexinfos
         if mode === :includet
-            mode = :sigs   # we already handled evaluation in `parse_source`
+            mode = :sigs   # we already handled evaluation in `parse_and_maybe_eval_source`
         end
         invokelatest(instantiate_sigs!, mod_exs_infos; mode, kwargs...)
         if !haspkgdata(id)
@@ -1683,7 +1686,8 @@ function track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
             pkgdatas[id] = pkgdata
         end
     end
-    return nothing
+    # issue #783: in `:includet` mode, return the value of the last evaluated expression
+    return isdefined(pr, :ret) ? pr.ret : nothing
 end
 
 function track(file::AbstractString; kwargs...)
@@ -1698,6 +1702,8 @@ Load `filename` and track future changes. `includet` is intended for quick "user
 established projects are encouraged to put the code in one or more packages loaded with `using`
 or `import` instead of using `includet`. See https://timholy.github.io/Revise.jl/stable/cookbook/
 for tips about setting up the package workflow.
+
+Like `include`, `includet` returns the value of the last evaluated expression in `filename`.
 
 By default, `includet` only tracks modifications to *methods*, not *data*. See the extended help for details.
 Note that this differs from packages, which evaluate all changes by default.
@@ -1761,8 +1767,9 @@ function includet(mod::Module, file::AbstractString)
     end
     tls = task_local_storage()
     tls[:SOURCE_PATH] = file
+    result = nothing
     try
-        track(mod, file; mode=:includet, skip_include=true)
+        result = track(mod, file; mode=:includet, skip_include=true)
         if prev === nothing
             delete!(tls, :SOURCE_PATH)
         else
@@ -1782,7 +1789,7 @@ function includet(mod::Module, file::AbstractString)
             rethrow()
         end
     end
-    return nothing
+    return result
 end
 includet(file::AbstractString) = includet(Main, file)
 
@@ -1948,7 +1955,7 @@ function add_definitions_from_repl(filename::String)
     id = PkgId(nothing, "@REPL")
     pkgdata = @lock revise_lock pkgdatas[id]
     mod_exs_infos = ModuleExprsInfos(Main::Module)
-    parse_source!(mod_exs_infos, src, filename, Main::Module)
+    parse_and_maybe_eval_source!(mod_exs_infos, src, filename, Main::Module)
     instantiate_sigs!(mod_exs_infos)
     fi = FileInfo(mod_exs_infos)
     push!(pkgdata, filename=>fi)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,37 +1,60 @@
-struct DoNotParse end
-
 """
-    mexs = parse_source(filename::AbstractString, mod::Module)
+    ParseResult(modexinfos, success, donotparse=false, [ret])
 
-Parse the source `filename`, returning a [`ModuleExprsInfos`](@ref) `mexs`.
-`mod` is the "parent" module for the file (i.e., the one that `include`d the file);
-if `filename` defines more module(s) then these will all have separate entries in `mexs`.
+The outcome of [`parse_and_maybe_eval_source`](@ref):
 
-If parsing `filename` fails, `nothing` is returned.
+- `modexinfos::ModuleExprsInfos`: the per-module expression map. The `!` form adds to it in place.
+- `success::Bool`: `false` if parsing produced no usable expressions, e.g. a missing file or a
+  source consisting only of a top-level literal.
+- `donotparse::Bool`: `true` if the source begins with `# REVISE: DO NOT PARSE` and was therefore
+  left unparsed.
+- `ret`: the value of the last evaluated expression, set only in `:includet` mode (see [`includet`](@ref)).
+  Left undefined (`isdefined(pr, :ret) === false`) when nothing was evaluated.
 """
-parse_source(filename::AbstractString, mod::Module; kwargs...) =
-    parse_source!(ModuleExprsInfos(mod), filename, mod; kwargs...)
-
-"""
-    parse_source!(mexs::ModuleExprsInfos, filename, mod::Module)
-
-Top-level parsing of `filename` as included into module
-`mod`. Successfully-parsed expressions will be added to `mexs`. Returns
-`mexs` if parsing finished successfully, otherwise `nothing` is returned.
-
-See also [`Revise.parse_source`](@ref).
-"""
-function parse_source!(mod_exprs_sigs::ModuleExprsInfos, filename::AbstractString, mod::Module; kwargs...)
-    if !isfile(filename)
-        @warn "$filename is not a file, omitting from revision tracking"
-        return nothing
-    end
-    return parse_source!(mod_exprs_sigs, read(filename, String), filename, mod; kwargs...)
+struct ParseResult
+    modexinfos::ModuleExprsInfos
+    success::Bool
+    donotparse::Bool
+    ret
+    ParseResult(modexinfos::ModuleExprsInfos, success::Bool, donotparse::Bool=false) =
+        new(modexinfos, success, donotparse)
+    ParseResult(modexinfos::ModuleExprsInfos, success::Bool, donotparse::Bool, @nospecialize(ret)) =
+        new(modexinfos, success, donotparse, ret)
 end
 
-function parse_source!(mod_exprs_sigs::ModuleExprsInfos, src::AbstractString, filename::AbstractString, mod::Module; kwargs...)
+"""
+    pr = parse_and_maybe_eval_source(filename::AbstractString, mod::Module; mode=:sigs)
+
+Parse the source `filename`, returning a [`ParseResult`](@ref) `pr`.
+`mod` is the "parent" module for the file (i.e., the one that `include`d the file);
+if `filename` defines more module(s) then these will all have separate entries in `pr.modexinfos`.
+
+In `:includet` mode the expressions are also evaluated as they are parsed, and `pr.ret` holds the
+value of the last one.
+"""
+parse_and_maybe_eval_source(filename::AbstractString, mod::Module; mode::Symbol=:sigs) =
+    parse_and_maybe_eval_source!(ModuleExprsInfos(mod), filename, mod; mode)
+
+"""
+    pr = parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, filename, mod::Module; mode=:sigs)
+
+Top-level parsing of `filename` as included into module `mod`. Successfully-parsed expressions are
+added to `modexinfos`, which is also returned as `pr.modexinfos`. In `:includet` mode the expressions
+are evaluated as they are parsed.
+
+See also [`Revise.parse_and_maybe_eval_source`](@ref).
+"""
+function parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, filename::AbstractString, mod::Module; mode::Symbol=:sigs)
+    if !isfile(filename)
+        @warn "$filename is not a file, omitting from revision tracking"
+        return ParseResult(modexinfos, false)
+    end
+    return parse_and_maybe_eval_source!(modexinfos, read(filename, String), filename, mod; mode)
+end
+
+function parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, src::AbstractString, filename::AbstractString, mod::Module; mode::Symbol=:sigs)
     if startswith(src, "# REVISE: DO NOT PARSE")
-        return DoNotParse()
+        return ParseResult(modexinfos, true, true)
     end
     if VERSION ≥ v"1.14-DEV.1836"
         ex = Base.parse_input_line(src; filename, mod)
@@ -39,11 +62,14 @@ function parse_source!(mod_exprs_sigs::ModuleExprsInfos, src::AbstractString, fi
         ex = Base.parse_input_line(src; filename)
     end
     if ex === nothing
-        return mod_exprs_sigs
+        return ParseResult(modexinfos, true)
     elseif ex isa Expr
-        return process_ex!(mod_exprs_sigs, ex, filename, mod; kwargs...)
+        # issue #783: in `:includet` mode `process_ex!` returns the value of the last evaluated
+        # expression, which `includet` returns like `include`.
+        ret = process_ex!(modexinfos, ex, filename, mod; mode)
+        return mode === :includet ? ParseResult(modexinfos, true, false, ret) : ParseResult(modexinfos, true)
     else # literals
-        return nothing
+        return ParseResult(modexinfos, false)
     end
 end
 
@@ -51,10 +77,11 @@ function process_ex!(mod_exprs_sigs::ModuleExprsInfos, ex::Expr, filename::Abstr
     if isexpr(ex, :error) || isexpr(ex, :incomplete)
         return eval(ex)
     end
+    lastval = nothing
     for (mod, ex) in ExprSplitter(mod, ex)
         if mode === :includet
             try
-                Core.eval(mod, ex)
+                lastval = Core.eval(mod, ex)
             catch err
                 bt = trim_toplevel!(catch_backtrace())
                 lnn = firstline(ex)
@@ -76,5 +103,7 @@ function process_ex!(mod_exprs_sigs::ModuleExprsInfos, ex::Expr, filename::Abstr
             pushex!(exprs_sigs, ex)
         end
     end
-    return mod_exprs_sigs
+    # issue #783: the value of the last evaluated expression, so `includet` can
+    # return it like `include`. Only `:includet` mode evaluates; otherwise `nothing`.
+    return lastval
 end

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -15,7 +15,7 @@
 #     `loading.jl`), so module-of-evaluation can't identify it. Here we hope
 #     that the top-level filename follows convention and matches the module.
 #
-# We pass `Base.__toplevel__` through to `parse_source` unchanged. `ExprSplitter`
+# We pass `Base.__toplevel__` through to `parse_and_maybe_eval_source` unchanged. `ExprSplitter`
 # has a dedicated `loaded_modules` fallback for that case which resolves
 # `module PkgName ... end` to the real loaded module even when `PkgName` is not
 # a direct dep of the active project. Rewriting to `Main` here would skip that
@@ -28,10 +28,10 @@ function queue_includes!(pkgdata::PkgData, id::PkgId)
             mod, fname = included_files[i]
             modname = String(Symbol(mod))
             if startswith(modname, modstring) || endswith(fname, modstring*".jl")
-                mod_exs_infos = parse_source(fname, mod)
-                if mod_exs_infos !== nothing
+                pr = parse_and_maybe_eval_source(fname, mod)
+                if pr.success
                     fname = relpath(fname, pkgdata)
-                    push!(pkgdata, fname=>FileInfo(mod_exs_infos))
+                    push!(pkgdata, fname=>FileInfo(pr.modexinfos))
                 end
                 push!(delids, i)
             end
@@ -103,11 +103,11 @@ function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString)
         filep = joinpath(basedir(pkgdata), file)
         filec = get(cache_file_key, filep, filep)
         topmod = first(keys(fi.mod_exs_infos))
-        ret = parse_source!(fi.mod_exs_infos, src, filec, topmod)
-        if ret === nothing
+        pr = parse_and_maybe_eval_source!(fi.mod_exs_infos, src, filec, topmod)
+        if !pr.success
             @error "failed to parse cache file source text for $file"
         end
-        if ret !== DoNotParse()
+        if !pr.donotparse
             add_modexs!(fi, fi.cacheexprs)
             empty!(fi.cacheexprs)
         end
@@ -207,7 +207,7 @@ function maybe_add_includes_to_pkgdata!(pkgdata::PkgData, file::AbstractString, 
             # Parse the source of the new file
             fullfile = joinpath(basedir(pkgdata), incrp)
             if isfile(fullfile)
-                parse_source!(fi.mod_exs_infos, fullfile, mod)
+                parse_and_maybe_eval_source!(fi.mod_exs_infos, fullfile, mod)
                 if eval_now
                     # Use runtime dispatch to reduce latency
                     Base.invokelatest(instantiate_sigs!, fi.mod_exs_infos; mode=:eval)
@@ -631,7 +631,7 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
                 filep = joinpath(basedir(pkgdata), file)
                 src = read(filep, String)
                 topmod = first(keys(fi.mod_exs_infos))
-                if parse_source!(fi.mod_exs_infos, src, filep, topmod) === nothing
+                if !parse_and_maybe_eval_source!(fi.mod_exs_infos, src, filep, topmod).success
                     @error "failed to parse source text for $filep"
                 end
                 add_modexs!(fi, fi.cacheexprs)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -222,7 +222,7 @@ function track_subdir_from_git!(pkgdata::PkgData, subdir::AbstractString; commit
                 push!(modified_files, (pkgdata, rpath))
             end
             fi = FileInfo(fmod)
-            if parse_source!(fi.mod_exs_infos, src, file, fmod) === nothing
+            if !parse_and_maybe_eval_source!(fi.mod_exs_infos, src, file, fmod).success
                 @warn "failed to parse Git source text for $file"
             else
                 instantiate_sigs!(fi.mod_exs_infos)

--- a/src/types.jl
+++ b/src/types.jl
@@ -241,7 +241,7 @@ or that the method table/signature pairs have not yet been cached.
 
 The first `mod` key is guaranteed to be the module into which this file was `include`d.
 
-To create a `ModuleExprsInfos` from a source file, see [`Revise.parse_source`](@ref).
+To create a `ModuleExprsInfos` from a source file, see [`Revise.parse_and_maybe_eval_source`](@ref).
 """
 const ModuleExprsInfos = OrderedDict{Module,ExprsInfos}
 

--- a/test/backedges.jl
+++ b/test/backedges.jl
@@ -40,7 +40,7 @@ do_test("Backedges") && @testset "Backedges" begin
         return planetdiameters[name]
     end
     """
-    mexs = Revise.parse_source!(Revise.ModuleExprsInfos(BackEdgesTest), src, "backedges_test.jl", BackEdgesTest)
+    mexs = parse_source!(Revise.ModuleExprsInfos(BackEdgesTest), src, "backedges_test.jl", BackEdgesTest)
     Revise.instantiate_sigs!(mexs)
     @test isempty(methods(BackEdgesTest.getdiameter))
     @test !isdefined(BackEdgesTest, :planetdiameters)

--- a/test/common.jl
+++ b/test/common.jl
@@ -82,6 +82,20 @@ function collectexprs(rex::Revise.RelocatableExpr)
     items
 end
 
+# Test helpers, *not* Revise functions: each wraps `Revise.parse_and_maybe_eval_source[!]`, asserts
+# the parse succeeded, and returns the resulting `ModuleExprsInfos`. Sharing one terse name keeps the
+# many call sites readable and localizes the `ParseResult` unwrapping to this one spot.
+function parse_source(file::AbstractString, mod::Module; kwargs...)
+    pr = Revise.parse_and_maybe_eval_source(file, mod; kwargs...)
+    pr.success || error("parsing $file produced no usable expressions")
+    return pr.modexinfos
+end
+function parse_source!(mexs::Revise.ModuleExprsInfos, args...; kwargs...)
+    pr = Revise.parse_and_maybe_eval_source!(mexs, args...; kwargs...)
+    pr.success || error("parsing produced no usable expressions")
+    return pr.modexinfos
+end
+
 function get_docstring(obj)
     while !isa(obj, AbstractString)
         fn = fieldnames(typeof(obj))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,7 +147,7 @@ end
     do_test("Parse errors") && @testset "Parse errors" begin
         md = Revise.ModuleExprsInfos(Main)
         errtype = Base.VERSION < v"1.10" ? LoadError : Base.Meta.ParseError
-        @test_throws errtype Revise.parse_source!(md, """
+        @test_throws errtype parse_source!(md, """
             begin # this block should parse correctly, cf. issue #109
 
             end
@@ -192,7 +192,7 @@ end
         scriptfile = joinpath(jidir, "test", "toplevel_script.jl")
         modex = :(module Toplevel include($scriptfile) end)
         mod = eval(modex)
-        mexs = Revise.parse_source(scriptfile, mod)
+        mexs = parse_source(scriptfile, mod)
         Revise.instantiate_sigs!(mexs)
         nms = names(mod; all=true)
         modeval, modinclude = getfield(mod, :eval), getfield(mod, :include)
@@ -262,12 +262,12 @@ end
         delmeth = first(methods(ReviseTest.Internal.mult4))
         mmult3 = @which ReviseTest.Internal.mult3(2)
 
-        mod_exs_infos_old = Revise.parse_source(tmpfile, Main)
+        mod_exs_infos_old = parse_source(tmpfile, Main)
         Revise.instantiate_sigs!(mod_exs_infos_old)
         mcube = @which ReviseTest.cube(2)
 
         cp(fl2, tmpfile; force=true)
-        mod_exs_infos_new = Revise.parse_source(tmpfile, Main)
+        mod_exs_infos_new = parse_source(tmpfile, Main)
         mod_exs_infos_new = Revise.eval_revised(mod_exs_infos_new, mod_exs_infos_old)
         @latestworld
         @test ReviseTest.cube(2) == 8
@@ -361,7 +361,7 @@ end
         # because both of these are revised definitions.
         cp(fl3, tmpfile; force=true)
         mod_exs_infos_old = mod_exs_infos_new
-        mod_exs_infos_new = Revise.parse_source(tmpfile, Main)
+        mod_exs_infos_new = parse_source(tmpfile, Main)
         mod_exs_infos_new = Revise.eval_revised(mod_exs_infos_new, mod_exs_infos_old)
         @latestworld
         try
@@ -421,7 +421,7 @@ end
         mod = private_module()
         file = joinpath(@__DIR__, "revisetest.jl")
         Base.include(mod, file)
-        mexs = Revise.parse_source(file, mod)
+        mexs = parse_source(file, mod)
         Revise.instantiate_sigs!(mexs)
         print(IOContext(io, :compact=>true), mexs)
         str = String(take!(io))
@@ -1370,7 +1370,7 @@ end
 
     do_test("doc expr signature") && @testset "Docstring attached to signatures" begin
         md = Revise.ModuleExprsInfos(Main)
-        Revise.parse_source!(md, """
+        parse_source!(md, """
             module DocstringSigsOnly
             function f end
             "basecase" f(x)
@@ -1387,8 +1387,8 @@ end
 
     do_test("Undef in docstrings") && @testset "Undef in docstrings" begin
         fn = Base.find_source_file("abstractset.jl")   # has lots of examples of """str""" func1, func2
-        mod_exs_infos_old = Revise.parse_source(fn, Base)
-        mod_exs_infos_new = Revise.parse_source(fn, Base)
+        mod_exs_infos_old = parse_source(fn, Base)
+        mod_exs_infos_new = parse_source(fn, Base)
         odict = mod_exs_infos_old[Base]
         ndict = mod_exs_infos_new[Base]
         for (k, v) in odict
@@ -3794,9 +3794,11 @@ end
         srcfile = joinpath(tempdir(), randtmp()*".jl")
         write(srcfile, "revise_f(x) = 1")
         sleep(mtimedelay)
-        includet(srcfile)
+        # issue #783: `includet` returns the value of the last evaluated expression
+        ret = includet(srcfile)
         sleep(mtimedelay)
         @latestworld
+        @test ret === revise_f
         @test revise_f(10) == 1
         @test length(signatures_at(srcfile, 1)) == 1
         write(srcfile, "revise_f(x) = 2")
@@ -3829,7 +3831,8 @@ end
         srcfile = joinpath(tempdir(), randtmp()*".jl")
         write(srcfile, "\n")
         sleep(mtimedelay)
-        includet(srcfile)
+        # issue #783: an empty file has no last expression, so `includet` returns `nothing`
+        @test includet(srcfile) === nothing
         sleep(mtimedelay)
         @test basename(srcfile) ∈ Revise.watched_files[dirname(srcfile)]
         push!(to_remove, srcfile)

--- a/test/sigtest.jl
+++ b/test/sigtest.jl
@@ -99,7 +99,7 @@ try # Suppress world age increments, since the instantiation messes with base
         Base.VERSION < v"1.7" && Sys.iswindows() && endswith(file, "RNGs.jl") && continue  # invalid redefinition of constant RandomDevice
         file = Revise.fixpath(file)
         push!(basefiles, reljpath(file))
-        mexs = Revise.parse_source(file, mod)
+        mexs = Revise.parse_and_maybe_eval_source(file, mod).modexinfos
         Revise.instantiate_sigs!(mexs; always_rethrow=true)
     end
     failed, extras, nmethods = signature_diffs(Base, CodeTracking.method_info; filepredicate = fn->filepredicate(fn, basefiles))


### PR DESCRIPTION
Like `include`, `includet` now returns the value of the last evaluated expression in the file (`nothing` when nothing was evaluated).

Capturing that value motivated a cleanup of the parsing entry point, which had grown from a pure parser into a parse-and-evaluate step:

- Rename `parse_source`/`parse_source!` to `parse_and_maybe_eval_source`/`parse_and_maybe_eval_source!`.
- Return a `ParseResult` struct (`modexinfos`, `success`, `donotparse`, and an optional `ret` holding the last `:includet`-evaluated value) in place of the `ModuleExprsInfos`-or-`nothing`-or-`DoNotParse()` sentinel union. `ret` is left undefined when nothing was evaluated.
- Delete the `DoNotParse` marker type; the `# REVISE: DO NOT PARSE` outcome is now `ParseResult.donotparse`.

`process_ex!` returns the value of the last evaluated expression rather than the dict it mutates, so the result reaches `includet` through `ParseResult.ret` without an out-parameter.

Tests use a local `parse_source`/`parse_source!` helper that unwraps `ParseResult` to the `ModuleExprsInfos` after asserting success.

Fixes #783