### PR TITLE
Warn when yry() times out expecting a revision

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -61,15 +61,26 @@ end
 #     path re-watches a single file after each revision and, unlike the
 #     buffered per-directory watcher, has neither an event queue nor a content
 #     hash to recover a write that lands while it is between watches.
-function yry()
-    timedwait(() -> !isempty(Revise.revision_queue), event_timeout; pollint=0.02)
+#
+# `expect_revision=true` (the default) means a write should already have been
+# queued: hitting `event_timeout` then signals a dropped/late filesystem event,
+# the usual cause of "revision not applied" CI flakes, so we warn. Tests that
+# legitimately expect no revision pass `expect_revision=false` to take the
+# timeout silently.
+function yry(; expect_revision::Bool=true)
+    status = timedwait(() -> !isempty(Revise.revision_queue), event_timeout; pollint=0.02)
+    if expect_revision && status === :timed_out
+        @warn "yry: timed out after $(event_timeout)s waiting for revision_queue; a filesystem event was likely dropped or delayed"
+    end
     sleep(0.02)
     revise()
     Revise.watching_files[] && sleep(mtimedelay)
 end
-macro yry()
+macro yry(args...)
+    # Forward `@yry(expect_revision=false)` as a keyword argument, not a positional one.
+    kws = [a isa Expr && a.head === :(=) ? Expr(:kw, a.args[1], a.args[2]) : a for a in args]
     esc(quote
-        yry()
+        yry($(kws...))
         @latestworld
     end)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1913,7 +1913,7 @@ end
             f(x) = 2
             end
             """)
-        @yry()
+        @yry(expect_revision=false)   # tmpfile is not the tracked path; no revision yet
         @test Timing.f(nothing) == 1
         mv(tmpfile, pathof(Timing), force=true)
         @yry()
@@ -2546,7 +2546,7 @@ end
 
         # test errors are not re-reported
         logs, _ = Test.collect_test_logs() do
-            yry()
+            yry(expect_revision=false)   # nothing new to revise
         end
         @test isempty(logs)
 
@@ -4048,10 +4048,10 @@ end
         user_track_includes = Revise.tracking_Main_includes[]
         Revise.tracking_Main_includes[] = false
         include(srcfile)
-        @yry()
+        @yry(expect_revision=false)   # user scripts are not tracked by default
         @test revise_g() == 1
         write(srcfile, "revise_g() = 2")
-        @yry()
+        @yry(expect_revision=false)   # still untracked, so the edit is not picked up
         @test revise_g() == 1
         # Turn on tracking of user scripts
         empty!(Revise.included_files)  # don't track files already loaded (like this one)
@@ -4062,7 +4062,7 @@ end
             write(srcfile, "revise_g() = 1")
             sleep(mtimedelay)
             include(srcfile)
-            @yry()
+            @yry(expect_revision=false)   # include just ran; no edit to revise yet
             @test revise_g() == 1
             write(srcfile, "revise_g() = 2")
             @yry()
@@ -4071,9 +4071,9 @@ end
             # issue #257
             logs, _ = Test.collect_test_logs() do  # just to prevent noisy warning
                 try include("nonexistent1.jl") catch end
-                yry()
+                yry(expect_revision=false)   # include of a missing file revises nothing
                 try include("nonexistent2.jl") catch end
-                yry()
+                yry(expect_revision=false)
             end
         finally
             Revise.tracking_Main_includes[] = user_track_includes  # restore old behavior


### PR DESCRIPTION
`yry()` waits for the file watcher to queue a pending edit, falling through after `event_timeout`. A dropped or delayed filesystem event hits that timeout and then revises nothing, so the staleness only surfaces later as a confusing "revision not applied" assertion failure (the typical macOS FSEvents CI flake).

Add `expect_revision::Bool=true`: when a revision is expected, a timeout now emits a warning naming the likely dropped event, flagging the flake at its source. Tests that legitimately expect no revision (writes to an untracked path, re-revising with nothing new, including a missing file) pass `expect_revision=false` to take the timeout silently. `@yry` forwards the keyword.

This does not fix any reported bug, its purpose is only to help diagnose occasional remaining flaky tests.