### PR TITLE
Deflake the past-grace Missing-file grace test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5050,16 +5050,30 @@ do_test("Missing-file grace") && !Revise.watching_files[] && @testset "Missing-f
         @test isempty(Revise.revision_queue)
 
         # Past the grace period: methods are deleted (with a warning), but the
-        # file remains registered, so recreating it still restores the methods
+        # file remains registered, so recreating it still restores the methods.
+        # The grace clock starts only when a `revise()` first observes the
+        # absence, and that observation rides a filesystem event whose delivery
+        # time we don't control. Rather than sleep a fixed interval and assume one
+        # revise deletes, poll: keep revising until the deletion lands. This can't
+        # flake on a late clock start; a genuine failure to ever delete still
+        # surfaces as the `timedwait` timing out.
         Revise.missing_file_grace[] = 0.5
         rm(genfile)
-        @yry()      # notices the absence, starting the grace clock
-        @test MissingFileGrace.gen() == 2
-        sleep(1.0)
-        @test_logs (:warn, r"no longer exists, deleted all methods") match_mode=:any yry()
+        @yry()
+        @test MissingFileGrace.gen() == 2          # survives while within grace
+        logs = []
+        deleted = timedwait(20.0; pollint=0.1) do
+            logs, _ = Test.collect_test_logs() do
+                revise()
+            end
+            isempty(methods(MissingFileGrace.gen))
+        end
+        @test deleted === :ok                      # :timed_out ⇒ a genuine "never deleted" bug
         @latestworld
         @test isempty(Revise.revision_queue)
         @test_throws MethodError MissingFileGrace.gen()
+        # the deleting revise (the final poll iteration) is the one that warns
+        @test any(r -> occursin("no longer exists, deleted all methods", r.message), logs)
         write(genfile, "gen() = 3")
         @yry()
         @test MissingFileGrace.gen() == 3


### PR DESCRIPTION
The "past the grace period" check assumed the `@yry()` right after `rm` started the grace clock, then slept a fixed 1.0s and expected a single `yry()` to delete. But the grace clock starts only when a `revise()` first observes the absence, which rides a filesystem event whose delivery time is not controlled; when that observation arrived late the clock started late, the deletion was deferred again, and the test failed (~12.5% on WSL, and intermittently on macOS CI).

Replace the fixed sleep + single revise with a poll that keeps revising until the deletion lands (bounded by `timedwait`). This no longer depends on when the clock starts; a genuine failure to ever delete still fails fast via `:timed_out`. The within-grace block already covers that deletion is deferred while the grace has not elapsed.