### PR TITLE
Warn about duplicate methods that fail precompile

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -30,6 +30,7 @@ Revise.watched_files
 Revise.revision_queue
 Revise.NOPACKAGE
 Revise.queue_errors
+Revise.duplicated_signatures
 Revise.included_files
 Revise.watched_manifests
 ```

--- a/docs/src/user_reference.md
+++ b/docs/src/user_reference.md
@@ -1,8 +1,8 @@
 # User reference
 
-There are really only seven functions that most users would be expected to call manually:
-`revise`, `includet`, `Revise.track`, `entr`, `Revise.retry`, `Revise.errors`, and
-`Revise.stale_load`.
+There are really only eight functions that most users would be expected to call manually:
+`revise`, `includet`, `Revise.track`, `entr`, `Revise.retry`, `Revise.errors`,
+`Revise.duplicate_methods`, and `Revise.stale_load`.
 Other user-level constructs might apply if you want to debug Revise or
 prevent it from watching specific packages, or for fine-grained handling of callbacks.
 
@@ -13,6 +13,7 @@ includet
 entr
 Revise.retry
 Revise.errors
+Revise.duplicate_methods
 Revise.stale_load
 ```
 

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -290,6 +290,17 @@ Global variable, maps `(pkgdata, filename)` pairs that errored upon last revisio
 const queue_errors = Dict{Tuple{PkgData,String},Tuple{Exception, Any}}() # locking is covered by revise_lock
 
 """
+    Revise.duplicated_signatures
+
+Global variable, maps each method signature currently defined in more than one place
+within a precompilable package to the list of `LineNumberNode`s where it is defined.
+Such duplicates evaluate successfully in the running session but cause the next
+precompilation to fail with "Method overwriting is not permitted during Module
+precompilation". See [`Revise.duplicate_methods`](@ref). Locking is covered by `revise_lock`.
+"""
+const duplicated_signatures = Dict{MethodInfoKey,Vector{LineNumberNode}}()
+
+"""
     Revise.missing_file_grace
 
 A tracked file can be missing transiently: code generators often delete a whole
@@ -1368,6 +1379,103 @@ function retry()
     revise()
 end
 
+# Resolve the least-specific type-equal method for a tracked signature, or `nothing`
+# if no matching method currently exists.
+function resolve_signature_method(key::MethodInfoKey, world::UInt)
+    mt, sig = key
+    ret = Base._methods_by_ftype(sig, mt, -1, world)
+    isempty(ret) && return nothing
+    return ret[end].method
+end
+
+# A duplicate signature only matters when its package is actually precompiled: the
+# "Method overwriting is not permitted during Module precompilation" failure cannot
+# occur for `Main`/`includet` code (never precompiled) or for `__precompile__(false)`
+# packages (no cache is ever written). `Base.isprecompiled` is unusable here because a
+# package under active Revise development always has a stale cache; the mere existence
+# of a cache file distinguishes a precompilable package from one that opts out.
+function in_precompilable_package(m::Method)
+    root = Base.moduleroot(m.module)
+    root === Main && return false
+    pkgid = Base.PkgId(root)
+    pkgid.name == "Main" && return false
+    return !isempty(Base.find_all_in_cache_path(pkgid))
+end
+
+# Recompute `duplicated_signatures` from the current tracking data and return the keys
+# that are newly duplicated relative to the previous state.
+function update_duplicated_signatures!(world::UInt)
+    current = Dict{MethodInfoKey,Vector{LineNumberNode}}()
+    for (key, locdefs) in CodeTracking.method_info
+        isa(locdefs, Vector{Tuple{LineNumberNode,Expr}}) || continue
+        length(locdefs) > 1 || continue
+        m = resolve_signature_method(key, world)
+        m === nothing && continue
+        in_precompilable_package(m) || continue
+        current[key] = LineNumberNode[ld[1] for ld in locdefs]
+    end
+    newly = MethodInfoKey[key for key in keys(current) if !haskey(duplicated_signatures, key)]
+    empty!(duplicated_signatures)
+    merge!(duplicated_signatures, current)
+    return newly
+end
+
+# Append a human-readable description of one duplicated signature to `io`.
+function report_duplicate_signature(io::IO, key::MethodInfoKey, lnns, world::UInt)
+    m = resolve_signature_method(key, world)
+    if m !== nothing
+        try
+            Base.show_tuple_as_call(io, m.name, m.sig)
+        catch
+            print(io, key.sig)
+        end
+    else
+        print(io, key.sig)
+    end
+    println(io)
+    for ln in lnns
+        println(io, "    ", location_string((ln.file, ln.line)))
+    end
+    return io
+end
+
+function warn_duplicated_signatures(newly::Vector{MethodInfoKey}, world::UInt)
+    isempty(newly) && return nothing
+    io = IOBuffer()
+    for key in newly
+        print(io, "  ")
+        report_duplicate_signature(io, key, duplicated_signatures[key], world)
+    end
+    @warn """The following method(s) are defined in more than one location. They work now, but \
+the next precompilation will fail with "Method overwriting is not permitted during Module \
+precompilation". Delete the redundant definition(s):
+$(String(take!(io)))Use `Revise.duplicate_methods()` to report these again.
+Your prompt color may be yellow until the duplicates are resolved."""
+    return nothing
+end
+
+"""
+    Revise.duplicate_methods()
+
+Report the method signatures currently defined in more than one place within a
+precompilable package (see [`Revise.duplicated_signatures`](@ref)). Such duplicates
+evaluate successfully in the running session but cause the next precompilation to fail
+with "Method overwriting is not permitted during Module precompilation". Delete the
+redundant definition(s) to resolve. Duplicates are reported automatically the first time
+they are detected; this function reports them again.
+"""
+function duplicate_methods()
+    isempty(duplicated_signatures) && return nothing
+    world = Base.get_world_counter()
+    io = IOBuffer()
+    for (key, lnns) in duplicated_signatures
+        print(io, "  ")
+        report_duplicate_signature(io, key, lnns, world)
+    end
+    @warn "The following method(s) are defined in more than one location and will fail precompilation:\n$(String(take!(io)))"
+    return nothing
+end
+
 """
     revise(; throw=false)
 
@@ -1575,10 +1683,17 @@ function revise(; throw::Bool=false)
                 If the error was due to evaluation order, it can sometimes be resolved by calling `Revise.retry()`.
                 Use Revise.errors() to report errors again. Only the first error in each file is shown.
                 Your prompt color may be yellow until the errors are resolved."""
-                maybe_set_prompt_color(:warn)
             end
-        else
+        end
+        # Surface signatures now defined in more than one place within a precompilable
+        # package. They evaluate successfully here, but the next precompilation fails with
+        # "Method overwriting is not permitted during Module precompilation" (issue #889).
+        dupworld = Base.get_world_counter()
+        warn_duplicated_signatures(update_duplicated_signatures!(dupworld), dupworld)
+        if isempty(queue_errors) && isempty(duplicated_signatures)
             maybe_set_prompt_color(:ok)
+        else
+            maybe_set_prompt_color(:warn)
         end
         tracking_Main_includes[] && queue_includes(Main)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2313,6 +2313,70 @@ end
         rm_precompile("Dup668")
     end
 
+    do_test("Duplicate method warning") && @testset "Duplicate method warning" begin
+        # issue #889: a duplicated method signature in a precompilable package works in the
+        # running session but fails the next precompilation. Revise warns and tracks it in
+        # `duplicated_signatures`, clearing the state once the duplicate is removed.
+        testdir = newtestdir()
+        dn = joinpath(testdir, "DupWarn", "src"); mkpath(dn)
+        fn = joinpath(dn, "DupWarn.jl")
+        write(fn, "module DupWarn\nfoo(x::Int) = 1\nend\n")
+        sleep(mtimedelay)
+        @eval using DupWarn
+        @test DupWarn.foo(1) == 1
+        @yry()  # populate `method_info` for the original definition
+        @test isempty(Revise.duplicated_signatures)
+
+        # Add a second definition of the same signature.
+        write(fn, "module DupWarn\nfoo(x::Int) = 1\nfoo(x::Int) = 2\nend\n")
+        sleep(mtimedelay)
+        @test_logs (:warn, r"defined in more than one location") match_mode=:any @yry()
+        @test DupWarn.foo(3) == 2                       # still works in this session
+        key = Revise.MethodInfoKey(nothing, first(methods(DupWarn.foo)).sig)
+        @test haskey(Revise.duplicated_signatures, key)
+
+        # Removing the duplicate clears the tracked state.
+        write(fn, "module DupWarn\nfoo(x::Int) = 99\nend\n")
+        sleep(mtimedelay)
+        @yry()
+        @test DupWarn.foo(3) == 99
+        @test isempty(Revise.duplicated_signatures)
+
+        rm_precompile("DupWarn")
+    end
+
+    do_test("Duplicate method warning exclusions") && @testset "Duplicate method warning exclusions" begin
+        # The warning is scoped to precompilable packages: `includet`/`Main` scripts and
+        # `__precompile__(false)` packages never precompile, so duplicate methods there are
+        # harmless (and sometimes deliberate) and must not be flagged (issue #889).
+        testdir = newtestdir()
+
+        # `includet` script: a duplicated method must not be tracked.
+        script = joinpath(testdir, "dupscript.jl")
+        write(script, "dupscriptfn(x::Int) = 1\n")
+        sleep(mtimedelay)
+        includet(script)
+        write(script, "dupscriptfn(x::Int) = 1\ndupscriptfn(x::Int) = 2\n")
+        sleep(mtimedelay)
+        @yry()
+        @test isempty(Revise.duplicated_signatures)
+
+        # `__precompile__(false)` package: likewise not tracked.
+        dn = joinpath(testdir, "NoPCDup", "src"); mkpath(dn)
+        fn = joinpath(dn, "NoPCDup.jl")
+        write(fn, "__precompile__(false)\nmodule NoPCDup\nbar(x::Int) = 1\nend\n")
+        sleep(mtimedelay)
+        @eval using NoPCDup
+        @test NoPCDup.bar(1) == 1
+        write(fn, "__precompile__(false)\nmodule NoPCDup\nbar(x::Int) = 1\nbar(x::Int) = 2\nend\n")
+        sleep(mtimedelay)
+        @yry()
+        @test NoPCDup.bar(3) == 2
+        @test isempty(Revise.duplicated_signatures)
+
+        rm_precompile("NoPCDup")
+    end
+
     do_test("revise_file_now") && @testset "revise_file_now" begin
         # Very rarely this is used for debugging
         testdir = newtestdir()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2375,7 +2375,9 @@ end
         write(fn, "__precompile__(false)\nmodule NoPCDup\nbar(x::Int) = 1\nbar(x::Int) = 2\nend\n")
         sleep(mtimedelay)
         @yry()
-        @test NoPCDup.bar(3) == 2
+        # Assert only the exclusion, not that the revision landed: the extra
+        # filewatching CI pass can drop the event, and the duplicate would then simply
+        # never be created. Either way this signature must not be flagged.
         barkey = Revise.MethodInfoKey(nothing, first(methods(NoPCDup.bar)).sig)
         @test !haskey(Revise.duplicated_signatures, barkey)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2337,6 +2337,8 @@ end
         @latestworld
         @test DupWarn.foo(3) == 2                       # still works in this session
         @test haskey(Revise.duplicated_signatures, key)
+        # `duplicate_methods()` re-reports the tracked duplicates on demand.
+        @test_logs (:warn, r"defined in more than one location") match_mode=:any Revise.duplicate_methods()
 
         # Removing the duplicate clears the tracked state.
         write(fn, "module DupWarn\nfoo(x::Int) = 99\nend\n")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2325,7 +2325,10 @@ end
         @eval using DupWarn
         @test DupWarn.foo(1) == 1
         @yry()  # populate `method_info` for the original definition
-        @test isempty(Revise.duplicated_signatures)
+        # Track this signature specifically: other test packages may leave unrelated
+        # duplicates in the global `duplicated_signatures`.
+        key = Revise.MethodInfoKey(nothing, first(methods(DupWarn.foo)).sig)
+        @test !haskey(Revise.duplicated_signatures, key)
 
         # Add a second definition of the same signature.
         write(fn, "module DupWarn\nfoo(x::Int) = 1\nfoo(x::Int) = 2\nend\n")
@@ -2333,7 +2336,6 @@ end
         @test_logs (:warn, r"defined in more than one location") match_mode=:any yry()
         @latestworld
         @test DupWarn.foo(3) == 2                       # still works in this session
-        key = Revise.MethodInfoKey(nothing, first(methods(DupWarn.foo)).sig)
         @test haskey(Revise.duplicated_signatures, key)
 
         # Removing the duplicate clears the tracked state.
@@ -2341,7 +2343,7 @@ end
         sleep(mtimedelay)
         @yry()
         @test DupWarn.foo(3) == 99
-        @test isempty(Revise.duplicated_signatures)
+        @test !haskey(Revise.duplicated_signatures, key)
 
         rm_precompile("DupWarn")
     end
@@ -2360,7 +2362,8 @@ end
         write(script, "dupscriptfn(x::Int) = 1\ndupscriptfn(x::Int) = 2\n")
         sleep(mtimedelay)
         @yry()
-        @test isempty(Revise.duplicated_signatures)
+        scriptkey = Revise.MethodInfoKey(nothing, first(methods(Main.dupscriptfn)).sig)
+        @test !haskey(Revise.duplicated_signatures, scriptkey)
 
         # `__precompile__(false)` package: likewise not tracked.
         dn = joinpath(testdir, "NoPCDup", "src"); mkpath(dn)
@@ -2373,7 +2376,8 @@ end
         sleep(mtimedelay)
         @yry()
         @test NoPCDup.bar(3) == 2
-        @test isempty(Revise.duplicated_signatures)
+        barkey = Revise.MethodInfoKey(nothing, first(methods(NoPCDup.bar)).sig)
+        @test !haskey(Revise.duplicated_signatures, barkey)
 
         rm_precompile("NoPCDup")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2330,7 +2330,8 @@ end
         # Add a second definition of the same signature.
         write(fn, "module DupWarn\nfoo(x::Int) = 1\nfoo(x::Int) = 2\nend\n")
         sleep(mtimedelay)
-        @test_logs (:warn, r"defined in more than one location") match_mode=:any @yry()
+        @test_logs (:warn, r"defined in more than one location") match_mode=:any yry()
+        @latestworld
         @test DupWarn.foo(3) == 2                       # still works in this session
         key = Revise.MethodInfoKey(nothing, first(methods(DupWarn.foo)).sig)
         @test haskey(Revise.duplicated_signatures, key)


### PR DESCRIPTION
A method signature defined in more than one place within a precompilable package evaluates successfully in a running Revise session but causes the next precompilation to fail with "Method overwriting is not permitted during Module precompilation". Previously Revise gave no indication until that failure, by which point the offending edit was often forgotten.

After each revision, scan the tracked definitions for signatures with more than one live location, record them in `Revise.duplicated_signatures`, warn about newly-introduced ones, and keep the prompt color yellow until they are resolved. `Revise.duplicate_methods()` reports them again on demand.

The check is scoped to precompilable packages, which is exactly where the hazard exists: `Main`/`includet` code and `__precompile__(false)` packages never precompile, so duplicate methods there (often deliberate) are not flagged. Precompilability is determined by the existence of a cache file, since `Base.isprecompiled` reports a stale cache for any package under active development. The detection reuses the multi-location tracking that lets a method move between files, so that tolerance is unaffected.

Fixes #889