### PR TITLE
Compare gensym names by base name and correlation

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -119,6 +119,7 @@ Much of the "brains" of Revise comes from doing analysis on lowered code.
 This part of the package is not as well documented.
 
 ```@docs
+Revise.gensym_base
 Revise.minimal_evaluation!
 Revise.methods_by_execution!
 Revise.ExInfo

--- a/src/relocatable_exprs.jl
+++ b/src/relocatable_exprs.jl
@@ -91,7 +91,69 @@ function skip_to_nonline(args::Vector{Any}, i::Int)
     end
 end
 
+# Gensym counters do not reproduce across runs of macro expansion or lowering,
+# so two structurally identical expressions can differ in the numeric part of
+# generated names. Comparison and hashing therefore ignore the counters — but
+# only the counters: the base name must match exactly, and the pairing between
+# generated names must be consistent across the whole expression (wherever one
+# expression repeats a generated name, the other must repeat the corresponding
+# name). `'#'`-prefixed names without a counter (`var"#self#"`, a user's
+# var"#x") are reproducible and compare exactly, like any other symbol; this
+# keeps distinct global bindings distinct as `ExprsInfos` keys.
+
+const anonymous_gensym_rex = r"^#+(\d+)$"        # gensym(): "##277"
+const suffixed_gensym_rex  = r"^#+(.*)#(\d+)$"   # gensym(:name): "##name#123"; closures: "#f#42"; anonymous closures: "#1#2"
+const hygiene_gensym_rex   = r"^#(?:\d+#)+(.+)$" # macro hygiene: "#28#t0"
+
+"""
+    base, iscounter = gensym_base(str)
+
+Classify a `'#'`-prefixed variable name. If `str` contains a gensym counter
+(`"##name#123"`, `"#f#42"`, `"#28#t0"`, `"##277"`, `"#1#2"`), return the
+non-counter part of the name and `iscounter = true`; names that are purely
+counters return `base = ""`. Otherwise (`"#self#"`, `"#x"`, ...) the name is
+reproducible: return it unmodified, with `iscounter = false`.
+"""
+function gensym_base(str::AbstractString)
+    m = match(anonymous_gensym_rex, str)
+    m !== nothing && return "", true
+    m = match(suffixed_gensym_rex, str)
+    if m !== nothing
+        base = m.captures[1]::AbstractString
+        return (all(isdigit, base) ? "" : String(base)), true
+    end
+    m = match(hygiene_gensym_rex, str)
+    m !== nothing && return String(m.captures[1]::AbstractString), true
+    return String(str), false
+end
+
+# Correspondence between the counter-bearing generated names of two expressions
+# under comparison. Consistency requires a bijection, so both directions are tracked.
+struct GensymPairing
+    fwd::Dict{Symbol,Symbol}
+    rev::Dict{Symbol,Symbol}
+end
+GensymPairing() = GensymPairing(Dict{Symbol,Symbol}(), Dict{Symbol,Symbol}())
+
+function isequal_sym(pairing::GensymPairing, a::Symbol, b::Symbol)
+    sa, sb = String(a), String(b)
+    if startswith(sa, '#') && startswith(sb, '#')
+        basea, countera = gensym_base(sa)
+        baseb, counterb = gensym_base(sb)
+        countera == counterb || return false
+        countera || return a === b
+        basea == baseb || return false
+        # the same pairing must hold at every occurrence, even when a === b
+        return get!(pairing.fwd, a, b) === b && get!(pairing.rev, b, a) === a
+    end
+    return a === b
+end
+
 function Base.isequal(itera::LineSkippingIterator, iterb::LineSkippingIterator)
+    return isequal_lsi(GensymPairing(), itera, iterb)
+end
+
+function isequal_lsi(pairing::GensymPairing, itera::LineSkippingIterator, iterb::LineSkippingIterator)
     # We could use `zip` here except that we want to insist that the
     # iterators also have the same length.
     reta, retb = iterate(itera), iterate(iterb)
@@ -103,12 +165,9 @@ function Base.isequal(itera::LineSkippingIterator, iterb::LineSkippingIterator)
         if isa(vala, Expr) && isa(valb, Expr)
             vala, valb = vala::Expr, valb::Expr
             vala.head == valb.head || return false
-            isequal(LineSkippingIterator(vala.args), LineSkippingIterator(valb.args)) || return false
+            isequal_lsi(pairing, LineSkippingIterator(vala.args), LineSkippingIterator(valb.args)) || return false
         elseif isa(vala, Symbol) && isa(valb, Symbol)
-            vala, valb = vala::Symbol, valb::Symbol
-            # two gensymed symbols do not need to match
-            sa, sb = String(vala), String(valb)
-            (startswith(sa, '#') && startswith(sb, '#')) || isequal(vala, valb) || return false
+            isequal_sym(pairing, vala::Symbol, valb::Symbol) || return false
         elseif isa(vala, Number) && isa(valb, Number)
             vala === valb || return false    # issue #233
         else
@@ -120,17 +179,27 @@ end
 
 const hashlsi_seed = UInt === UInt64 ? 0x533cb920dedccdae : 0x2667c89b
 function Base.hash(iter::LineSkippingIterator, h::UInt)
+    return hash_lsi(Dict{Symbol,Int}(), iter, h)
+end
+
+function hash_lsi(gensym_indices::Dict{Symbol,Int}, iter::LineSkippingIterator, h::UInt)
     h += hashlsi_seed
     for x in iter
         if x isa Expr
-            h += hash(LineSkippingIterator(x.args), hash(x.head, h + hashrex_seed))
+            h += hash_lsi(gensym_indices, LineSkippingIterator(x.args), hash(x.head, h + hashrex_seed))
         elseif x isa Symbol
             xs = String(x)
-            if startswith(xs, '#')  # all gensymmed symbols are treated as identical
-                h += hash("gensym", h)
-            else
-                h += hash(x, h)
+            if startswith(xs, '#')
+                base, iscounter = gensym_base(xs)
+                if iscounter
+                    # hash the base name and the order of first occurrence;
+                    # this matches `isequal_sym`'s counter-insensitive pairing
+                    idx = get!(gensym_indices, x, length(gensym_indices) + 1)
+                    h += hash(base, hash(idx, h))
+                    continue
+                end
             end
+            h += hash(x, h)
         elseif x isa Number
             h += hash(typeof(x), hash(x, h))::UInt
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -402,15 +402,74 @@ end
         rex2 = Revise.RelocatableExpr(:(x = $sym2))
         @test isequal(rex1, rex2)
         @test hash(rex1) == hash(rex2)
+        # the gensym counter is ignored, but the base name is not
         sym3 = gensym(:world)
         rex3 = Revise.RelocatableExpr(:(x = $sym3))
-        @test isequal(rex1, rex3)
-        @test hash(rex1) == hash(rex3)
+        @test !isequal(rex1, rex3)
+        @test hash(rex1) != hash(rex3)
+        # the pairing between gensyms must be consistent across the expression
+        @test isequal(Revise.RelocatableExpr(:($sym1 + f($sym1))),
+                      Revise.RelocatableExpr(:($sym2 + f($sym2))))
+        @test hash(Revise.RelocatableExpr(:($sym1 + f($sym1)))) ==
+              hash(Revise.RelocatableExpr(:($sym2 + f($sym2))))
+        @test !isequal(Revise.RelocatableExpr(:($sym1 + f($sym1))),
+                       Revise.RelocatableExpr(:($sym1 + f($sym2))))
+        @test hash(Revise.RelocatableExpr(:($sym1 + f($sym1)))) !=
+              hash(Revise.RelocatableExpr(:($sym1 + f($sym2))))
+        @test !isequal(Revise.RelocatableExpr(:(g($sym1, $sym2) = $sym1)),
+                       Revise.RelocatableExpr(:(g($sym1, $sym2) = $sym2)))
+        # counter-free `#` names denote reproducible bindings and compare exactly
+        @test !isequal(Revise.RelocatableExpr(:(getval() = var"#x")),
+                       Revise.RelocatableExpr(:(getval() = var"#y")))
+        @test hash(Revise.RelocatableExpr(:(getval() = var"#x"))) !=
+              hash(Revise.RelocatableExpr(:(getval() = var"#y")))
+        @test isequal(Revise.RelocatableExpr(:(getval() = var"#x")),
+                      Revise.RelocatableExpr(:(getval() = var"#x")))
+        # expressions differing only in such names must not collide as
+        # `ExprsInfos` keys (generated precompile files contain many
+        # directives that differ only in the gensym base name)
+        src = """
+            module GensymKeyCollision
+            precompile(Tuple{typeof(var"#f#1"), Int})
+            precompile(Tuple{typeof(var"#g#2"), Int})
+            end
+            """
+        mexs = parse_source!(Revise.ModuleExprsInfos(), src, "gensym_collision.jl", Main)
+        @test length(mexs[getfield(Main, :GensymKeyCollision)]) == 2
 
         # coverage
         rex = convert(Revise.RelocatableExpr, :(a = 1))
         @test Revise.striplines!(rex) isa Revise.RelocatableExpr
         @test copy(rex) !== rex
+    end
+
+    do_test("Gensym names in source") && @testset "Gensym names in source" begin
+        # An edit confined to var"#..." names must still trigger revision
+        testdir = newtestdir()
+        fn = joinpath(testdir, "gensymnames.jl")
+        write(fn, """
+            module GensymNames
+            const var"#x" = 1
+            const var"#y" = 2
+            getval() = var"#x"
+            end
+            """)
+        sleep(mtimedelay)
+        includet(fn)
+        @latestworld
+        @test GensymNames.getval() == 1
+        sleep(mtimedelay)
+        write(fn, """
+            module GensymNames
+            const var"#x" = 1
+            const var"#y" = 2
+            getval() = var"#y"
+            end
+            """)
+        @yry()
+        @test GensymNames.getval() == 2
+
+        pop!(LOAD_PATH)
     end
 
     do_test("Display") && @testset "Display" begin


### PR DESCRIPTION
The expression comparator treated every '#'-prefixed symbol as equal to every other one, so an AST difference confined to such names was invisible to revision. However, only the numeric gensym counter fails to reproduce across runs of macro expansion or lowering; the rest of the name is semantic. Comparison and hashing now:

- ignore the counter in counter-bearing names ("##name#123", "#f#42", "#28#t0", "##277", "#1#2"), but require equal base names and a consistent bijective pairing between the two expressions' generated names (so an expression that repeats one gensym never matches one that uses two distinct gensyms in those positions);

- compare counter-free names (var"#self#", var"#x") exactly, like any other symbol, since these are reproducible and denote stable bindings.

Surprisingly, I'm not aware of any bug that has ever been traced to the previous way of handling gensyms, but it's an obvious correctness improvement.