### PR TITLE
Point stale-cache warning at the active depot

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -414,6 +414,14 @@ function fallback_juliadir(candidate = expected_juliadir())
     normpath(candidate)
 end
 
+# issue #717: point users at their actual depot. Stale caches are written to
+# the first depot entry, which honors a custom DEPOT_PATH rather than ~/.julia.
+function revise_cache_dir()
+    major, minor = Base.VERSION.major, Base.VERSION.minor
+    depot = isempty(DEPOT_PATH) ? joinpath(homedir(), ".julia") : first(DEPOT_PATH)
+    return joinpath(depot, "compiled", "v$major.$minor", "Revise")
+end
+
 function find_juliadir()
     candidate = expected_juliadir()
     isdir(candidate) && return normpath(candidate)
@@ -2293,10 +2301,9 @@ function __init__()
 
     # Check Julia paths (issue #601)
     if !isdir(juliadir)
-        major, minor = Base.VERSION.major, Base.VERSION.minor
         @warn """Expected non-existent $juliadir to be your Julia directory.
                  Certain functionality will be disabled.
-                 To fix this, try deleting Revise's cache files in ~/.julia/compiled/v$major.$minor/Revise, then restart Julia and load Revise.
+                 To fix this, try deleting Revise's cache files in $(revise_cache_dir()), then restart Julia and load Revise.
                  If this doesn't fix the problem, please report an issue at https://github.com/timholy/Revise.jl/issues."""
     end
     excluded = Preferences.@load_preference("dont_watch_packages", String[])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5821,6 +5821,11 @@ do_test("misc - coverage") && !isinteractive() && @testset "misc - coverage" beg
 
     @test endswith(Revise.fallback_juliadir(), "julia")
 
+    # issue #717: the stale-cache hint must point at the active depot, not a
+    # hardcoded ~/.julia
+    major, minor = Base.VERSION.major, Base.VERSION.minor
+    @test Revise.revise_cache_dir() == joinpath(first(DEPOT_PATH), "compiled", "v$major.$minor", "Revise")
+
     @test isnothing(Revise.revise(REPL.REPLBackend()))
 end
 


### PR DESCRIPTION
The "Julia directory not found" warning suggested deleting cache files under a hardcoded ~/.julia. A user with a custom DEPOT_PATH would delete the wrong directory and the hint would not help. Build the path from the first depot entry, where precompile caches are actually written.

Fixes #717