### PR TITLE
Add @includet macro for caller-module evaluation

### DIFF
--- a/docs/src/user_reference.md
+++ b/docs/src/user_reference.md
@@ -1,7 +1,7 @@
 # User reference
 
-There are really only eight functions that most users would be expected to call manually:
-`revise`, `includet`, `Revise.track`, `entr`, `Revise.retry`, `Revise.errors`,
+There are really only a handful of functions that most users would be expected to call manually:
+`revise`, `includet` (or [`@includet`](@ref)), `Revise.track`, `entr`, `Revise.retry`, `Revise.errors`,
 `Revise.duplicate_methods`, and `Revise.stale_load`.
 Other user-level constructs might apply if you want to debug Revise or
 prevent it from watching specific packages, or for fine-grained handling of callbacks.
@@ -10,6 +10,7 @@ prevent it from watching specific packages, or for fine-grained handling of call
 revise
 Revise.track
 includet
+@includet
 entr
 Revise.retry
 Revise.errors

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -11,7 +11,7 @@ if !isdefined(Core, :isdefinedglobal)
     isdefinedglobal(m::Module, s::Symbol) = isdefined(m, s)
 end
 
-export revise, includet, entr, MethodSummary
+export revise, includet, @includet, entr, MethodSummary
 
 ## BEGIN abstract Distributed API
 
@@ -1820,6 +1820,10 @@ for tips about setting up the package workflow.
 
 Like `include`, `includet` returns the value of the last evaluated expression in `filename`.
 
+Unlike `include`, `includet` evaluates `filename` into `Main` rather than into the module from
+which it is called. To evaluate into the caller's module instead, use [`@includet`](@ref) or pass
+the module explicitly with `includet(mod, filename)`.
+
 By default, `includet` only tracks modifications to *methods*, not *data*. See the extended help for details.
 Note that this differs from packages, which evaluate all changes by default.
 This default behavior can be overridden; see [Configuring the revise mode](@ref).
@@ -1872,6 +1876,8 @@ try fixing it with something like `push!(LOAD_PATH, "/path/to/my/private/repos")
 `includet` is deliberately non-recursive, so if `filename` loads any other files,
 they will not be automatically tracked.
 (Call [`Revise.track`](@ref) manually on each file, if you've already `included`d all the code you need.)
+Multi-file code that needs all of its files tracked is better organized as a package loaded with
+`using`/`import`, which Revise tracks recursively and which gives you a proper module namespace.
 """
 function includet(mod::Module, file::AbstractString)
     prev = Base.source_path(nothing)
@@ -1907,6 +1913,23 @@ function includet(mod::Module, file::AbstractString)
     return result
 end
 includet(file::AbstractString) = includet(Main, file)
+
+"""
+    @includet "file.jl"
+
+Load `file` and track future changes, evaluating its code into the module in which the macro
+is expanded. This is the only difference from [`includet`](@ref): the function form always
+evaluates into `Main` (or an explicitly-passed module), whereas `@includet` uses the caller's
+module, just as `include` does.
+
+Use `@includet` when calling from inside a module other than `Main`; at the REPL the two forms
+are equivalent. The expansion is simply
+
+    Revise.includet(@__MODULE__, file)
+"""
+macro includet(file)
+    return :(includet($__module__, $(esc(file))))
+end
 
 """
     Revise.silence(pkg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5815,6 +5815,28 @@ do_test("includet with mod arg (issue #689)") && @testset "includet with mod arg
     @test Driver.Codes.Common.foo == 2
 end
 
+do_test("@includet uses caller's module (issue #682)") && @testset "@includet uses caller's module (issue #682)" begin
+    testdir = newtestdir()
+
+    srcfile = joinpath(testdir, "evalscope.jl")
+    write(srcfile, "f_682() = 1")
+
+    module682 = Module(:Module682)
+    Core.eval(module682, :(using Revise))
+    sleep(mtimedelay)
+    Core.eval(module682, :(@includet $srcfile))
+
+    # The macro evaluates into the caller's module, not `Main`.
+    @test Base.invokelatest(module682.f_682) == 1
+    @test !isdefined(Main, :f_682)
+
+    # Tracking still works.
+    sleep(mtimedelay)
+    write(srcfile, "f_682() = 2")
+    yry()
+    @test Base.invokelatest(module682.f_682) == 2
+end
+
 do_test("misc - coverage") && !isinteractive() && @testset "misc - coverage" begin
     @test Revise.ReviseEvalException("undef", UndefVarError(:foo)).loc isa String
     @test !Revise.throwto_repl(UndefVarError(:foo))   # this causes an error in interactive


### PR DESCRIPTION
The `includet` function always evaluates into `Main` because a function cannot know its caller's module. `@includet` expands to `includet(@__MODULE__, file)`, so code loaded from within another module lands in that module, as `include` does. The docstring now states the `Main`-scope behavior of the function form and points multi-file users at packages, which Revise tracks recursively.

Fixes #682