### PR TITLE
Support retraction of exports

### DIFF
--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -2,7 +2,7 @@
 
 ## Struct revision
 
-### Struct revision  is supported on Julia 1.12+
+### Struct revision is supported on Julia 1.12+
 
 Starting with Julia 1.12, Revise can handle changes to struct definitions. When you modify
 a struct, Revise will automatically re-evaluate the struct definition and any methods or
@@ -166,7 +166,7 @@ struct MyVec{T}
 end
 ```
 
-If you change `MyVecType{T}` from `Vector{T}` to `AbstractVector{T}`, the struct `A` will
+If you change `MyVecType{T}` from `Vector{T}` to `AbstractVector{T}`, the struct `MyVec` will
 **not** be automatically re-evaluated because Revise does not track the dependency edge
 from `MyVecType` to `MyVec`. The same applies to `const` bindings and other global bindings
 that are referenced in type definitions.
@@ -191,6 +191,14 @@ already evaluated the macro or generated function.
 You may explicitly call `revise(MyModule)` to force reevaluating every definition in module
 `MyModule`.
 Note that when a macro changes, you have to revise all of the modules that *use* it.
+
+### Removing a name from `export` (Julia before 1.14)
+
+On Julia versions before 1.14, deleting a name from a module's `export` list
+leaves the name accessible in any module that had already done `using
+ThatModule`. Revise itself supports retracting exported names, but it relies on
+a Julia feature that will only become available starting with Julia 1.14
+(https://github.com/JuliaLang/julia/pull/62131).
 
 ### [Code that depends on data](@id data)
 

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -601,8 +601,54 @@ function delete_missing!(
     for (mod, exs_infos_old) in mod_exs_infos_old
         exs_infos_new = get(mod_exs_infos_new, mod, empty_exs_infos)
         delete_missing!(exs_infos_old, exs_infos_new, reeval_list, handled_types, world, predictions)
+        retract_dropped_exports!(mod, exs_infos_old, exs_infos_new)
     end
     return mod_exs_infos_old
+end
+
+# issue #633: a name dropped from a module's `export` list must be un-exported,
+# otherwise modules that already did `using ThatModule` keep resolving it. This
+# needs `Base.set_binding_visibility!`, the accessor that can lower a binding's
+# declared visibility to `:none`; it does not exist before Julia 1.14, where
+# retracting an export is impossible and this is a no-op.
+@static if isdefined(Base, :set_binding_visibility!)
+    function retract_dropped_exports!(mod::Module, exs_infos_old::ExprsInfos, exs_infos_new::ExprsInfos)
+        old = exported_names(exs_infos_old)
+        isempty(old) && return nothing
+        new = exported_names(exs_infos_new)
+        for name in old
+            name in new && continue
+            Base.set_binding_visibility!(mod, name, :none)
+        end
+        return nothing
+    end
+
+    function exported_names(exs_infos::ExprsInfos)
+        names = Set{Symbol}()
+        for rex in keys(exs_infos)
+            add_exported_names!(names, rex.ex)
+        end
+        return names
+    end
+
+    # `parse_source!` stores each top-level statement wrapped in a `:block` (and
+    # conditional/`for`-`include` groups can nest further), so recurse to reach
+    # the `:export` expression.
+    function add_exported_names!(names::Set{Symbol}, @nospecialize(ex))
+        isa(ex, Expr) || return names
+        if ex.head === :export
+            for a in ex.args
+                a isa Symbol && push!(names, a)
+            end
+        elseif ex.head === :block || ex.head === :toplevel
+            for a in ex.args
+                add_exported_names!(names, a)
+            end
+        end
+        return names
+    end
+else
+    retract_dropped_exports!(::Module, ::ExprsInfos, ::ExprsInfos) = nothing
 end
 
 # `true` if diffing old against new will delete at least one expression that defined

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -779,6 +779,36 @@ end
         rm_precompile("A228")
         rm_precompile("B228")
 
+        # Retracting an export (issue #633): dropping a name from `export`
+        # un-exports it, so `using`-ing modules stop resolving it. Requires the
+        # `Base.set_binding_visibility!` accessor added in Julia 1.14.
+        @static if isdefined(Base, :set_binding_visibility!)
+            write(joinpath(testdir, "Export633.jl"), """
+                module Export633
+                export hello633, g633
+                hello633() = 1
+                g633() = 2
+                end
+                """)
+            sleep(mtimedelay)
+            using Export633
+            sleep(mtimedelay)
+            @test Base.isexported(Export633, :g633)
+            @test @eval(g633()) == 2
+            write(joinpath(testdir, "Export633.jl"), """
+                module Export633
+                export hello633
+                hello633() = 1
+                g633() = 2
+                end
+                """)
+            @yry()
+            @test !Base.isexported(Export633, :g633)
+            @test Export633.g633() == 2          # only the export is retracted; the method remains
+            @test_throws UndefVarError @eval g633()
+            rm_precompile("Export633")
+        end
+
         # uncoupled packages in the same directory (issue #339)
         write(joinpath(testdir, "A339.jl"), """
             module A339


### PR DESCRIPTION
EDITED: This relies on https://github.com/JuliaLang/julia/pull/62131, so will only be available starting with Julia 1.14. Documents the limitation on versions earlier than that.

Fixes #633