### PR TITLE
Drop the fixed settling sleep in revise()

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1518,7 +1518,6 @@ revise(; throw::Bool=false) = frozen(_revise; throw)
 
 function _revise(; throw::Bool=false)
     active[] || return nothing
-    sleep(0.01)  # in case the file system isn't quite done writing out the new files
 
     @lock revise_lock begin
         have_queue_errors = !isempty(queue_errors)


### PR DESCRIPTION
`revise()` no longer sleeps before draining the revision queue. The interactive REPL hook fires `revise()` only when the user submits the next expression, long after the editor finished writing, so the file is always settled; the sleep was pure latency. Change-triggered settling is handled where it belongs: `entr` debounces a burst of edits, and the watcher converges on the final write event regardless, so a stale read during a burst self-corrects on the next event.

Fixes #838.