### PR TITLE
test: Write the revise_structs preference to the file that has priority

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3145,12 +3145,19 @@ end
     do_test("revise_structs preference") && if Base.VERSION >= v"1.12.0-DEV.2047"
         @testset "revise_structs preference" begin
             # The preference is read in __init__, so we have to test it via subprocesses.
-            # Set the value explicitly in the active project's `LocalPreferences.toml`: a
+            # Set the value explicitly in the active project's preferences file: a
             # preference there takes precedence over one inherited from the default
             # environment, so the test reflects the `revise_structs` plumbing rather than
-            # whatever the host machine happens to set globally.
+            # whatever the host machine happens to set globally. NOTE: when the tests run
+            # in a `Pkg.test` sandbox (e.g. testing Revise as a dependency of another
+            # project), Pkg materializes the ambient preferences as
+            # `JuliaLocalPreferences.toml`, which shadows any `LocalPreferences.toml` in
+            # the same directory — so write to the file that actually has priority.
             test_proj_dir = dirname(Base.active_project())
-            prefs_file = joinpath(test_proj_dir, "LocalPreferences.toml")
+            prefs_file = let candidates = joinpath.(test_proj_dir, Base.preferences_names)
+                i = findfirst(isfile, candidates)
+                i === nothing ? joinpath(test_proj_dir, last(Base.preferences_names)) : candidates[i]
+            end
             backup = isfile(prefs_file) ? read(prefs_file, String) : nothing
             julia = Base.julia_cmd()
             check_bpart = "using Revise; print(Revise.__bpart__[])"


### PR DESCRIPTION
When the tests run in a `Pkg.test` sandbox (testing Revise as a dependency of another project, as julia's own CI does), Pkg has materialized the ambient preferences — even when empty — as `JuliaLocalPreferences.toml` since JuliaLang/Pkg.jl#2920, and the preference resolution in `base/loading.jl` stops at that file, shadowing any `LocalPreferences.toml` written next to it. The `revise_structs preference` test therefore always read the default in such setups. Write to whichever preferences file actually takes priority. The checkout-as-active-project flow (julia-runtest) is unaffected: no preferences file pre-exists there, and the test keeps using `LocalPreferences.toml`.