### PR TITLE
test: Use an IdSet for the sigtest signature comparison

### DIFF
--- a/test/sigtest.jl
+++ b/test/sigtest.jl
@@ -19,7 +19,11 @@ end
 function signature_diffs(mod::Module, signatures; filepredicate=nothing)
     # `signatures` (CodeTracking.method_info) is keyed by `MethodInfoKey(mt, sig)`;
     # compare against the signature types it records.
-    sigkeys = Set(k.sig for k in keys(signatures))
+    # Use an IdSet: an ==-hashed Set would dynamically dispatch on each distinct
+    # signature type, minting (and natively compiling) a fresh MethodInstance per
+    # signature — ~25ms x tens of thousands of signatures. Identity matching is
+    # also what the pre-MethodInfoKey code did (method_info is an IdDict).
+    sigkeys = Base.IdSet{Any}(k.sig for k in keys(signatures))
     extras = copy(sigkeys)
     modeval, modinclude = getfield(mod, :eval), getfield(mod, :include)
     failed = []


### PR DESCRIPTION
I think this is quite likely a Base overspecialization bug, but regardless it's breaking CI on Base, so we need a stopgap and the fix is good anyway. Claude reports:

Since #1091, sigtest builds `Set(k.sig for k in keys(signatures))` and queries it with `m.sig in sigkeys`. Both operations dynamically dispatch into `Dict` methods whose key slot is declared `key::K`, so every distinct signature type mints (and natively compiles) a fresh MethodInstance. At tens of thousands of Base signatures and 10-200ms per compile, the "Base signatures" testset now takes upwards of half an hour on recent Julia nightlies (where each such compile got ~2x more expensive), which times out JuliaLang/julia's `test revise` CI job.

Use `Base.IdSet` instead: its methods take the key `@nospecialize`d, so no per-signature specializations are created, and identity matching is what the pre-#1091 code did anyway (`method_info` is an `IdDict`). This brings the testset back from >30 minutes to seconds.

This commit was written with the assistance of generative AI (Claude).