### PR TITLE
Support Core.define_method builtin for method tracking

### DIFF
--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -82,7 +82,7 @@ function categorize_stmt(@nospecialize(stmt), code::Vector{Any})
                 callee = code[callee.id]
             end
             isinclude = is_some_include(callee)
-            ismeth = is_defaultctors(callee)
+            ismeth = is_defaultctors(callee) || LoweredCodeUtils.is_define_method_ref(callee)
         end
     end
     return ismeth, haseval, isinclude, isnamespace, istoplevel
@@ -348,7 +348,7 @@ function _methods_by_execution!(
             #     # They may be needed to define later signatures.
             #     # Note that named inner methods don't require special treatment.
             #     pc = step_expr!(interp, frame, stmt, true)
-            elseif head === :method
+            elseif LoweredCodeUtils.ismethod(stmt)
                 empty!(signatures)
                 ret = methoddef!(interp, signatures, frame, stmt, pc; define=mode!==:sigs)
                 if ret === nothing
@@ -365,14 +365,19 @@ function _methods_by_execution!(
                             end
                         end
                     end
-                    @assert length(stmt.args) == 1
+                    @assert LoweredCodeUtils.ismethod1(stmt)
                     pc = mode !== :sigs ? step_expr!(interp, frame, stmt, true) :
                         next_or_nothing!(frame)
                 else
                     pc, pc3 = ret
                     # Get the line number from the body
                     stmt3 = pc_expr(frame, pc3)::Expr
-                    sigcode = lookup(interp, frame, stmt3.args[2])::Core.SimpleVector
+                    if LoweredCodeUtils.is_define_method_call_4arg(stmt3)
+                        # define_method(mod, name, sigdata, body): sigdata = svec(types, sparams, lnn)
+                        sigcode = lookup(interp, frame, stmt3.args[4])::Core.SimpleVector
+                    else
+                        sigcode = lookup(interp, frame, stmt3.args[2])::Core.SimpleVector
+                    end
                     lnn = sigcode[end]
                     if !isa(lnn, LineNumberNode)
                         lnn = nothing

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -60,6 +60,16 @@ function is_defaultctors(@nospecialize(f))
     return false
 end
 
+is_define_method_ref(@nospecialize(f)) = isdefined(LoweredCodeUtils, :is_define_method_ref) &&
+    getfield(LoweredCodeUtils, :is_define_method_ref)(f)
+is_methoddef(@nospecialize(stmt)) = isdefined(LoweredCodeUtils, :ismethod) ?
+    getfield(LoweredCodeUtils, :ismethod)(stmt) : isexpr(stmt, :method)
+is_methoddef1(@nospecialize(stmt)) = isdefined(LoweredCodeUtils, :ismethod1) ?
+    getfield(LoweredCodeUtils, :ismethod1)(stmt) : isexpr(stmt, :method, 1)
+is_define_method_call_4arg(@nospecialize(stmt)) =
+    isdefined(LoweredCodeUtils, :is_define_method_call_4arg) &&
+    getfield(LoweredCodeUtils, :is_define_method_call_4arg)(stmt)
+
 function matches_eval(stmt::Expr)
     stmt.head === :call || return false
     f = stmt.args[1]
@@ -82,7 +92,7 @@ function categorize_stmt(@nospecialize(stmt), code::Vector{Any})
                 callee = code[callee.id]
             end
             isinclude = is_some_include(callee)
-            ismeth = is_defaultctors(callee) || LoweredCodeUtils.is_define_method_ref(callee)
+            ismeth = is_defaultctors(callee) || is_define_method_ref(callee)
         end
     end
     return ismeth, haseval, isinclude, isnamespace, istoplevel
@@ -348,7 +358,7 @@ function _methods_by_execution!(
             #     # They may be needed to define later signatures.
             #     # Note that named inner methods don't require special treatment.
             #     pc = step_expr!(interp, frame, stmt, true)
-            elseif LoweredCodeUtils.ismethod(stmt)
+            elseif is_methoddef(stmt)
                 empty!(signatures)
                 ret = methoddef!(interp, signatures, frame, stmt, pc; define=mode!==:sigs)
                 if ret === nothing
@@ -365,14 +375,14 @@ function _methods_by_execution!(
                             end
                         end
                     end
-                    @assert LoweredCodeUtils.ismethod1(stmt)
+                    @assert is_methoddef1(stmt)
                     pc = mode !== :sigs ? step_expr!(interp, frame, stmt, true) :
                         next_or_nothing!(frame)
                 else
                     pc, pc3 = ret
                     # Get the line number from the body
                     stmt3 = pc_expr(frame, pc3)::Expr
-                    if LoweredCodeUtils.is_define_method_call_4arg(stmt3)
+                    if is_define_method_call_4arg(stmt3)
                         # define_method(mod, name, sigdata, body): sigdata = svec(types, sparams, lnn)
                         sigcode = lookup(interp, frame, stmt3.args[4])::Core.SimpleVector
                     else


### PR DESCRIPTION
Handle the upcoming `Core.define_method` builtin that will replace `Expr(:method)` in Julia's lowered code (JuliaLang/julia#62320). The existing `:method` handling is preserved for backward compatibility with older Julia versions.

Changes:
- Add `is_define_method_ref` helper for `categorize_stmt`
- Update `_methods_by_execution!` to use `LoweredCodeUtils.ismethod()` and `methoddef!()` which now handle both `:method` and `define_method` forms
- Handle sigdata lookup for 4-arg `define_method` (sigdata in args[4] vs args[2] for `:method`)
- Convert `Core.LineInfoNode` to `LineNumberNode` for line number tracking