### PR TITLE
Support include(mapexpr, file)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,21 @@ This file describes only major changes, and does not include bug fixes,
 cleanups, or minor enhancements.
 
 <!-- links start -->
+[Revise 3.17]: https://github.com/timholy/Revise.jl/compare/v3.16.0...v3.17.0
 [Revise 3.16]: https://github.com/timholy/Revise.jl/compare/v3.15.0...v3.16.0
 [Revise 3.15]: https://github.com/timholy/Revise.jl/compare/v3.14.5...v3.15.0
 [Revise 3.13]: https://github.com/timholy/Revise.jl/compare/v3.12.3...v3.13.0
 <!-- links end -->
+
+## [Revise 3.17]
+
+- **`include(mapexpr, file)` support**: revising a file that was included with a
+  transform now re-applies the same transform to each top-level expression, instead of
+  silently dropping it. For files included while a package loads, discovering the
+  transform relies on `Base.include_mapexprs` (Julia ≥ 1.14); `includet` and
+  `Revise.track` also accept a leading `mapexpr` on all supported Julia versions.
+  (https://github.com/timholy/Revise.jl/issues/634,
+  https://github.com/timholy/Revise.jl/issues/820)
 
 ## [Revise 3.16]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.16.0"
+version = "3.17.0"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -321,7 +321,14 @@ end # module
 and the corresponding edit to the code would be to modify it to `greetcaller(x) = greet("Bar")`
 and `remotecall_fetch(greetcaller, p, 1)`.
 
-### `include(mapexpr, filename)` is not supported
+### `include(mapexpr, filename)` requires Julia 1.14 for packages
 
-Julia supports the ability to modify source code after parsing and before evaluation.
-Supporting this is a TODO item but is not yet implemented.
+Julia supports the ability to modify source code after parsing and before evaluation,
+via `include(mapexpr, filename)`. Revising such files applies the same transform.
+For files included this way *while a package loads*, Revise depends on a record kept
+by Julia (`Base.include_mapexprs`) that is available starting with Julia 1.14; on
+older Julia versions the transform is silently dropped when the file is revised.
+No version restriction applies to [`includet`](@ref)/[`Revise.track`](@ref) (which
+accept a leading `mapexpr` of their own) or to `include(mapexpr, filename)` statements
+*added* to an already-loaded package, since those transforms are discovered without
+the load-time record.

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -76,23 +76,41 @@ function parse_pkg_files(id::PkgId)
         if cachefile_includes_reqs_buildid !== nothing
             cachefile, includes, reqs, buildid = cachefile_includes_reqs_buildid
             pkgdata.requirements = reqs
+            if isdefined(Base, :maybe_loaded_precompile) && (mod′ = Base.maybe_loaded_precompile(id, buildid); mod′ isa Module)
+                root = mod′
+            elseif isdefined(Base, :loaded_precompiles) && haskey(Base.loaded_precompiles, id => buildid)
+                root = Base.loaded_precompiles[id => buildid]
+            else
+                root = Base.root_module(id)
+            end
+            # Transforms recorded by `include(mapexpr, ...)` calls while the package
+            # loaded/precompiled (Julia ≥ 1.14), keyed by `(including_module, abspath)`.
+            # `nothing` when there were none or the recording is unavailable.
+            mapexprs = @static isdefined(Base, :include_mapexprs) ? (@invokelatest Base.include_mapexprs(root)) : nothing
+            matched_mapexprs = mapexprs === nothing ? nothing : Set{keytype(mapexprs)}()
             for chi in includes
-                if isdefined(Base, :maybe_loaded_precompile) && (mod′ = Base.maybe_loaded_precompile(id, buildid); mod′ isa Module)
-                    mod = mod′
-                elseif isdefined(Base, :loaded_precompiles) && haskey(Base.loaded_precompiles, id => buildid)
-                    mod = Base.loaded_precompiles[id => buildid]
-                else
-                    mod = Base.root_module(id)
-                end
+                mod = root
                 for mpath in chi.modpath
                     mod = getglobal(mod, Symbol(mpath))::Module
                 end
                 fname = relpath(chi.filename, pkgdata)
+                mapexpr = identity
+                if mapexprs !== nothing
+                    key = (mod, chi.filename)
+                    if haskey(mapexprs, key)
+                        mapexpr = mapexprs[key]::Function
+                        push!(matched_mapexprs, key)
+                    end
+                end
                 # For precompiled packages, we can read the source later (whenever we need it)
                 # from the *.ji cachefile. Keep `chi.filename` itself: that is the exact key
                 # the cache is indexed by, and reconstructing it from `fname` is unreliable
                 # when path forms diverge (e.g. symlinks, see #1033).
-                push!(pkgdata, fname=>FileInfo(mod, cachefile, chi.filename))
+                push!(pkgdata, fname=>FileInfo(mod, cachefile, chi.filename; mapexpr))
+            end
+            if mapexprs !== nothing && length(matched_mapexprs) != length(mapexprs)
+                unmatched = [key for key in keys(mapexprs) if key ∉ matched_mapexprs]
+                @warn "Revise could not associate the following `include(mapexpr, ...)` records of $id with tracked files; their transforms will not be applied on revision" unmatched
             end
             CodeTracking._pkgfiles[id] = pkgdata.info
             return pkgdata
@@ -106,6 +124,21 @@ function parse_pkg_files(id::PkgId)
     # infrastructure and it's better to wait to compile it until we actually need it.
     frozen(queue_includes!, pkgdata, id)
     return pkgdata
+end
+
+# The transform recorded when `fname` was `include(mapexpr, ...)`ed into `mod`
+# (Julia ≥ 1.14, `Base.include_mapexprs`), or `identity` when there was none or no
+# record is available. The record lives in a binding created when the target package
+# loaded — after Revise's frozen world — hence the `@invokelatest`.
+function include_mapexpr_for(mod::Module, fname::AbstractString)
+    @static if isdefined(Base, :include_mapexprs)
+        mod === Base.__toplevel__ && return identity
+        table = @invokelatest Base.include_mapexprs(mod)
+        table === nothing && return identity
+        return get(table, (mod, String(fname)), identity)::Function
+    else
+        return identity
+    end
 end
 
 """

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -577,22 +577,36 @@ end
 
 function handle_include!(exinfo::ExInfo, interp::Interpreter, frame::Frame, stmt::Expr)
     if length(stmt.args) == 2
+        # include(path)
         local arg2 = lookup(interp, frame, stmt.args[2])
         if arg2 isa AbstractString
-            push!(exinfo.includes, moduleof(frame)=>arg2)
+            push!(exinfo.includes, (moduleof(frame), identity, arg2))
             return exinfo
         end
-        error("Bad include call")
     elseif length(stmt.args) == 3
+        # include(mod, path) or include(mapexpr, path)
         local arg2 = lookup(interp, frame, stmt.args[2])
         local arg3 = lookup(interp, frame, stmt.args[3])
-        if arg2 isa Module && arg3 isa AbstractString
-            push!(exinfo.includes, arg2=>arg3)
+        if arg3 isa AbstractString
+            if arg2 isa Module
+                push!(exinfo.includes, (arg2, identity, arg3))
+                return exinfo
+            elseif arg2 isa Function
+                push!(exinfo.includes, (moduleof(frame), arg2, arg3))
+                return exinfo
+            end
+        end
+    elseif length(stmt.args) == 4
+        # include(mapexpr, mod, path)
+        local arg2 = lookup(interp, frame, stmt.args[2])
+        local arg3 = lookup(interp, frame, stmt.args[3])
+        local arg4 = lookup(interp, frame, stmt.args[4])
+        if arg2 isa Function && arg3 isa Module && arg4 isa AbstractString
+            push!(exinfo.includes, (arg3, arg2, arg4))
             return exinfo
         end
-        error("Bad include call")
     end
-    error("include(mapexpr::Function, mod::Module, path::AbstractString) is not supported") # TODO (issue #634)
+    error("Bad include call")
 end
 
 function analyze_typebody!(exinfo::ExInfo, interp::Interpreter, frame::Frame, stmt::Expr)

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -4,12 +4,30 @@ function assign_this!(frame::Frame, @nospecialize value)
     frame.framedata.ssavalues[frame.pc] = value
 end
 
+# The callee of a lowered statement may be a `GlobalRef`, or the function itself: JuliaInterpreter
+# resolves some `GlobalRef`s to their values (as a `QuoteNode`) when it builds a `FrameCode`.
+function is_getproperty(@nospecialize(f))
+    isa(f, QuoteNode) && (f = f.value)
+    isa(f, GlobalRef) && return f.name === :getproperty
+    return f === getproperty
+end
+
 function is_some_include(@nospecialize(f))
     @assert !isa(f, Core.SSAValue) && !isa(f, JuliaInterpreter.SSAValue)
     if isa(f, GlobalRef)
         return f.name === :include
     elseif isa(f, Symbol)
         return f === :include
+    elseif isa(f, Expr)
+        # A qualified `Mod.include` (e.g. `Base.include(mapexpr, mod, path)`) lowers to a
+        # `getproperty` call, so the callee of the `include` call is that expression rather
+        # than a `GlobalRef`. Whether it really resolves to an `include` function is settled
+        # by identity when the call is reached; here it need only be a candidate.
+        isexpr(f, :call) && length(f.args) == 3 || return false
+        is_getproperty(f.args[1]) || return false
+        name = f.args[3]
+        isa(name, QuoteNode) && (name = name.value)
+        return name === :include
     else
         if isa(f, QuoteNode)
             f = f.value

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -815,7 +815,7 @@ end
 # These are typically bypassed in favor of expression-by-expression evaluation to
 # allow handling of new `include` statements.
 function eval_new!(exs_infos_new::ExprsInfos, exs_infos_old::ExprsInfos, mod::Module; mode::Symbol=:eval)
-    includes = Vector{Pair{Module,String}}()
+    includes = Vector{Tuple{Module,Function,String}}()
     for rex in keys(exs_infos_new)
         exinfos, includes′ = eval_rex(rex, exs_infos_old, mod; mode)
         if exinfos !== nothing
@@ -829,7 +829,7 @@ function eval_new!(exs_infos_new::ExprsInfos, exs_infos_old::ExprsInfos, mod::Mo
 end
 
 function eval_new!(mod_exs_infos_new::ModuleExprsInfos, mod_exs_infos_old::ModuleExprsInfos; mode::Symbol=:eval)
-    includes = Vector{Pair{Module,String}}()
+    includes = Vector{Tuple{Module,Function,String}}()
     for (mod, exs_infos_new) in mod_exs_infos_new
         # Allow packages to override the supplied mode
         if isdefined(mod, :__revise_mode__)
@@ -1087,7 +1087,7 @@ function parse_for_revision(pkgdata::PkgData, file::AbstractString, idx::Int)
     end
     topmod = first(keys(mod_exs_infos_old))
     fileok = file_exists(String(filep)::String)
-    pr = fileok ? parse_and_maybe_eval_source(filep, topmod) : ParseResult(ModuleExprsInfos(topmod), true)
+    pr = fileok ? parse_and_maybe_eval_source(filep, topmod; mapexpr=fi.mapexpr) : ParseResult(ModuleExprsInfos(topmod), true)
     return pr, mod_exs_infos_old, fileok
 end
 
@@ -1799,17 +1799,25 @@ end
 """
     Revise.track(mod::Module, file::AbstractString)
     Revise.track(file::AbstractString)
+    Revise.track(mapexpr::Function, [mod::Module], file::AbstractString)
 
 Watch `file` for updates and [`revise`](@ref) loaded code with any
 changes. `mod` is the module into which `file` is evaluated; if omitted,
 it defaults to `Main`.
 
+If the file was loaded with `include(mapexpr, file)`, pass the same `mapexpr` so
+revisions apply the same transform to each top-level expression.
+
 If this produces many errors, check that you specified `mod` correctly.
 """
 track(mod::Module, file::AbstractString; mode=:sigs, kwargs...) =
     frozen(_track, mod, file; mode, kwargs...)
+track(mapexpr::Function, mod::Module, file::AbstractString; kwargs...) =
+    track(mod, file; mapexpr, kwargs...)
+track(mapexpr::Function, file::AbstractString; kwargs...) =
+    track(mapexpr, Main, file; kwargs...)
 
-function _track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
+function _track(mod::Module, file::AbstractString; mode=:sigs, mapexpr::Function=identity, kwargs...)
     isfile(file) || error(file, " is not a file")
     # Determine whether we're already tracking this file
     id = Base.moduleroot(mod) == Main ? PkgId(mod, string(mod)) : PkgId(mod)  # see #689 for `Main`
@@ -1829,7 +1837,7 @@ function _track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
         file = abspath_no_normalize(file)
     end
     # Set up tracking
-    pr = parse_and_maybe_eval_source(file, mod; mode)
+    pr = parse_and_maybe_eval_source(file, mod; mode, mapexpr)
     if pr.success
         mod_exs_infos = pr.modexinfos
         if mode === :includet
@@ -1848,7 +1856,7 @@ function _track(mod::Module, file::AbstractString; mode=:sigs, kwargs...)
             CodeTracking._pkgfiles[id] = pkgdata.info
         end
         @lock revise_lock begin
-            push!(pkgdata, relpath(file, pkgdata)=>FileInfo(mod_exs_infos))
+            push!(pkgdata, relpath(file, pkgdata)=>FileInfo(mod_exs_infos; mapexpr))
             init_watching(pkgdata, (String(file)::String,))
             pkgdatas[id] = pkgdata
         end
@@ -1864,13 +1872,16 @@ end
 
 """
     includet(filename::AbstractString)
+    includet(mapexpr::Function, filename::AbstractString)
 
 Load `filename` and track future changes. `includet` is intended for quick "user scripts"; larger or more
 established projects are encouraged to put the code in one or more packages loaded with `using`
 or `import` instead of using `includet`. See https://timholy.github.io/Revise.jl/stable/cookbook/
 for tips about setting up the package workflow.
 
-Like `include`, `includet` returns the value of the last evaluated expression in `filename`.
+Like `include`, `includet` returns the value of the last evaluated expression in `filename`,
+and accepts a leading `mapexpr` that transforms each top-level expression before it is
+evaluated; revisions of `filename` apply the same transform.
 
 Unlike `include`, `includet` evaluates `filename` into `Main` rather than into the module from
 which it is called. To evaluate into the caller's module instead, use [`@includet`](@ref) or pass
@@ -1931,7 +1942,7 @@ they will not be automatically tracked.
 Multi-file code that needs all of its files tracked is better organized as a package loaded with
 `using`/`import`, which Revise tracks recursively and which gives you a proper module namespace.
 """
-function includet(mod::Module, file::AbstractString)
+function includet(mapexpr::Function, mod::Module, file::AbstractString)
     prev = Base.source_path(nothing)
     file = if prev === nothing
         abspath(file)
@@ -1942,7 +1953,7 @@ function includet(mod::Module, file::AbstractString)
     tls[:SOURCE_PATH] = file
     result = nothing
     try
-        result = track(mod, file; mode=:includet, skip_include=true)
+        result = track(mod, file; mode=:includet, skip_include=true, mapexpr)
         if prev === nothing
             delete!(tls, :SOURCE_PATH)
         else
@@ -1964,7 +1975,9 @@ function includet(mod::Module, file::AbstractString)
     end
     return result
 end
-includet(file::AbstractString) = includet(Main, file)
+includet(mod::Module, file::AbstractString) = includet(identity, mod, file)
+includet(mapexpr::Function, file::AbstractString) = includet(mapexpr, Main, file)
+includet(file::AbstractString) = includet(identity, Main, file)
 
 """
     @includet "file.jl"

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -23,20 +23,23 @@ struct ParseResult
 end
 
 """
-    pr = parse_and_maybe_eval_source(filename::AbstractString, mod::Module; mode=:sigs)
+    pr = parse_and_maybe_eval_source(filename::AbstractString, mod::Module; mode=:sigs, mapexpr=identity)
 
 Parse the source `filename`, returning a [`ParseResult`](@ref) `pr`.
 `mod` is the "parent" module for the file (i.e., the one that `include`d the file);
 if `filename` defines more module(s) then these will all have separate entries in `pr.modexinfos`.
 
+`mapexpr` is applied to each top-level expression, mirroring `include(mapexpr, filename)`;
+supply the transform that was used when the file was included.
+
 In `:includet` mode the expressions are also evaluated as they are parsed, and `pr.ret` holds the
 value of the last one.
 """
-parse_and_maybe_eval_source(filename::AbstractString, mod::Module; mode::Symbol=:sigs) =
-    parse_and_maybe_eval_source!(ModuleExprsInfos(mod), filename, mod; mode)
+parse_and_maybe_eval_source(filename::AbstractString, mod::Module; mode::Symbol=:sigs, mapexpr::Function=identity) =
+    parse_and_maybe_eval_source!(ModuleExprsInfos(mod), filename, mod; mode, mapexpr)
 
 """
-    pr = parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, filename, mod::Module; mode=:sigs)
+    pr = parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, filename, mod::Module; mode=:sigs, mapexpr=identity)
 
 Top-level parsing of `filename` as included into module `mod`. Successfully-parsed expressions are
 added to `modexinfos`, which is also returned as `pr.modexinfos`. In `:includet` mode the expressions
@@ -44,15 +47,15 @@ are evaluated as they are parsed.
 
 See also [`Revise.parse_and_maybe_eval_source`](@ref).
 """
-function parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, filename::AbstractString, mod::Module; mode::Symbol=:sigs)
+function parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, filename::AbstractString, mod::Module; mode::Symbol=:sigs, mapexpr::Function=identity)
     if !isfile(filename)
         @warn "$filename is not a file, omitting from revision tracking"
         return ParseResult(modexinfos, false)
     end
-    return parse_and_maybe_eval_source!(modexinfos, read(filename, String), filename, mod; mode)
+    return parse_and_maybe_eval_source!(modexinfos, read(filename, String), filename, mod; mode, mapexpr)
 end
 
-function parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, src::AbstractString, filename::AbstractString, mod::Module; mode::Symbol=:sigs)
+function parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, src::AbstractString, filename::AbstractString, mod::Module; mode::Symbol=:sigs, mapexpr::Function=identity)
     if startswith(src, "# REVISE: DO NOT PARSE")
         return ParseResult(modexinfos, true, true)
     end
@@ -66,16 +69,49 @@ function parse_and_maybe_eval_source!(modexinfos::ModuleExprsInfos, src::Abstrac
     elseif ex isa Expr
         # issue #783: in `:includet` mode `process_ex!` returns the value of the last evaluated
         # expression, which `includet` returns like `include`.
-        ret = process_ex!(modexinfos, ex, filename, mod; mode)
+        ret = process_ex!(modexinfos, ex, filename, mod; mode, mapexpr)
         return mode === :includet ? ParseResult(modexinfos, true, false, ret) : ParseResult(modexinfos, true)
     else # literals
         return ParseResult(modexinfos, false)
     end
 end
 
-function process_ex!(mod_exprs_sigs::ModuleExprsInfos, ex::Expr, filename::AbstractString, mod::Module; mode::Symbol=:sigs)
+# Transform `ex`, the `:toplevel` block that `Base.parse_input_line` returns for a whole file,
+# the way `include(mapexpr, filename)` does: `Base.include_string` applies `mapexpr` to each
+# parsed top-level statement, not to the file as a whole. A `module ... end` is a single
+# top-level statement, so the transform sees it once; statements inside it are not individually
+# transformed. `mapexpr` comes from user code loaded after Revise, hence the `invokelatest`.
+# `ex.args` is mutated in place.
+function apply_mapexpr!(mapexpr::Function, ex::Expr, filename::AbstractString)
+    @assert ex.head === :toplevel
+    lnn = LineNumberNode(1, Symbol(filename))
+    function transform(@nospecialize(a), lnn::LineNumberNode)
+        try
+            return Base.invokelatest(mapexpr, a)
+        catch err
+            bt = trim_toplevel!(catch_backtrace())
+            loc = location_string((lnn.file, lnn.line))
+            throw(ReviseEvalException(loc, err, Any[(sf, 1) for sf in stacktrace(bt)]))
+        end
+    end
+    for (i, a) in enumerate(ex.args)
+        if a isa LineNumberNode
+            lnn = a
+            continue
+        end
+        ex.args[i] = transform(a, lnn)
+    end
+    return ex
+end
+
+function process_ex!(mod_exprs_sigs::ModuleExprsInfos, ex::Expr, filename::AbstractString, mod::Module; mode::Symbol=:sigs, mapexpr::Function=identity)
     if isexpr(ex, :error) || isexpr(ex, :incomplete)
         return eval(ex)
+    end
+    if mapexpr !== identity
+        # A statement the transform maps to a non-`Expr` (e.g. a literal) defines nothing;
+        # `ExprSplitter` skips it, so there is nothing to track.
+        apply_mapexpr!(mapexpr, ex, filename)
     end
     lastval = nothing
     for (mod, ex) in ExprSplitter(mod, ex)

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -28,10 +28,11 @@ function queue_includes!(pkgdata::PkgData, id::PkgId)
             mod, fname = included_files[i]
             modname = String(Symbol(mod))
             if startswith(modname, modstring) || endswith(fname, modstring*".jl")
-                pr = parse_and_maybe_eval_source(fname, mod)
+                mapexpr = include_mapexpr_for(mod, fname)
+                pr = parse_and_maybe_eval_source(fname, mod; mapexpr)
                 if pr.success
                     fname = relpath(fname, pkgdata)
-                    push!(pkgdata, fname=>FileInfo(pr.modexinfos))
+                    push!(pkgdata, fname=>FileInfo(pr.modexinfos; mapexpr))
                 end
                 push!(delids, i)
             end
@@ -106,7 +107,7 @@ function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString, fi::Fil
         filep = joinpath(basedir(pkgdata), file)
         filec = get(cache_file_key, filep, filep)
         topmod = first(keys(fi.mod_exs_infos))
-        pr = parse_and_maybe_eval_source!(fi.mod_exs_infos, src, filec, topmod)
+        pr = parse_and_maybe_eval_source!(fi.mod_exs_infos, src, filec, topmod; mapexpr=fi.mapexpr)
         if !pr.success
             @error "failed to parse cache file source text for $file"
         end
@@ -192,35 +193,26 @@ function maybe_extract_sigs_for_types(types)
 end
 
 function maybe_add_includes_to_pkgdata!(pkgdata::PkgData, file::AbstractString, includes; eval_now::Bool=false)
-    for (mod, inc) in includes
+    for (mod, mapexpr, inc) in includes
         inc = joinpath(splitdir(file)[1], inc)
         incrp = relpath(inc, pkgdata)
-        hasfile = false
-        for srcfile in srcfiles(pkgdata)
-            if srcfile == incrp
-                hasfile = true
+        hasinclude = false
+        # An entry for the same path and destination module whose `mapexpr` differs:
+        # the `include(mapexpr, ...)` statement was edited (or its closure was
+        # recreated when the including statement was re-evaluated), so that entry
+        # describes a transform that is no longer in the source.
+        stale_idx = 0
+        for (i, srcfile) in enumerate(srcfiles(pkgdata))
+            srcfile == incrp || continue
+            fi = pkgdata.fileinfos[i]
+            if fi.mapexpr === mapexpr
+                hasinclude = true
                 break
+            elseif stale_idx == 0 && first(keys(fi.mod_exs_infos)) === mod
+                stale_idx = i
             end
         end
-        if !hasfile
-            # Add the file to pkgdata
-            push!(pkgdata.info.files, incrp)
-            fi = FileInfo(mod)
-            push!(pkgdata.fileinfos, fi)
-            # Parse the source of the new file
-            fullfile = joinpath(basedir(pkgdata), incrp)
-            if isfile(fullfile)
-                parse_and_maybe_eval_source!(fi.mod_exs_infos, fullfile, mod)
-                if eval_now
-                    # Pin to Revise's frozen world (issue #552); `frozen`'s runtime dispatch
-                    # also reduces latency.
-                    frozen(instantiate_sigs!, fi.mod_exs_infos; mode=:eval)
-                end
-            end
-            # Add to watchlist
-            init_watching(pkgdata, (incrp,))
-            yield()
-        else
+        if hasinclude
             # Already registered, but the watch may have been relinquished while
             # the file's directory was absent (e.g. a branch switch removed it
             # past `watch_reappear_grace`); an `include` of the file in revised
@@ -232,6 +224,44 @@ function maybe_add_includes_to_pkgdata!(pkgdata::PkgData, file::AbstractString, 
                 revise_file_now(pkgdata, incrp)
                 init_watching(pkgdata, (incrp,))
             end
+        elseif stale_idx != 0
+            fi = pkgdata.fileinfos[stale_idx]
+            # The stored expressions must describe what is currently loaded, which was
+            # produced by the *old* transform: reconstruct them from the source snapshot
+            # in the precompile cache before swapping in the new transform. (Parsing
+            # after the swap would apply the new transform to the old source, making the
+            # subsequent diff vacuous and leaving the session stale.)
+            maybe_parse_from_cache!(pkgdata, incrp, fi)
+            pkgdata.fileinfos[stale_idx] = FileInfo(fi.mod_exs_infos, mapexpr, fi.cachefile, fi.cachefilename,
+                                                    fi.cacheexprs, fi.extracted, fi.parsed)
+            # Re-diff the file under the new transform so the session catches up with
+            # the new effective source.
+            if eval_now
+                revise_file_now(pkgdata, incrp)
+            else
+                @lock revise_lock push!(revision_queue, (pkgdata, incrp))
+            end
+            if !iswatched(pkgdata, incrp)
+                init_watching(pkgdata, (incrp,))
+            end
+        else
+            # Add the file to pkgdata
+            push!(pkgdata.info.files, incrp)
+            fi = FileInfo(mod; mapexpr)
+            push!(pkgdata.fileinfos, fi)
+            # Parse the source of the new file
+            fullfile = joinpath(basedir(pkgdata), incrp)
+            if isfile(fullfile)
+                parse_and_maybe_eval_source!(fi.mod_exs_infos, fullfile, mod; mapexpr)
+                if eval_now
+                    # Pin to Revise's frozen world (issue #552); `frozen`'s runtime dispatch
+                    # also reduces latency.
+                    frozen(instantiate_sigs!, fi.mod_exs_infos; mode=:eval)
+                end
+            end
+            # Add to watchlist
+            init_watching(pkgdata, (incrp,))
+            yield()
         end
     end
 end
@@ -286,10 +316,10 @@ function add_require(sourcefile::String, modcaller::Module, idmod::String, ::Str
             # signature-extraction code has not yet been compiled (latency reduction)
             includes, complex = deferrable_require(expr)
             if !complex
-                # [(modcaller, inc) for inc in includes] but without precompiling a Generator
-                modincludes = Tuple{Module,String}[]
+                # [(modcaller, identity, inc) for inc in includes] but without precompiling a Generator
+                modincludes = Tuple{Module,Function,String}[]
                 for inc in includes
-                    push!(modincludes, (modcaller, inc))
+                    push!(modincludes, (modcaller, identity, inc))
                 end
                 maybe_add_includes_to_pkgdata!(pkgdata, filekey, modincludes)
                 if isempty(fi.mod_exs_infos)
@@ -635,7 +665,7 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
                 filep = joinpath(basedir(pkgdata), file)
                 src = read(filep, String)
                 topmod = first(keys(fi.mod_exs_infos))
-                if !parse_and_maybe_eval_source!(fi.mod_exs_infos, src, filep, topmod).success
+                if !parse_and_maybe_eval_source!(fi.mod_exs_infos, src, filep, topmod; mapexpr=fi.mapexpr).success
                     @error "failed to parse source text for $filep"
                 end
                 add_modexs!(fi, fi.cacheexprs)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -99,7 +99,7 @@ function _precompile_()
     @warnpcfail precompile(Tuple{Type{PkgData}, PkgId})
     @warnpcfail precompile(Tuple{typeof(Base._deleteat!), Vector{Tuple{Module,String,Float64}}, Vector{Int}})
     @warnpcfail precompile(Tuple{typeof(add_require), String, Module, String, String, Expr})
-    @warnpcfail precompile(Tuple{Core.kwftype(typeof(maybe_add_includes_to_pkgdata!)),NamedTuple{(:eval_now,), Tuple{Bool}},typeof(maybe_add_includes_to_pkgdata!),PkgData,String,Vector{Pair{Module, String}}})
+    @warnpcfail precompile(Tuple{Core.kwftype(typeof(maybe_add_includes_to_pkgdata!)),NamedTuple{(:eval_now,), Tuple{Bool}},typeof(maybe_add_includes_to_pkgdata!),PkgData,String,Vector{Tuple{Module, Function, String}}})
 
     for TT in (Tuple{Module,Expr}, Tuple{DataType,MethodSummary})
         @warnpcfail precompile(Tuple{Core.kwftype(typeof(Base.CoreLogging.handle_message)),NamedTuple{(:time, :deltainfo), Tuple{Float64, TT}},typeof(Base.CoreLogging.handle_message),ReviseLogger,LogLevel,String,Module,String,Symbol,String,Int})

--- a/src/types.jl
+++ b/src/types.jl
@@ -107,16 +107,17 @@ It also has the following fields:
 - `exprstack`: used when descending into `@eval` statements: `ex` (used in creating the `ExInfo` object) is the first entry in the stack
 - `allsigs`: a list of all method signatures defined by a given expression (cached in `CodeTracking.method_info`)
 - `typeinfos`: a list of all type definitions defined by a given expression (not cached in CodeTracking)
-- `includes`: a list of `module=>filename` for any `include` statements encountered while the
-  expression was parsed.
+- `includes`: a list of `(module, mapexpr, filename)` for any `include` statements encountered
+  while the expression was parsed. `mapexpr` is the transform passed to
+  `include(mapexpr, filename)`, or `identity` for plain `include(filename)`.
 """
 struct ExInfo
     exprstack::Vector{Expr}
     allsigs::Vector{SigInfo}
     typeinfos::Vector{TypeInfo}
-    includes::Vector{Pair{Module,String}}
+    includes::Vector{Tuple{Module,Function,String}}
 end
-ExInfo(ex::Expr) = ExInfo(Expr[ex], SigInfo[], TypeInfo[], Pair{Module,String}[])
+ExInfo(ex::Expr) = ExInfo(Expr[ex], SigInfo[], TypeInfo[], Tuple{Module,Function,String}[])
 
 """
     get_extended_data(ext::ExtendedData, owner::Symbol) -> ext::Union{ExtendedData,Nothing}
@@ -260,11 +261,17 @@ ModuleExprsInfos(mod::Module) = ModuleExprsInfos(mod=>ExprsInfos())
 Base.isempty(fm::ModuleExprsInfos) = length(fm) == 1 && isempty(first(values(fm)))
 
 """
-    FileInfo(mod_exs_infos::ModuleExprsInfos, cachefile="")
+    FileInfo(mod_exs_infos::ModuleExprsInfos, cachefile=""; mapexpr=identity)
 
 Structure to hold the per-module expressions found when parsing a
 single file.
 `mod_exs_infos` holds the [`Revise.ModuleExprsInfos`](@ref) for the file.
+
+`mapexpr` is the transform passed to `include(mapexpr, filename)` when the file was
+included (`identity` for plain `include`). Parsing the file for revision applies the
+same transform to each top-level expression, matching what `include` evaluated.
+A file included more than once with different `mapexpr`s has one `FileInfo` per
+inclusion (see `Revise.fileindices`).
 
 Optionally, a `FileInfo` can also record the path to a cache file holding the original source code.
 This is applicable only for precompiled modules and `Base`.
@@ -278,24 +285,25 @@ Source cache files greatly reduce the overhead of using Revise.
 """
 struct FileInfo
     mod_exs_infos::ModuleExprsInfos
+    mapexpr::Function                                  # transform applied to each top-level expression (identity if none)
     cachefile::String
-    cachefilename::String                              # the source path as recorded inside `cachefile`, used to read from the cache
+    cachefilename::String                              # the source path as recorded inside `cachefile`; the lookup key for reading from the cache
     cacheexprs::Vector{Tuple{Module,Expr}}             # "unprocessed" exprs, used to support @require
     extracted::Base.RefValue{Bool}                     # true if signatures have been processed from mod_exs_infos
     parsed::Base.RefValue{Bool}                        # true if mod_exs_infos have been parsed from cachefile
 end
-FileInfo(mod_exs_infos::ModuleExprsInfos, cachefile="", cachefilename="") =
-    FileInfo(mod_exs_infos, cachefile, cachefilename, Tuple{Module,Expr}[], Ref(false), Ref(false))
+FileInfo(mod_exs_infos::ModuleExprsInfos, cachefile="", cachefilename=""; mapexpr::Function=identity) =
+    FileInfo(mod_exs_infos, mapexpr, cachefile, cachefilename, Tuple{Module,Expr}[], Ref(false), Ref(false))
 
 """
-    FileInfo(mod::Module, cachefile="", cachefilename="")
+    FileInfo(mod::Module, cachefile="", cachefilename=""; mapexpr=identity)
 
 Initialize an empty FileInfo for a file that is `include`d into `mod`.
 """
-FileInfo(mod::Module, cachefile::AbstractString="", cachefilename::AbstractString="") =
-    FileInfo(ModuleExprsInfos(mod), cachefile, cachefilename)
+FileInfo(mod::Module, cachefile::AbstractString="", cachefilename::AbstractString=""; mapexpr::Function=identity) =
+    FileInfo(ModuleExprsInfos(mod), cachefile, cachefilename; mapexpr)
 
-FileInfo(fm::ModuleExprsInfos, fi::FileInfo) = FileInfo(fm, fi.cachefile, fi.cachefilename, copy(fi.cacheexprs), Ref(fi.extracted[]), Ref(fi.parsed[]))
+FileInfo(fm::ModuleExprsInfos, fi::FileInfo) = FileInfo(fm, fi.mapexpr, fi.cachefile, fi.cachefilename, copy(fi.cacheexprs), Ref(fi.extracted[]), Ref(fi.parsed[]))
 
 function Base.show(io::IO, fi::FileInfo)
     print(io, "FileInfo(")
@@ -304,6 +312,9 @@ function Base.show(io::IO, fi::FileInfo)
         print(io, "=>")
         show(io, exs_infos)
         print(io, ", ")
+    end
+    if fi.mapexpr !== identity
+        print(io, "with mapexpr ", fi.mapexpr, ", ")
     end
     if !isempty(fi.cachefile)
         print(io, "with cachefile ", fi.cachefile)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1018,6 +1018,171 @@ end
         pop!(LOAD_PATH)
     end
 
+    do_test("include with mapexpr") && @testset "include with mapexpr" begin
+        # The transform passed to `include(mapexpr, file)`/`includet(mapexpr, file)` must be
+        # re-applied whenever the file is revised (issues #634, #820). The test transform
+        # bumps the integer literal body of a short-form function definition by a fixed
+        # offset, so `f() = 2` behaves as `f() = 42`: return values reveal whether the
+        # transform was applied, and which one.
+        function mkbump(n)
+            return function (ex)
+                if Meta.isexpr(ex, :(=), 2)
+                    rhs = ex.args[2]
+                    if rhs isa Expr && rhs.head === :block && rhs.args[end] isa Int
+                        rhs.args[end] += n
+                    end
+                end
+                return ex
+            end
+        end
+        bump40 = mkbump(40)
+        testdir = newtestdir()
+
+        # includet(mapexpr, file)
+        script = joinpath(testdir, "mapexpr_script.jl")
+        write(script, "fmap634() = 2\n")
+        sleep(mtimedelay)
+        includet(bump40, script)
+        @latestworld
+        @test fmap634() == 42
+        sleep(mtimedelay)
+        write(script, "fmap634() = 3\n")
+        @yry()
+        @test fmap634() == 43
+        @test occursin("with mapexpr", sprint(show, Revise.FileInfo(Main; mapexpr=bump40)))
+
+        # An error thrown by the transform is reported against the statement it was applied to
+        badscript = joinpath(testdir, "mapexpr_bad.jl")
+        write(badscript, "# a comment\nfmap634bad() = 2\n")
+        sleep(mtimedelay)
+        badmap(ex) = error("bad transform")
+        err = try
+            Revise.track(badmap, badscript)
+        catch err
+            err
+        end
+        @test err isa Revise.ReviseEvalException
+        @test occursin("mapexpr_bad.jl:2", err.loc)
+        @test occursin("bad transform", sprint(showerror, err))
+
+        # track(mapexpr, file) on an already-loaded script
+        script2 = joinpath(testdir, "mapexpr_script2.jl")
+        write(script2, "fmap634b() = 2\n")
+        include(bump40, script2)
+        @latestworld
+        @test fmap634b() == 42
+        sleep(mtimedelay)
+        Revise.track(bump40, script2)
+        sleep(mtimedelay)
+        write(script2, "fmap634b() = 3\n")
+        @yry()
+        @test fmap634b() == 43
+
+        # A revision that introduces `include(mapexpr, file)` into a package starts
+        # tracking the file with its transform. This path discovers the transform from
+        # the revised code itself, so it works on all supported Julia versions.
+        dn = joinpath(testdir, "MapExprRT", "src")
+        mkpath(dn)
+        top_rt(inc) = """
+            module MapExprRT
+            function bump(ex)
+                if Meta.isexpr(ex, :(=), 2)
+                    rhs = ex.args[2]
+                    rhs isa Expr && rhs.head === :block && rhs.args[end] isa Int && (rhs.args[end] += 40)
+                end
+                return ex
+            end
+            f() = 1
+            $inc
+            end
+            """
+        write(joinpath(dn, "MapExprRT.jl"), top_rt(""))
+        sleep(mtimedelay)
+        @eval using MapExprRT
+        @test MapExprRT.f() == 1
+        sleep(mtimedelay)
+        write(joinpath(dn, "b_rt.jl"), "g() = 2\n")
+        write(joinpath(dn, "MapExprRT.jl"), top_rt("include(bump, \"b_rt.jl\")"))
+        @yry()
+        @test MapExprRT.g() == 42
+        # Subsequent revisions of the included file re-apply the transform
+        sleep(mtimedelay)
+        write(joinpath(dn, "b_rt.jl"), "g() = 3\n")
+        @yry()
+        @test MapExprRT.g() == 43
+        # Method deletion works through the transform
+        sleep(mtimedelay)
+        write(joinpath(dn, "b_rt.jl"), "h() = 4\n")
+        @yry()
+        @test MapExprRT.h() == 44
+        @test_throws MethodError MapExprRT.g()
+        rm_precompile("MapExprRT")
+
+        # For `include(mapexpr, file)` executed while a package loads (including from its
+        # precompile cache), the transform is discovered from the record kept by
+        # `Base.include_mapexprs` (Julia ≥ 1.14).
+        if isdefined(Base, :include_mapexprs)
+            dn = joinpath(testdir, "MapExprPC", "src")
+            mkpath(dn)
+            top_pc(f) = """
+                module MapExprPC
+                function mkbump(n)
+                    return function (ex)
+                        if Meta.isexpr(ex, :(=), 2)
+                            rhs = ex.args[2]
+                            if rhs isa Expr && rhs.head === :block && rhs.args[end] isa Int
+                                rhs.args[end] += n
+                            end
+                        end
+                        return ex
+                    end
+                end
+                const pcbump40 = mkbump(40)   # closures capturing load-time state
+                const pcbump50 = mkbump(50)
+                include($f, "b_pc.jl")
+                module Sub end
+                Base.include(pcbump50, Sub, "c_pc.jl")
+                include(pcbump40, "c_pc.jl")
+                end
+                """
+            write(joinpath(dn, "MapExprPC.jl"), top_pc("pcbump40"))
+            write(joinpath(dn, "b_pc.jl"), "g() = 2\n")
+            write(joinpath(dn, "c_pc.jl"), "h() = 2\n")
+            sleep(mtimedelay)
+            @eval using MapExprPC
+            @test MapExprPC.g() == 42        # pcbump40 applied at load (Base behavior)
+            @test MapExprPC.Sub.h() == 52    # include(mapexpr, mod, path) into Sub
+            @test MapExprPC.h() == 42        # same file, different transform, into the root
+            # Revise recorded each inclusion's transform
+            pkgdata = Revise.pkgdatas[Base.PkgId(MapExprPC)]
+            @test Revise.fileinfo(pkgdata, "src/b_pc.jl").mapexpr === MapExprPC.pcbump40
+            @test Revise.fileinfo(pkgdata, "src/MapExprPC.jl").mapexpr === identity
+            # A file included twice with different transforms revises under each
+            sleep(mtimedelay)
+            write(joinpath(dn, "c_pc.jl"), "h() = 3\n")
+            @yry()
+            @test MapExprPC.Sub.h() == 53
+            @test MapExprPC.h() == 43
+            # Editing the `include(mapexpr, ...)` statement itself re-diffs the file under
+            # the new transform, replacing (not duplicating) the tracked entry
+            sleep(mtimedelay)
+            write(joinpath(dn, "MapExprPC.jl"), top_pc("pcbump50"))
+            @yry()
+            @test MapExprPC.g() == 52
+            idxs = Revise.fileindices(pkgdata, "src/b_pc.jl")
+            @test length(idxs) == 1
+            @test pkgdata.fileinfos[only(idxs)].mapexpr === MapExprPC.pcbump50
+            # ...and later revisions of the file use the new transform
+            sleep(mtimedelay)
+            write(joinpath(dn, "b_pc.jl"), "g() = 4\n")
+            @yry()
+            @test MapExprPC.g() == 54
+            rm_precompile("MapExprPC")
+        end
+
+        pop!(LOAD_PATH)
+    end
+
     do_test("IJulia preexecute hook") && @testset "IJulia preexecute hook" begin
         # IJulia reloads code by registering `Revise.revise` as a preexecute
         # hook (IJulia.push_preexecute_hook) and invoking every hook before each
@@ -5091,7 +5256,7 @@ do_test("@require path switch") && @testset "@require path switch" begin
     # empty `mod_exs_infos` plus an unprocessed `cacheexpr` and no cache file, which
     # drives `switch_basepath` into its read-from-disk fallback.
     reqfile = joinpath("src", "Issue678.jl") * Revise.requires_suffix
-    fi = Revise.FileInfo(Revise.ModuleExprsInfos(), "", "",
+    fi = Revise.FileInfo(Revise.ModuleExprsInfos(), identity, "", "",
                          Tuple{Module,Expr}[(mod, :(g() = 42))], Ref(false), Ref(false))
     push!(pkgdata, reqfile=>fi)
     @test Revise.is_requires_file(reqfile)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1116,6 +1116,17 @@ end
         @yry()
         @test MapExprRT.h() == 44
         @test_throws MethodError MapExprRT.g()
+        # The three-argument `include(mapexpr, mod, path)` targets another module
+        sleep(mtimedelay)
+        write(joinpath(dn, "c_rt.jl"), "k() = 5\n")
+        write(joinpath(dn, "MapExprRT.jl"),
+              top_rt("include(bump, \"b_rt.jl\")\nmodule SubRT end\nBase.include(bump, SubRT, \"c_rt.jl\")"))
+        @yry()
+        @test MapExprRT.SubRT.k() == 45
+        sleep(mtimedelay)
+        write(joinpath(dn, "c_rt.jl"), "k() = 6\n")
+        @yry()
+        @test MapExprRT.SubRT.k() == 46
         rm_precompile("MapExprRT")
 
         # For `include(mapexpr, file)` executed while a package loads (including from its


### PR DESCRIPTION
Revising a file included with a non-identity `mapexpr` now re-applies the same transform to each top-level expression, matching `Base.include_string` semantics; previously the transform was silently dropped, so revised code lost the effects of tools like DispatchDoctor's `@stable` wrapping.

Each tracked inclusion (`FileInfo`) records its `mapexpr`. The transform is discovered:
- at package load from `Base.include_mapexprs` (Julia >= 1.14), which records the function objects in the package image;
- at revision time from intercepted `include(mapexpr, ...)` calls, which also handles transforms introduced or edited during a session (the tracked entry is re-diffed under the new transform);
- from the caller for `includet(mapexpr, file)` and `Revise.track(mapexpr, [mod], file)`, which now accept a leading transform.

A file included more than once with different transforms has one entry per inclusion. On Julia < 1.14, transforms used while a package loads remain undiscoverable and revision keeps its prior (dropping) behavior; see the limitations docs.

Julia 1.14+ fix was enabled by https://github.com/JuliaLang/julia/pull/62176

Fixes #634; fixes #820
Closes #939