### PR TITLE
Revise only changed files when a package moves

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -639,11 +639,7 @@ function watch_manifest(mfile::String)
     end
 end
 
-"""
-    same_contents(file1, file2)
-
-Return `true` if both paths are files with identical contents.
-"""
+# Return `true` if both paths are files with identical contents.
 function same_contents(file1::AbstractString, file2::AbstractString)
     (isfile(file1) && isfile(file2)) || return false
     filesize(file1) == filesize(file2) || return false

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -639,22 +639,40 @@ function watch_manifest(mfile::String)
     end
 end
 
+"""
+    same_contents(file1, file2)
+
+Return `true` if both paths are files with identical contents.
+"""
+function same_contents(file1::AbstractString, file2::AbstractString)
+    (isfile(file1) && isfile(file2)) || return false
+    filesize(file1) == filesize(file2) || return false
+    return read(file1) == read(file2)
+end
+
 function switch_basepath(pkgdata::PkgData, newpath::String)
+    oldpath = basedir(pkgdata)
     # Stop all associated watching tasks
     for dir in unique_dirs(srcfiles(pkgdata))
         @debug "Pkg" _group="unwatch" dir=dir
-        @lock revise_lock delete!(watched_files, joinpath(basedir(pkgdata), dir))
+        @lock revise_lock delete!(watched_files, joinpath(oldpath, dir))
         # Note: if the file is revised, the task(s) will run one more time.
         # However, because we've removed the directory from the watch list this will be a no-op,
         # and then the tasks will be dropped.
     end
     # Revise code as needed
-    files = String[]
+    watchfiles = String[]
     mustnotify = false
     for file in srcfiles(pkgdata)
         # issue #678: `@require` blocks are tracked under a synthetic filename with no
         # file on disk; reading or watching it as a real path would error.
         is_requires_file(file) && continue
+        push!(watchfiles, file)
+        # A file that is byte-identical in the new directory defines what the module
+        # already contains, so there is nothing to revise. Skipping it also avoids the
+        # signature extraction below, which re-executes macro expansions that define
+        # types or constants; those error when the definition is already present.
+        same_contents(joinpath(oldpath, file), joinpath(newpath, file)) && continue
         fi = try
             maybe_parse_from_cache!(pkgdata, file)
         catch
@@ -662,7 +680,7 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
             # Get the source-text from the package source instead
             fi = fileinfo(pkgdata, file)
             if isempty(fi.mod_exs_infos) && (!isempty(fi.cachefile) || !isempty(fi.cacheexprs))
-                filep = joinpath(basedir(pkgdata), file)
+                filep = joinpath(oldpath, file)
                 src = read(filep, String)
                 topmod = first(keys(fi.mod_exs_infos))
                 if !parse_and_maybe_eval_source!(fi.mod_exs_infos, src, filep, topmod; mapexpr=fi.mapexpr).success
@@ -676,7 +694,6 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
         end
         maybe_extract_sigs_or_queue_error!(pkgdata, file, fi)
         @lock revise_lock push!(revision_queue, (pkgdata, file))
-        push!(files, file)
         mustnotify = true
     end
     mustnotify && notify(revision_event)
@@ -684,7 +701,7 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
     pkgdata.info.basedir = newpath
     # Restart watching, if applicable
     if has_writable_paths(pkgdata)
-        init_watching(pkgdata, files)
+        init_watching(pkgdata, watchfiles)
     end
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5305,6 +5305,51 @@ do_test("@require path switch") && @testset "@require path switch" begin
     @test Revise.basedir(pkgdata) == newdir
 end
 
+do_test("Unchanged files across a path switch") && @testset "Unchanged files across a path switch" begin
+    # A package directory can change while most of its files stay as they are: a
+    # `Pkg.develop`ed copy of a release, or a new release that edits only part of its
+    # source. `switch_basepath` revises the files that differ and leaves the rest alone,
+    # because extracting signatures re-executes macro expansions that define types or
+    # constants, which fails once those definitions exist.
+    mod = Module(:PathSwitch)
+    Core.eval(mod, :(using Base))
+    id = Base.PkgId(Base.UUID("00000000-0000-0000-0000-000000000679"), "PathSwitch")
+    olddir, newdir = mktempdir(), mktempdir()
+    mkpath(joinpath(olddir, "src"))
+    mkpath(joinpath(newdir, "src"))
+
+    samefile, changedfile = joinpath("src", "same.jl"), joinpath("src", "changed.jl")
+    write(joinpath(olddir, samefile), "f() = 1\n")
+    write(joinpath(newdir, samefile), "f() = 1\n")
+    write(joinpath(olddir, changedfile), "g() = 1\n")
+    write(joinpath(newdir, changedfile), "g() = 2\n")
+
+    pkgdata = Revise.PkgData(id, olddir)
+    for (file, ex) in ((samefile, :(f() = 1)), (changedfile, :(g() = 1)))
+        mei = Revise.ModuleExprsInfos(mod)
+        mei[mod][Revise.RelocatableExpr(ex)] = nothing
+        push!(pkgdata, file=>Revise.FileInfo(mei))
+    end
+
+    try
+        Revise.switch_basepath(pkgdata, newdir)
+        @test Revise.basedir(pkgdata) == newdir
+        @test (pkgdata, changedfile) ∈ Revise.revision_queue
+        @test (pkgdata, samefile) ∉ Revise.revision_queue
+        # Signatures are extracted only for the file that is queued.
+        @test Revise.fileinfo(pkgdata, changedfile).extracted[]
+        @test !Revise.fileinfo(pkgdata, samefile).extracted[]
+        # Both files are watched at the new location, queued or not.
+        watchlist = Revise.watched_files[joinpath(newdir, "src")]
+        @test haskey(watchlist.trackedfiles, "same.jl")
+        @test haskey(watchlist.trackedfiles, "changed.jl")
+    finally
+        filter!(pr -> first(pr) !== pkgdata, Revise.revision_queue)
+        delete!(Revise.watched_files, joinpath(olddir, "src"))
+        delete!(Revise.watched_files, joinpath(newdir, "src"))
+    end
+end
+
 do_test("Switching environments") && @testset "Switching environments" begin
     old_project = Base.active_project()
 


### PR DESCRIPTION
`switch_basepath` queued every source file of a package whenever the manifest pointed it at a new directory. Most of those files are usually identical at both locations: `Pkg.develop` can select a copy of the release that is loaded, and successive releases of a package share most of their source. Revising a file extracts its signatures, which lowers each expression and so re-expands its macros. A macro that defines a type or a constant as it expands throws the second time around, and that error costs the whole file its signatures.

Files the new directory holds verbatim are now left alone. Every file is watched at the new location whether or not it was queued, so later edits are picked up as before.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>