### PR TITLE
ci: Keep REPL tests active with EOF stdin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         echo "Methods at REPL"
         TERM="xterm" julia --project --code-coverage=user -e '
           using InteractiveUtils, REPL, Revise
+          # Keep the REPL alive while GitHub Actions stdin is at EOF.
+          input = redirect_stdin()
           t = @async(
             VERSION >= v"1.12.0-DEV.612" ? Base.run_main_repl(true, true, :no, true) :
             VERSION >= v"1.11.0-DEV.222" ? Base.run_main_repl(true, true, :no, true, false)   :

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4904,22 +4904,29 @@ end
     do_test("Methods at REPL") && @testset "Methods at REPL" begin
         if isdefined(Base, :active_repl) && !isnothing(Base.active_repl)
             hp = Base.active_repl.interface.modes[1].hist
-            # The element type of `hp.history` changed from `String` to
-            # `REPL.History.HistEntry` in Julia 1.14; wrap accordingly.
-            push_hist! = if isdefined(REPL, :History) && isdefined(REPL.History, :HistEntry)
-                (h, s) -> push!(h.history, REPL.History.HistEntry(
-                    :julia, Dates.now(), s, UInt32(length(h.history) + 1)))
+            # REPL history changed from `Vector{String}` to `HistoryFile` in Julia
+            # 1.14. Work with its in-memory records so test entries are not persisted.
+            history = if isdefined(REPL, :History) &&
+                    isdefined(REPL.History, :HistoryFile) &&
+                    hp.history isa REPL.History.HistoryFile
+                hp.history.records
             else
-                (h, s) -> push!(h.history, s)
+                hp.history
+            end
+            push_hist! = if isdefined(REPL, :History) && isdefined(REPL.History, :HistEntry)
+                (h, s) -> push!(h, REPL.History.HistEntry(
+                    :julia, Dates.now(), s, UInt32(length(h) + 1)))
+            else
+                (h, s) -> push!(h, s)
             end
             fstr = "__fREPL__(x::Int16) = 0"
-            histidx = length(hp.history) + 1 - hp.start_idx
+            histidx = length(history) + 1 - hp.start_idx
             ex = Base.parse_input_line(fstr; filename="REPL[$histidx]")
             f = Core.eval(Main, ex)
             if ex.head === :toplevel
                 ex = ex.args[end]
             end
-            push_hist!(hp, fstr)
+            push_hist!(history, fstr)
             m = first(methods(f))
             @test !isempty(signatures_at(String(m.file), m.line))
             @test isequal(Revise.RelocatableExpr(definition(m)), Revise.RelocatableExpr(ex))
@@ -4927,20 +4934,20 @@ end
 
             # Test that revisions work (https://github.com/timholy/CodeTracking.jl/issues/38)
             fstr = "__fREPL__(x::Int16) = 1"
-            histidx = length(hp.history) + 1 - hp.start_idx
+            histidx = length(history) + 1 - hp.start_idx
             ex = Base.parse_input_line(fstr; filename="REPL[$histidx]")
             f = Core.eval(Main, ex)
             if ex.head === :toplevel
                 ex = ex.args[end]
             end
-            push_hist!(hp, fstr)
+            push_hist!(history, fstr)
             m = first(methods(f))
             @test isequal(Revise.RelocatableExpr(definition(m)), Revise.RelocatableExpr(ex))
             @test definition(String, m)[1] == fstr
             @test !isempty(signatures_at(String(m.file), m.line))
 
-            pop!(hp.history)
-            pop!(hp.history)
+            pop!(history)
+            pop!(history)
         else
             @warn "REPL tests skipped"
         end

--- a/test/start_late.jl
+++ b/test/start_late.jl
@@ -2,7 +2,10 @@
 # Catches #664
 
 using Test
+using REPL
 
+# Keep the REPL alive when the test process receives EOF on stdin.
+input = redirect_stdin()
 t = @async(
     VERSION >= v"1.12.0-DEV.612" ? Base.run_main_repl(true, true, :no, true) :
     VERSION >= v"1.11.0-DEV.222" ? Base.run_main_repl(true, true, :no, true, false)   :
@@ -15,4 +18,4 @@ end
 using Revise
 @test Revise.revise_first ∈ Base.active_repl_backend.ast_transforms
 
-exit()
+REPL.eval_user_input(:(exit()), Base.active_repl_backend, Main)


### PR DESCRIPTION
GitHub Actions provides EOF on stdin, so the asynchronously started REPL could exit before the `Methods at REPL` test. The workflow relied on a Julia bug that left `active_repl_backend` set after `run_std_repl` returned. JuliaLang/julia#62531 fixed that restoration, so the backend now becomes `nothing` and the final `eval_user_input` call fails.

Keep the REPL alive with a redirected stdin pipe for the duration of the test. Once the test runs on Julia 1.14, use `HistoryFile.records` for its temporary entries because `HistoryFile` does not implement `pop!`. Retain the vector-backed history path on older Julia versions.

The focused `Methods at REPL` test passes on Julia 1.10 and nightly.