### PR TITLE
Handle rewritten cache files 

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -56,6 +56,7 @@ Revise.PkgData
 Revise.WatchList
 Revise.TaskThunk
 Revise.ReviseEvalException
+Revise.StaleCacheError
 Revise.SignatureExtractionError
 MethodSummary
 ```
@@ -99,7 +100,9 @@ Revise.remove_callback
 
 ```@docs
 Revise.revise_file_now
+Revise.hold_cache!
 Revise.cache_snapshot_is_valid
+Revise.cached_source_is_current
 ```
 
 Revise pins its own method dispatch to the world age captured at initialization, so that

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -33,6 +33,7 @@ Revise.queue_errors
 Revise.duplicated_signatures
 Revise.included_files
 Revise.watched_manifests
+Revise.rewritten_caches
 ```
 
 The following are specific to user callbacks (see [`Revise.add_callback`](@ref)) and
@@ -98,6 +99,7 @@ Revise.remove_callback
 
 ```@docs
 Revise.revise_file_now
+Revise.cache_snapshot_is_valid
 ```
 
 Revise pins its own method dispatch to the world age captured at initialization, so that

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -340,3 +340,18 @@ No version restriction applies to [`includet`](@ref)/[`Revise.track`](@ref) (whi
 accept a leading `mapexpr` of their own) or to `include(mapexpr, filename)` statements
 *added* to an already-loaded package, since those transforms are discovered without
 the load-time record.
+
+### Precompilation by another process discards Revise's baseline
+
+For a precompiled package, Revise reads the "before" state of a source file from the
+package's `*.ji` cache, and does so only when that file is first revised. The path of the
+cache is determined by the active project and the compile flags rather than by the source,
+so a `using` or `Pkg.precompile` in a *separate* process — running the test suite or a
+script in a fresh Julia while an interactive session stays open — overwrites the very file
+Revise recorded, and with it the snapshot of the code the session is running.
+
+Revise detects this, because a cache's build id changes with every precompilation, and
+warns. Edited files of that package are then evaluated in full rather than by difference:
+their current definitions are applied, but definitions that the edits *removed* cannot be
+identified and remain in force. Restart Julia if you need a session guaranteed to match
+the source.

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -353,5 +353,6 @@ Revise recorded, and with it the snapshot of the code the session is running.
 Revise detects this, because a cache's build id changes with every precompilation, and
 warns. Edited files of that package are then evaluated in full rather than by difference:
 their current definitions are applied, but definitions that the edits *removed* cannot be
-identified and remain in force. Restart Julia if you need a session guaranteed to match
-the source.
+identified and remain in force. Revision of that package is best-effort from then on, so
+the prompt stays yellow for the rest of the session. Restart Julia if you need a session
+guaranteed to match the source.

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -341,18 +341,22 @@ accept a leading `mapexpr` of their own) or to `include(mapexpr, filename)` stat
 *added* to an already-loaded package, since those transforms are discovered without
 the load-time record.
 
-### Precompilation by another process discards Revise's baseline
+### Precompilation by another process can discard Revise's baseline
 
 For a precompiled package, Revise reads the "before" state of a source file from the
 package's `*.ji` cache, and does so only when that file is first revised. The path of the
 cache is determined by the active project and the compile flags rather than by the source,
 so a `using` or `Pkg.precompile` in a *separate* process — running the test suite or a
-script in a fresh Julia while an interactive session stays open — overwrites the very file
-Revise recorded, and with it the snapshot of the code the session is running.
+script in a fresh Julia while an interactive session stays open — replaces the very file
+Revise recorded.
 
-Revise detects this, because a cache's build id changes with every precompilation, and
-warns. Edited files of that package are then evaluated in full rather than by difference:
-their current definitions are applied, but definitions that the edits *removed* cannot be
-identified and remain in force. Revision of that package is best-effort from then on, so
-the prompt stays yellow for the rest of the session. Restart Julia if you need a session
-guaranteed to match the source.
+On platforms where an open handle stays attached to a file that has been renamed away,
+Revise holds one on each cache it watches, so the snapshot survives the rebuild and
+revision continues normally. Elsewhere, a rebuilt cache costs nothing as long as it was
+built from the same source; only a file whose content differs between the build the
+session loaded and the build now on disk loses its baseline. For such a file there is
+nothing left to compare an edit against, so Revise does not guess: it makes no attempt to
+revise it, raises a [`Revise.StaleCacheError`](@ref) naming the file, and turns the prompt
+yellow for the rest of the session. The file's definitions stay as the session loaded
+them; restart Julia to pick up their current state. Every other file, and every other
+package, continues to revise as usual.

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -76,6 +76,7 @@ function parse_pkg_files(id::PkgId)
         if cachefile_includes_reqs_buildid !== nothing
             cachefile, includes, reqs, buildid = cachefile_includes_reqs_buildid
             pkgdata.requirements = reqs
+            pkgdata.cachebuildid = buildid
             if isdefined(Base, :maybe_loaded_precompile) && (mod′ = Base.maybe_loaded_precompile(id, buildid); mod′ isa Module)
                 root = mod′
             elseif isdefined(Base, :loaded_precompiles) && haskey(Base.loaded_precompiles, id => buildid)

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -3,15 +3,23 @@ function pkg_fileinfo(id::PkgId)
     origin === nothing && return nothing
     cachepath = origin.cachepath
     cachepath === nothing && return nothing
+    return pkg_fileinfo(id, cachepath, nothing)
+end
+
+# `io`, when given, is a handle already open on `cachepath` (see `Revise.hold_cache!`);
+# it is rewound and left open, and reports the file it is attached to rather than
+# whatever now occupies `cachepath`.
+function pkg_fileinfo(id::PkgId, cachepath::AbstractString, io::Union{Nothing,IOStream})
     local checksum
     provides, includes_requires, required_modules = try
         ret = @static if VERSION ≥ v"1.11.0-DEV.683" # https://github.com/JuliaLang/julia/pull/49866
-            io = open(cachepath, "r")
-            checksum = Base.isvalid_cache_header(io)
-            iszero(checksum) && (close(io); return nothing)
+            ownio = io === nothing
+            iou = ownio ? open(cachepath, "r") : (seekstart(io); io)
+            checksum = Base.isvalid_cache_header(iou)
+            iszero(checksum) && (ownio && close(iou); return nothing)
             provides, (_, includes_srcfiles_only, requires), required_modules, _... =
-                Base.parse_cache_header(io, cachepath)
-            close(io)
+                Base.parse_cache_header(iou, cachepath)
+            ownio && close(iou)
             provides, (includes_srcfiles_only, requires), required_modules
         else
             checksum = UInt64(0) # Buildid prior to v"1.12.0-DEV.764", and the `srcfiles_only` API does not take `io`
@@ -107,7 +115,7 @@ function parse_pkg_files(id::PkgId)
                 # from the *.ji cachefile. Keep `chi.filename` itself: that is the exact key
                 # the cache is indexed by, and reconstructing it from `fname` is unreliable
                 # when path forms diverge (e.g. symlinks, see #1033).
-                push!(pkgdata, fname=>FileInfo(mod, cachefile, chi.filename; mapexpr))
+                push!(pkgdata, fname=>FileInfo(mod, cachefile, chi.filename; mapexpr, cachesrcid=cache_src_id(chi)))
             end
             if mapexprs !== nothing && length(matched_mapexprs) != length(mapexprs)
                 unmatched = [key for key in keys(mapexprs) if key ∉ matched_mapexprs]

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -356,6 +356,19 @@ haspkgdata(id::PkgId) = @lock revise_lock haskey(pkgdatas, id)
 allpkgdatas() = @lock revise_lock collect(values(pkgdatas))
 
 """
+    Revise.rewritten_caches
+
+Set of packages whose precompile cache file was rebuilt or removed by another process
+after this session loaded the package. The path of a cache file is determined by the
+active project and the compile flags rather than by the source, so a `using` or
+`Pkg.precompile` in a separate process overwrites the very file this session recorded.
+Its stored source snapshot then describes neither the running code nor any state this
+session held, so it is not used as a revision baseline; edits to the affected files are
+evaluated in full instead.
+"""
+const rewritten_caches = Set{PkgId}()
+
+"""
     Revise.included_files
 
 Global variable, `included_files` gets populated by callbacks we register with `include`.

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -364,7 +364,9 @@ active project and the compile flags rather than by the source, so a `using` or
 `Pkg.precompile` in a separate process overwrites the very file this session recorded.
 Its stored source snapshot then describes neither the running code nor any state this
 session held, so it is not used as a revision baseline; edits to the affected files are
-evaluated in full instead.
+evaluated in full instead. Revision of these packages is best-effort, and nothing short
+of a restart can undo that, so a non-empty `rewritten_caches` keeps the prompt yellow for
+the rest of the session.
 """
 const rewritten_caches = Set{PkgId}()
 
@@ -1818,7 +1820,10 @@ function _revise(; throw::Bool=false)
         # "Method overwriting is not permitted during Module precompilation" (issue #889).
         dupworld = Base.get_world_counter()
         warn_duplicated_signatures(update_duplicated_signatures!(dupworld), dupworld)
-        if isempty(queue_errors) && isempty(duplicated_signatures)
+        # A package in `rewritten_caches` keeps the prompt yellow for the rest of the
+        # session: revision of such a package is best-effort (see `cache_snapshot_is_valid`)
+        # and only a restart can restore a session that provably matches the source.
+        if isempty(queue_errors) && isempty(duplicated_signatures) && isempty(rewritten_caches)
             maybe_set_prompt_color(:ok)
         else
             maybe_set_prompt_color(:warn)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -358,15 +358,19 @@ allpkgdatas() = @lock revise_lock collect(values(pkgdatas))
 """
     Revise.rewritten_caches
 
-Set of packages whose precompile cache file was rebuilt or removed by another process
-after this session loaded the package. The path of a cache file is determined by the
-active project and the compile flags rather than by the source, so a `using` or
+Set of packages that have lost the source snapshot of at least one file because another
+process rebuilt or removed their precompile cache. The path of a cache file is determined
+by the active project and the compile flags rather than by the source, so a `using` or
 `Pkg.precompile` in a separate process overwrites the very file this session recorded.
-Its stored source snapshot then describes neither the running code nor any state this
-session held, so it is not used as a revision baseline; edits to the affected files are
-evaluated in full instead. Revision of these packages is best-effort, and nothing short
-of a restart can undo that, so a non-empty `rewritten_caches` keeps the prompt yellow for
-the rest of the session.
+
+Revise compares an edit against the source the session loaded, so for a file whose
+snapshot is gone there is nothing to compare against and no revision is attempted: the
+file's definitions stay as they were, and each attempt raises a
+[`Revise.StaleCacheError`](@ref). Only a restart recovers them, so a non-empty
+`rewritten_caches` keeps the prompt yellow for the rest of the session. Files whose source
+was identical in both builds, and every other package, are unaffected; where
+[`Revise.hold_cache!`](@ref) applies, the snapshot survives the rebuild and nothing is
+lost at all.
 """
 const rewritten_caches = Set{PkgId}()
 
@@ -1480,7 +1484,7 @@ function errors(revision_errors=keys(queue_errors))
         pkgdata, file = item
         (err, bt) = queue_errors[(pkgdata, file)]
         fullpath = joinpath(basedir(pkgdata), file)
-        if (err isa ReviseEvalException ||
+        if (err isa ReviseEvalException || err isa StaleCacheError ||
             (err isa SignatureExtractionError && captured_stacktrace(err) !== nothing))
             @error "Failed to revise $fullpath" exception=(err, nothing)
         else
@@ -2220,7 +2224,9 @@ function get_def(method::Method; modified_files=revision_queue)
 end
 
 function get_def(method, pkgdata, filename)
-    maybe_extract_sigs!(maybe_parse_from_cache!(pkgdata, filename))
+    fi = try_parse_from_cache!(pkgdata, filename)
+    fi === nothing && return nothing
+    maybe_extract_sigs!(fi)
     return get(CodeTracking.method_info, MethodInfoKey(method), nothing)
 end
 
@@ -2244,7 +2250,8 @@ get_tracked_id(mod::Module; modified_files=revision_queue) =
 function get_expressions(id::PkgId, filename)
     get_tracked_id(id)
     pkgdata = @lock revise_lock pkgdatas[id]
-    fi = maybe_parse_from_cache!(pkgdata, filename)
+    fi = try_parse_from_cache!(pkgdata, filename)
+    fi === nothing && return nothing
     maybe_extract_sigs!(fi)
     return fi.mod_exs_infos
 end

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -124,7 +124,7 @@ function cache_snapshot_is_valid(pkgdata::PkgData)
     @warn """The precompile cache for $(id.name) is no longer the one this session loaded; another process rebuilt or removed it.
         Revise compares edits against the source snapshot stored in that cache, and no snapshot of the running code remains.
         Edited files of $(id.name) are therefore evaluated in full rather than by difference; definitions that the edits removed cannot be identified and stay in force.
-        Restart Julia for a session guaranteed to match the source."""
+        Revision is best-effort from here on, so your prompt color will be yellow for the rest of this session. Restart Julia for a session guaranteed to match the source."""
     return false
 end
 

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -91,7 +91,53 @@ function read_from_cache(pkgdata::PkgData, file::AbstractString, fi::FileInfo)
     # up by the filename the cache was indexed with rather than one reconstructed from
     # `basedir` (which can diverge in form, e.g. across symlinks; see #1033).
     lookup = isempty(fi.cachefilename) ? filep : fi.cachefilename
-    Base.read_dependency_src(fi.cachefile, lookup)
+    io = pkgdata.cacheio
+    io === nothing && return Base.read_dependency_src(fi.cachefile, lookup)
+    seekstart(io)
+    iszero(Base.isvalid_cache_header(io)) && throw(ArgumentError("invalid header in cache file $(fi.cachefile)"))
+    return Base.read_dependency_src(io, fi.cachefile, lookup)
+end
+
+# Whether this platform and Julia version support keeping the snapshot alive with an open
+# handle. On Windows a held handle can block the other process from replacing the file, and
+# reading a cache through a handle needs the header API of Julia 1.11+.
+can_hold_cache() = !Sys.iswindows() && VERSION >= v"1.11.0-DEV.683"
+
+"""
+    Revise.hold_cache!(pkgdata)
+
+Keep a handle open on `pkgdata`'s precompile cache file, so that the source snapshot it
+holds stays readable for as long as the session runs.
+
+Julia replaces a cache file by renaming a freshly built one over it. On platforms where
+that leaves existing handles attached to the original file, a handle opened here still
+reads the snapshot this session loaded even after another process rebuilds the cache;
+[`Revise.cache_snapshot_is_valid`](@ref) then finds the cache intact and revision
+proceeds normally. Where a held handle would instead block the other process from
+replacing the file, no handle is taken and the rebuild is handled by detection.
+"""
+function hold_cache!(pkgdata::PkgData)
+    can_hold_cache() || return pkgdata
+    pkgdata.cacheio === nothing || return pkgdata
+    isempty(srcfiles(pkgdata)) && return pkgdata
+    cachefile = fileinfo(pkgdata, 1).cachefile
+    (isempty(cachefile) || cachefile == basesrccache) && return pkgdata
+    pkgdata.cacheio = try
+        open(cachefile, "r")
+    catch
+        nothing
+    end
+    return pkgdata
+end
+
+# Identifies the source text a precompile cache holds for one file, so that a cache
+# rebuilt from unchanged source is recognized as still carrying the same snapshot.
+# Julia 1.11+ records a size and a content hash; 1.10 records only the source file's
+# mtime, so on that version a file merely touched between two builds reads as changed.
+@static if VERSION >= v"1.11.0-DEV.683"    # https://github.com/JuliaLang/julia/pull/49866
+    cache_src_id(inc) = hash(inc.fsize, UInt64(inc.hash))
+else
+    cache_src_id(inc) = hash(inc.mtime)
 end
 
 function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString)
@@ -103,41 +149,68 @@ end
 """
     Revise.cache_snapshot_is_valid(pkgdata) -> Bool
 
-Whether the source snapshot stored in `pkgdata`'s precompile cache still describes the
-code this session loaded. Every precompilation mints a new build id, so a cache whose
+Whether the precompile cache Revise reads `pkgdata`'s source snapshots from is still the
+one this session loaded. Every precompilation mints a new build id, so a cache whose
 build id has changed, or that has gone missing, was rebuilt or removed by another
-process, and its snapshot is unusable as a revision baseline. The first such observation
-records the package in [`Revise.rewritten_caches`](@ref) and warns.
+process. A handle held by [`Revise.hold_cache!`](@ref) keeps the original readable, in
+which case the check passes and nothing is lost; otherwise the individual files that
+changed between the two builds lose their baseline (see
+[`Revise.cached_source_is_current`](@ref)).
 """
 function cache_snapshot_is_valid(pkgdata::PkgData)
     pkgdata.cachebuildid == 0 && return true   # not loaded from a cache; nothing to compare against
-    id = PkgId(pkgdata)
-    @lock revise_lock begin
-        id ∈ rewritten_caches && return false
-        cachedata = pkg_fileinfo(id)   # re-reads the header of the cache file on disk
-        if cachedata !== nothing
-            _, _, _, buildid = cachedata
-            buildid == pkgdata.cachebuildid && return true
-        end
-        push!(rewritten_caches, id)
+    cachedata = current_cachedata(pkgdata)
+    cachedata === nothing && return false
+    _, _, _, buildid = cachedata
+    return buildid == pkgdata.cachebuildid
+end
+
+# Header of the cache Revise can still read for this package: through the held handle when
+# there is one, since that reports the file the handle is attached to rather than whatever
+# now occupies the path.
+function current_cachedata(pkgdata::PkgData)
+    io = pkgdata.cacheio
+    io === nothing && return pkg_fileinfo(PkgId(pkgdata))
+    return pkg_fileinfo(PkgId(pkgdata), fileinfo(pkgdata, 1).cachefile, io)
+end
+
+"""
+    Revise.cached_source_is_current(pkgdata, fi) -> Bool
+
+Whether the source snapshot Revise can still read for the file described by `fi` is the
+one this session loaded. A cache rebuilt from unchanged source carries the same snapshot
+and remains a valid baseline; only the files whose content differs between the build this
+session loaded and the build now on disk lose theirs.
+"""
+function cached_source_is_current(pkgdata::PkgData, fi::FileInfo)
+    cache_snapshot_is_valid(pkgdata) && return true
+    fi.cachesrcid === nothing && return false     # nothing recorded to compare against
+    cachedata = current_cachedata(pkgdata)
+    cachedata === nothing && return false
+    _, includes, _, _ = cachedata
+    for inc in includes
+        inc.filename == fi.cachefilename && return cache_src_id(inc) == fi.cachesrcid
     end
-    @warn """The precompile cache for $(id.name) is no longer the one this session loaded; another process rebuilt or removed it.
-        Revise compares edits against the source snapshot stored in that cache, and no snapshot of the running code remains.
-        Edited files of $(id.name) are therefore evaluated in full rather than by difference; definitions that the edits removed cannot be identified and stay in force.
-        Revision is best-effort from here on, so your prompt color will be yellow for the rest of this session. Restart Julia for a session guaranteed to match the source."""
     return false
+end
+
+# Record the loss and warn once per package, then let the caller report the individual
+# files. A package listed here keeps the prompt yellow for the rest of the session.
+function note_rewritten_cache(id::PkgId)
+    isnew = @lock revise_lock (id ∈ rewritten_caches ? false : (push!(rewritten_caches, id); true))
+    isnew || return nothing
+    @warn """The precompile cache of $(id.name) was rebuilt by another process after this session loaded it, and the source it held for one or more edited files is gone.
+        Revise compares an edit against the source the session loaded, so for those files there is nothing to compare against and no revision is attempted; each one is reported separately.
+        Other files of $(id.name), and every other package, continue to revise normally. Your prompt color will be yellow for the rest of this session; restart Julia to pick up the current state of the affected files."""
+    return nothing
 end
 
 function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString, fi::FileInfo)
     if (isempty(fi.mod_exs_infos) && !fi.parsed[]) && (!isempty(fi.cachefile) || !isempty(fi.cacheexprs))
-        if !isempty(fi.cachefile) && !cache_snapshot_is_valid(pkgdata)
-            # No trustworthy baseline: leave `mod_exs_infos` empty so that every expression
-            # in the current source counts as new. `cacheexprs` come from `@require` blocks
-            # this session evaluated, not from the cache, so they remain valid.
-            add_modexs!(fi, fi.cacheexprs)
-            empty!(fi.cacheexprs)
-            fi.parsed[] = true
-            return fi
+        if !isempty(fi.cachefile) && !cached_source_is_current(pkgdata, fi)
+            id = PkgId(pkgdata)
+            note_rewritten_cache(id)
+            throw(StaleCacheError(id, joinpath(basedir(pkgdata), file)))
         end
         # Source was never parsed, get it from the precompile cache
         src = read_from_cache(pkgdata, file, fi)
@@ -155,6 +228,18 @@ function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString, fi::Fil
         fi.parsed[] = true
     end
     return fi
+end
+
+# Reading the cache to look up where something was defined is best-effort: a file whose
+# snapshot is gone has no definitions to report. The loss is raised where it matters,
+# when the file is actually being revised.
+function try_parse_from_cache!(pkgdata::PkgData, file::AbstractString)
+    try
+        return maybe_parse_from_cache!(pkgdata, file)
+    catch err
+        err isa StaleCacheError || rethrow()
+        return nothing
+    end
 end
 
 function add_modexs!(fi::FileInfo, modexs::Vector{Tuple{Module,Expr}})
@@ -206,8 +291,8 @@ function maybe_extract_sigs_for_meths(meths)
             for file in srcfiles(pkgdata)
                 fi = fileinfo(pkgdata, file)
                 if is_not_populated(fi)
-                    fi = maybe_parse_from_cache!(pkgdata, file)
-                    instantiate_sigs!(fi.mod_exs_infos)
+                    fi = try_parse_from_cache!(pkgdata, file)
+                    fi === nothing || instantiate_sigs!(fi.mod_exs_infos)
                 end
             end
         end
@@ -222,8 +307,8 @@ function maybe_extract_sigs_for_types(types)
         for file in srcfiles(pkgdata)
             fi = fileinfo(pkgdata, file)
             if is_not_populated(fi)
-                fi = maybe_parse_from_cache!(pkgdata, file)
-                instantiate_sigs!(fi.mod_exs_infos)
+                fi = try_parse_from_cache!(pkgdata, file)
+                fi === nothing || instantiate_sigs!(fi.mod_exs_infos)
             end
         end
     end
@@ -270,7 +355,7 @@ function maybe_add_includes_to_pkgdata!(pkgdata::PkgData, file::AbstractString, 
             # subsequent diff vacuous and leaving the session stale.)
             maybe_parse_from_cache!(pkgdata, incrp, fi)
             pkgdata.fileinfos[stale_idx] = FileInfo(fi.mod_exs_infos, mapexpr, fi.cachefile, fi.cachefilename,
-                                                    fi.cacheexprs, fi.extracted, fi.parsed)
+                                                    fi.cachesrcid, fi.cacheexprs, fi.extracted, fi.parsed)
             # Re-diff the file under the new transform so the session catches up with
             # the new effective source.
             if eval_now
@@ -562,6 +647,7 @@ function watch_package(id::PkgId)
         pkgdata = parse_pkg_files(id)
         if has_writable_paths(pkgdata)
             init_watching(pkgdata, srcfiles(pkgdata))
+            hold_cache!(pkgdata)
         end
         pkgdatas[id] = pkgdata
         pkgdata
@@ -708,7 +794,14 @@ function switch_basepath(pkgdata::PkgData, newpath::String)
         same_contents(joinpath(oldpath, file), joinpath(newpath, file)) && continue
         fi = try
             maybe_parse_from_cache!(pkgdata, file)
-        catch
+        catch err
+            if err isa StaleCacheError
+                # No baseline to diff the new location against, and the old source on disk
+                # is not one either. Queue the file so `revise` reports the loss.
+                @lock revise_lock push!(revision_queue, (pkgdata, file))
+                mustnotify = true
+                continue
+            end
             # https://github.com/JuliaLang/julia/issues/42404
             # Get the source-text from the package source instead
             fi = fileinfo(pkgdata, file)

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -100,8 +100,45 @@ function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString)
     end
     return maybe_parse_from_cache!(pkgdata, file, fileinfo(pkgdata, file))
 end
+"""
+    Revise.cache_snapshot_is_valid(pkgdata) -> Bool
+
+Whether the source snapshot stored in `pkgdata`'s precompile cache still describes the
+code this session loaded. Every precompilation mints a new build id, so a cache whose
+build id has changed, or that has gone missing, was rebuilt or removed by another
+process, and its snapshot is unusable as a revision baseline. The first such observation
+records the package in [`Revise.rewritten_caches`](@ref) and warns.
+"""
+function cache_snapshot_is_valid(pkgdata::PkgData)
+    pkgdata.cachebuildid == 0 && return true   # not loaded from a cache; nothing to compare against
+    id = PkgId(pkgdata)
+    @lock revise_lock begin
+        id ∈ rewritten_caches && return false
+        cachedata = pkg_fileinfo(id)   # re-reads the header of the cache file on disk
+        if cachedata !== nothing
+            _, _, _, buildid = cachedata
+            buildid == pkgdata.cachebuildid && return true
+        end
+        push!(rewritten_caches, id)
+    end
+    @warn """The precompile cache for $(id.name) is no longer the one this session loaded; another process rebuilt or removed it.
+        Revise compares edits against the source snapshot stored in that cache, and no snapshot of the running code remains.
+        Edited files of $(id.name) are therefore evaluated in full rather than by difference; definitions that the edits removed cannot be identified and stay in force.
+        Restart Julia for a session guaranteed to match the source."""
+    return false
+end
+
 function maybe_parse_from_cache!(pkgdata::PkgData, file::AbstractString, fi::FileInfo)
     if (isempty(fi.mod_exs_infos) && !fi.parsed[]) && (!isempty(fi.cachefile) || !isempty(fi.cacheexprs))
+        if !isempty(fi.cachefile) && !cache_snapshot_is_valid(pkgdata)
+            # No trustworthy baseline: leave `mod_exs_infos` empty so that every expression
+            # in the current source counts as new. `cacheexprs` come from `@require` blocks
+            # this session evaluated, not from the cache, so they remain valid.
+            add_modexs!(fi, fi.cacheexprs)
+            empty!(fi.cacheexprs)
+            fi.parsed[] = true
+            return fi
+        end
         # Source was never parsed, get it from the precompile cache
         src = read_from_cache(pkgdata, file, fi)
         filep = joinpath(basedir(pkgdata), file)

--- a/src/stale_load.jl
+++ b/src/stale_load.jl
@@ -195,7 +195,9 @@ function queue_changed_files!(id::PkgId)
                 continue
             end
             cached = try
-                read_from_cache(pkgdata, file)
+                # A snapshot that is no longer the one this session loaded says nothing
+                # about what needs revising, so treat it as absent.
+                cached_source_is_current(pkgdata, fi) ? read_from_cache(pkgdata, file) : nothing
             catch
                 nothing  # queue it; revision will surface the problem
             end

--- a/src/types.jl
+++ b/src/types.jl
@@ -329,6 +329,9 @@ end
 A structure holding the data required to handle a particular package.
 `path` is the top-level directory defining the package,
 and `fileinfos` holds the [`Revise.FileInfo`](@ref) for each file defining the package.
+`cachebuildid` is the build id of the precompile cache this session loaded the package
+from, and identifies the source snapshot the `FileInfo`s read from that cache (see
+[`Revise.rewritten_caches`](@ref)); it is zero for packages not loaded from a cache.
 
 For the `PkgData` associated with `Main` (e.g., for files loaded with [`includet`](@ref)),
 the corresponding `path` entry will be empty.
@@ -337,9 +340,10 @@ mutable struct PkgData
     info::PkgFiles
     fileinfos::Vector{FileInfo}
     requirements::Vector{PkgId}
+    cachebuildid::UInt128        # build id of the precompile cache this session loaded (0 if none)
 end
 
-PkgData(id::PkgId, path) = PkgData(PkgFiles(id, path), FileInfo[], PkgId[])
+PkgData(id::PkgId, path) = PkgData(PkgFiles(id, path), FileInfo[], PkgId[], zero(UInt128))
 PkgData(id::PkgId, ::Nothing) = PkgData(id, "")
 function PkgData(id::PkgId)
     bp = basepath(id)

--- a/src/types.jl
+++ b/src/types.jl
@@ -289,22 +289,23 @@ struct FileInfo
     mapexpr::Function                                  # transform applied to each top-level expression (identity if none)
     cachefile::String
     cachefilename::String                              # the source path as recorded inside `cachefile`; the lookup key for reading from the cache
+    cachesrcid::Union{Nothing,UInt64}                  # identifies the source text `cachefile` holds for this file (`nothing` if unknown)
     cacheexprs::Vector{Tuple{Module,Expr}}             # "unprocessed" exprs, used to support @require
     extracted::Base.RefValue{Bool}                     # true if signatures have been processed from mod_exs_infos
     parsed::Base.RefValue{Bool}                        # true if mod_exs_infos have been parsed from cachefile
 end
-FileInfo(mod_exs_infos::ModuleExprsInfos, cachefile="", cachefilename=""; mapexpr::Function=identity) =
-    FileInfo(mod_exs_infos, mapexpr, cachefile, cachefilename, Tuple{Module,Expr}[], Ref(false), Ref(false))
+FileInfo(mod_exs_infos::ModuleExprsInfos, cachefile="", cachefilename=""; mapexpr::Function=identity, cachesrcid=nothing) =
+    FileInfo(mod_exs_infos, mapexpr, cachefile, cachefilename, cachesrcid, Tuple{Module,Expr}[], Ref(false), Ref(false))
 
 """
-    FileInfo(mod::Module, cachefile="", cachefilename=""; mapexpr=identity)
+    FileInfo(mod::Module, cachefile="", cachefilename=""; mapexpr=identity, cachesrcid=nothing)
 
 Initialize an empty FileInfo for a file that is `include`d into `mod`.
 """
-FileInfo(mod::Module, cachefile::AbstractString="", cachefilename::AbstractString=""; mapexpr::Function=identity) =
-    FileInfo(ModuleExprsInfos(mod), cachefile, cachefilename; mapexpr)
+FileInfo(mod::Module, cachefile::AbstractString="", cachefilename::AbstractString=""; mapexpr::Function=identity, cachesrcid=nothing) =
+    FileInfo(ModuleExprsInfos(mod), cachefile, cachefilename; mapexpr, cachesrcid)
 
-FileInfo(fm::ModuleExprsInfos, fi::FileInfo) = FileInfo(fm, fi.mapexpr, fi.cachefile, fi.cachefilename, copy(fi.cacheexprs), Ref(fi.extracted[]), Ref(fi.parsed[]))
+FileInfo(fm::ModuleExprsInfos, fi::FileInfo) = FileInfo(fm, fi.mapexpr, fi.cachefile, fi.cachefilename, fi.cachesrcid, copy(fi.cacheexprs), Ref(fi.extracted[]), Ref(fi.parsed[]))
 
 function Base.show(io::IO, fi::FileInfo)
     print(io, "FileInfo(")
@@ -332,6 +333,9 @@ and `fileinfos` holds the [`Revise.FileInfo`](@ref) for each file defining the p
 `cachebuildid` is the build id of the precompile cache this session loaded the package
 from, and identifies the source snapshot the `FileInfo`s read from that cache (see
 [`Revise.rewritten_caches`](@ref)); it is zero for packages not loaded from a cache.
+`cacheio` is a handle held open on that cache file, which on platforms where a rename
+does not disturb open handles keeps the snapshot readable even after another process
+replaces the file; it is `nothing` when no handle is held.
 
 For the `PkgData` associated with `Main` (e.g., for files loaded with [`includet`](@ref)),
 the corresponding `path` entry will be empty.
@@ -341,9 +345,10 @@ mutable struct PkgData
     fileinfos::Vector{FileInfo}
     requirements::Vector{PkgId}
     cachebuildid::UInt128        # build id of the precompile cache this session loaded (0 if none)
+    cacheio::Union{Nothing,IOStream}   # handle held open on that cache file, where the platform allows it
 end
 
-PkgData(id::PkgId, path) = PkgData(PkgFiles(id, path), FileInfo[], PkgId[], zero(UInt128))
+PkgData(id::PkgId, path) = PkgData(PkgFiles(id, path), FileInfo[], PkgId[], zero(UInt128), nothing)
 PkgData(id::PkgId, ::Nothing) = PkgData(id, "")
 function PkgData(id::PkgId)
     bp = basepath(id)
@@ -461,6 +466,24 @@ function Base.showerror(io::IO, ex::ReviseEvalException; blame_revise::Bool=true
     if blame_revise
         println(io, "\nRevise evaluation error at ", ex.loc)
     end
+end
+
+"""
+    StaleCacheError(id::PkgId, file::String)
+
+Reports that `file` cannot be revised because the precompile cache of `id` no longer
+holds the source this session loaded it from, leaving nothing to compare the current
+source against. See [`Revise.rewritten_caches`](@ref).
+"""
+struct StaleCacheError <: Exception
+    id::PkgId
+    file::String
+end
+
+function Base.showerror(io::IO, err::StaleCacheError)
+    print(io, """
+        $(err.file) cannot be revised: the precompile cache of $(err.id.name) was rebuilt by another process, and the source this session loaded for this file is no longer recorded anywhere, so there is nothing to compare the current source against.
+        The definitions in this file remain as they were when the session loaded them. Restart Julia to pick up their current state.""")
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4183,6 +4183,55 @@ end
         pop!(LOAD_PATH)
     end
 
+    # `Revise.hold_cache!` keeps a precompile cache's source snapshot readable by holding a
+    # handle open on the file. That is sound only where replacing the file by rename both
+    # succeeds while the handle is open — otherwise Revise would break the *other* process's
+    # precompilation — and leaves the handle reading the original bytes.
+    # `Revise.can_hold_cache()` records where those two things are known to hold; this
+    # measures them. Where it says no, they are `@test_broken`: an "Unexpected Pass" in CI
+    # means the platform supports the handle after all and the test in `can_hold_cache` can
+    # be relaxed to admit it.
+    do_test("Cache handle across a rebuild") && @testset "Cache handle across a rebuild" begin
+        if VERSION >= v"1.11.0-DEV.683"   # older Julia cannot read a cache through a handle at all
+            testdir = newtestdir()
+            dn = joinpath(testdir, "CacheHandle", "src")
+            mkpath(dn)
+            write(joinpath(dn, "CacheHandle.jl"), "module CacheHandle\nchfun() = 1\nend\n")
+            id = Base.identify_package("CacheHandle")
+            ret = Base.compilecache(id)
+            cachefile = ret isa Tuple ? ret[1] : ret
+            io = open(cachefile, "r")
+            local rebuilt, preserved
+            try
+                srcname = first(Revise.pkg_fileinfo(id, cachefile, io)[2]).filename
+                readsrc() = (seekstart(io); Base.isvalid_cache_header(io);
+                             Base.read_dependency_src(io, cachefile, srcname))
+                before = readsrc()
+                sleep(mtimedelay)
+                write(joinpath(dn, "CacheHandle.jl"), "module CacheHandle\nchfun() = 2\nend\n")
+                sleep(mtimedelay)
+                rebuilt = try
+                    Base.compilecache(id)          # the replacing rename, with our handle open
+                    true
+                catch
+                    false
+                end
+                preserved = rebuilt && (try readsrc() == before catch; false end)
+            finally
+                close(io)
+            end
+            @info "cache handle across a rebuild" Sys.KERNEL rebuilt preserved Revise.can_hold_cache()
+            if Revise.can_hold_cache()
+                @test rebuilt
+                @test preserved
+            else
+                @test_broken rebuilt && preserved
+            end
+            rm_precompile("CacheHandle")
+            pop!(LOAD_PATH)
+        end
+    end
+
     # issue #738
     do_test("stale_load") && @testset "stale_load" begin
         testdir = newtestdir()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4183,6 +4183,42 @@ end
         pop!(LOAD_PATH)
     end
 
+    do_test("Queueing when the snapshot is gone") && @testset "Queueing when the snapshot is gone" begin
+        # `stale_load` decides what to revise by comparing each file against the source
+        # snapshot in the cache. A snapshot that is no longer the one the session loaded
+        # says nothing about what needs revising, so the file is queued rather than passed
+        # over for matching a cache the session never ran.
+        testdir = newtestdir()
+        dn = joinpath(testdir, "QueueStale", "src")
+        mkpath(dn)
+        write(joinpath(dn, "QueueStale.jl"), "module QueueStale\nqfun() = 1\nend\n")
+        sleep(mtimedelay)
+        @eval using QueueStale
+        @latestworld
+        id = Base.PkgId(QueueStale)
+        pkgdata = Revise.pkgdatas[id]
+        pkgdata.cacheio = nothing        # as on a platform that cannot hold a handle
+        file = joinpath("src", "QueueStale.jl")
+        try
+            @test !Revise.queue_changed_files!(id)     # nothing differs from the snapshot
+            sleep(mtimedelay)
+            write(joinpath(dn, "QueueStale.jl"), "module QueueStale\nqfun() = 2\nend\n")
+            sleep(mtimedelay)
+            Base.compilecache(id)                      # sweeps the edit into the cache
+            filter!(pr -> first(pr) !== pkgdata, Revise.revision_queue)
+            # The source on disk now matches the cache, so comparing against it would find
+            # nothing to do...
+            @test read(joinpath(dn, "QueueStale.jl"), String) == Revise.read_from_cache(pkgdata, file)
+            # ...but that snapshot is not the one this session loaded, so the file is queued
+            @test Revise.queue_changed_files!(id)
+            @test (pkgdata, file) ∈ Revise.revision_queue
+        finally
+            filter!(pr -> first(pr) !== pkgdata, Revise.revision_queue)
+            rm_precompile("QueueStale")
+            pop!(LOAD_PATH)
+        end
+    end
+
     # `Revise.hold_cache!` keeps a precompile cache's source snapshot readable by holding a
     # handle open on the file. That is sound only where replacing the file by rename both
     # succeeds while the handle is open — otherwise Revise would break the *other* process's
@@ -5619,6 +5655,44 @@ do_test("Unchanged files across a path switch") && @testset "Unchanged files acr
         @test haskey(watchlist.trackedfiles, "changed.jl")
     finally
         filter!(pr -> first(pr) !== pkgdata, Revise.revision_queue)
+        delete!(Revise.watched_files, joinpath(olddir, "src"))
+        delete!(Revise.watched_files, joinpath(newdir, "src"))
+    end
+end
+
+do_test("Path switch without a baseline") && @testset "Path switch without a baseline" begin
+    # A file whose cached source snapshot is gone has no baseline to compare the new
+    # location against, and the old location's source on disk is not one either. The file
+    # is queued so that `revise` reports the loss, rather than `switch_basepath` adopting
+    # the new source as though the session already held it.
+    mod = Module(:PathSwitchStale)
+    Core.eval(mod, :(using Base))
+    id = Base.PkgId(Base.UUID("00000000-0000-0000-0000-000000001115"), "PathSwitchStale")
+    olddir, newdir = mktempdir(), mktempdir()
+    mkpath(joinpath(olddir, "src"))
+    mkpath(joinpath(newdir, "src"))
+    file = joinpath("src", "stale.jl")
+    write(joinpath(olddir, file), "h() = 1\n")
+    write(joinpath(newdir, file), "h() = 2\n")
+
+    pkgdata = Revise.PkgData(id, olddir)
+    # An unparsed file whose only baseline was a cache that can no longer be read
+    push!(pkgdata, file=>Revise.FileInfo(mod, joinpath(olddir, "nonexistent.ji"), joinpath(olddir, file)))
+    pkgdata.cachebuildid = 0x0123    # nonzero: the session did load from a cache
+
+    try
+        @test !Revise.cached_source_is_current(pkgdata, Revise.fileinfo(pkgdata, file))
+        @test_logs (:warn, r"source it held for one or more edited files is gone") match_mode=:any Revise.switch_basepath(pkgdata, newdir)
+        @test Revise.basedir(pkgdata) == newdir
+        @test (pkgdata, file) ∈ Revise.revision_queue
+        # Nothing was adopted as a baseline
+        @test !Revise.fileinfo(pkgdata, file).parsed[]
+        @test !Revise.fileinfo(pkgdata, file).extracted[]
+        # The file is still watched at the new location
+        @test haskey(Revise.watched_files[joinpath(newdir, "src")].trackedfiles, "stale.jl")
+    finally
+        filter!(pr -> first(pr) !== pkgdata, Revise.revision_queue)
+        delete!(Revise.rewritten_caches, id)
         delete!(Revise.watched_files, joinpath(olddir, "src"))
         delete!(Revise.watched_files, joinpath(newdir, "src"))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4101,6 +4101,46 @@ end
         end
     end
 
+    do_test("Rewritten precompile cache") && @testset "Rewritten precompile cache" begin
+        testdir = newtestdir()
+        dn = joinpath(testdir, "RewrittenCache", "src")
+        mkpath(dn)
+        write(joinpath(dn, "RewrittenCache.jl"), """
+            module RewrittenCache
+            include("f.jl")
+            end
+            """)
+        write(joinpath(dn, "f.jl"), "f(x; b::Int=2) = x + b\n")
+        sleep(mtimedelay)
+        @eval using RewrittenCache
+        @latestworld
+        id = Base.PkgId(RewrittenCache)
+        pkgdata = Revise.pkgdatas[id]
+        @test pkgdata.cachebuildid != 0
+        @test Revise.cache_snapshot_is_valid(pkgdata)
+        sleep(mtimedelay)
+        write(joinpath(dn, "f.jl"), "f(x; a::Int=10, b::Int=2) = x + a + b\n")
+        sleep(mtimedelay)
+        # Stands in for a `using` or `Pkg.precompile` in a separate process: the cache
+        # path depends on the project and compile flags, not on the source, so this
+        # overwrites the source snapshot Revise would otherwise diff the edit against.
+        Base.compilecache(id)
+        @test_logs (:warn, r"no longer the one this session loaded") match_mode=:any yry()
+        @latestworld
+        @test id ∈ Revise.rewritten_caches
+        # The edit is applied even though no baseline survived to compare it with
+        @test RewrittenCache.f(1; a=5) == 8
+        # Further edits keep revising, and the warning is not repeated
+        sleep(mtimedelay)
+        write(joinpath(dn, "f.jl"), "f(x; a::Int=10, b::Int=2) = x + a + b + 100\n")
+        logs, _ = collect_test_logs(yry; min_level=Base.CoreLogging.Warn)
+        @latestworld
+        @test !any(r -> occursin("no longer the one this session loaded", string(r.message)), logs)
+        @test RewrittenCache.f(1; a=5) == 108
+        rm_precompile("RewrittenCache")
+        pop!(LOAD_PATH)
+    end
+
     # issue #738
     do_test("stale_load") && @testset "stale_load" begin
         testdir = newtestdir()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4137,6 +4137,8 @@ end
         @latestworld
         @test !any(r -> occursin("no longer the one this session loaded", string(r.message)), logs)
         @test RewrittenCache.f(1; a=5) == 108
+        # A clean revision does not clear the flag, so the prompt stays yellow
+        @test id ∈ Revise.rewritten_caches
         rm_precompile("RewrittenCache")
         pop!(LOAD_PATH)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4107,38 +4107,78 @@ end
         mkpath(dn)
         write(joinpath(dn, "RewrittenCache.jl"), """
             module RewrittenCache
-            include("f.jl")
+            include("a.jl")
+            include("b.jl")
+            include("c.jl")
             end
             """)
-        write(joinpath(dn, "f.jl"), "f(x; b::Int=2) = x + b\n")
+        write(joinpath(dn, "a.jl"), "afun() = 1\n")
+        write(joinpath(dn, "b.jl"), "bfun() = 1\n")
+        write(joinpath(dn, "c.jl"), "cfun() = 1\n")
         sleep(mtimedelay)
         @eval using RewrittenCache
         @latestworld
-        id = Base.PkgId(RewrittenCache)
+        M = RewrittenCache
+        id = Base.PkgId(M)
         pkgdata = Revise.pkgdatas[id]
         @test pkgdata.cachebuildid != 0
         @test Revise.cache_snapshot_is_valid(pkgdata)
+
+        # Where a handle can be held on the cache, it keeps the snapshot readable across a
+        # rebuild and the rebuild is a non-event. Drop it afterwards to exercise the
+        # platforms that cannot hold one.
+        held = pkgdata.cacheio
+        @test (held !== nothing) == Revise.can_hold_cache()
+        if held !== nothing
+            sleep(mtimedelay)
+            write(joinpath(dn, "a.jl"), "afun() = 2\n")
+            sleep(mtimedelay)
+            # Stands in for a `using` or `Pkg.precompile` in a separate process: the cache
+            # path depends on the project and compile flags, not on the source, so this
+            # replaces the file Revise recorded.
+            Base.compilecache(id)
+            @yry()
+            @test Revise.cache_snapshot_is_valid(pkgdata)   # read through the held handle
+            @test M.afun() == 2
+            @test isempty(Revise.rewritten_caches)
+            pkgdata.cacheio = nothing
+        end
+
+        # A rebuild from unchanged source carries the same snapshot: still a non-event.
         sleep(mtimedelay)
-        write(joinpath(dn, "f.jl"), "f(x; a::Int=10, b::Int=2) = x + a + b\n")
-        sleep(mtimedelay)
-        # Stands in for a `using` or `Pkg.precompile` in a separate process: the cache
-        # path depends on the project and compile flags, not on the source, so this
-        # overwrites the source snapshot Revise would otherwise diff the edit against.
         Base.compilecache(id)
-        @test_logs (:warn, r"no longer the one this session loaded") match_mode=:any yry()
-        @latestworld
-        @test id ∈ Revise.rewritten_caches
-        # The edit is applied even though no baseline survived to compare it with
-        @test RewrittenCache.f(1; a=5) == 8
-        # Further edits keep revising, and the warning is not repeated
+        @test !Revise.cache_snapshot_is_valid(pkgdata)      # the build id did change
+        @test Revise.cached_source_is_current(pkgdata, Revise.fileinfo(pkgdata, "src/b.jl"))
         sleep(mtimedelay)
-        write(joinpath(dn, "f.jl"), "f(x; a::Int=10, b::Int=2) = x + a + b + 100\n")
-        logs, _ = collect_test_logs(yry; min_level=Base.CoreLogging.Warn)
+        write(joinpath(dn, "b.jl"), "bfun() = 2\n")
+        @yry()
+        @test M.bfun() == 2
+        @test isempty(Revise.rewritten_caches)
+        @test isempty(Revise.queue_errors)
+
+        # An edit that a rebuild sweeps into the cache leaves no baseline for that file:
+        # no revision is attempted, and the loss is reported rather than guessed at.
+        # (A file already revised once holds its baseline in memory and is unaffected;
+        # c.jl has not been revised, so the cache is still its only baseline.)
+        sleep(mtimedelay)
+        write(joinpath(dn, "c.jl"), "cfun() = 2\n")
+        sleep(mtimedelay)
+        Base.compilecache(id)
+        @test !Revise.cached_source_is_current(pkgdata, Revise.fileinfo(pkgdata, "src/c.jl"))
+        @test_logs (:warn, r"source it held for one or more edited files is gone") match_mode=:any yry()
         @latestworld
-        @test !any(r -> occursin("no longer the one this session loaded", string(r.message)), logs)
-        @test RewrittenCache.f(1; a=5) == 108
-        # A clean revision does not clear the flag, so the prompt stays yellow
-        @test id ∈ Revise.rewritten_caches
+        @test M.cfun() == 1                                 # left as the session had it
+        @test id in Revise.rewritten_caches
+        err, _ = Revise.queue_errors[(pkgdata, "src/c.jl")]
+        @test err isa Revise.StaleCacheError
+        @test occursin("cannot be revised", sprint(showerror, err))
+        # a.jl and b.jl kept their baselines, so they still revise normally
+        sleep(mtimedelay)
+        write(joinpath(dn, "a.jl"), "afun() = 42\n")
+        @yry()
+        @test M.afun() == 42
+        empty!(Revise.rewritten_caches)
+        empty!(Revise.queue_errors)
         rm_precompile("RewrittenCache")
         pop!(LOAD_PATH)
     end
@@ -5482,7 +5522,7 @@ do_test("@require path switch") && @testset "@require path switch" begin
     # empty `mod_exs_infos` plus an unprocessed `cacheexpr` and no cache file, which
     # drives `switch_basepath` into its read-from-disk fallback.
     reqfile = joinpath("src", "Issue678.jl") * Revise.requires_suffix
-    fi = Revise.FileInfo(Revise.ModuleExprsInfos(), identity, "", "",
+    fi = Revise.FileInfo(Revise.ModuleExprsInfos(), identity, "", "", nothing,
                          Tuple{Module,Expr}[(mod, :(g() = 42))], Ref(false), Ref(false))
     push!(pkgdata, reqfile=>fi)
     @test Revise.is_requires_file(reqfile)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4148,7 +4148,7 @@ end
         sleep(mtimedelay)
         Base.compilecache(id)
         @test !Revise.cache_snapshot_is_valid(pkgdata)      # the build id did change
-        @test Revise.cached_source_is_current(pkgdata, Revise.fileinfo(pkgdata, "src/b.jl"))
+        @test Revise.cached_source_is_current(pkgdata, Revise.fileinfo(pkgdata, joinpath("src", "b.jl")))
         sleep(mtimedelay)
         write(joinpath(dn, "b.jl"), "bfun() = 2\n")
         @yry()
@@ -4164,12 +4164,12 @@ end
         write(joinpath(dn, "c.jl"), "cfun() = 2\n")
         sleep(mtimedelay)
         Base.compilecache(id)
-        @test !Revise.cached_source_is_current(pkgdata, Revise.fileinfo(pkgdata, "src/c.jl"))
+        @test !Revise.cached_source_is_current(pkgdata, Revise.fileinfo(pkgdata, joinpath("src", "c.jl")))
         @test_logs (:warn, r"source it held for one or more edited files is gone") match_mode=:any yry()
         @latestworld
         @test M.cfun() == 1                                 # left as the session had it
         @test id in Revise.rewritten_caches
-        err, _ = Revise.queue_errors[(pkgdata, "src/c.jl")]
+        err, _ = Revise.queue_errors[(pkgdata, joinpath("src", "c.jl"))]
         @test err isa Revise.StaleCacheError
         @test occursin("cannot be revised", sprint(showerror, err))
         # a.jl and b.jl kept their baselines, so they still revise normally


### PR DESCRIPTION
Revise uses a source-cache stored in the precompile snapshot of a package as the source of "pre-edit state of the code"; to save both time and memory, it does not parse this source until edits are detected. The correct precompile file is stored as a path in the `pkgdata`.

It turns out this design has always had a hole: suppose something (typically an external process performing precompilation) causes the cache-file to be *rewritten with different content* before one of the source files gets edited. Then the source for "pre-edit state" no longer matches the code that's actually running in the session; it can cause you to fail to detect changes, or falsely detect changes.

This largely fixes the issue by (1) tracking the buildid at the time of package-loading, so you can detect if the cache file gets replaced out from under you, and (2) on platforms that can still access the old version (Julia does a write-to-a-temporary-and-then-rename, so on some platforms the old cache file is just detached, not actually overwritten), consult the old version by holding an `IOStream` to ensure we can still access it by non-path mechanisms. The latter is only done if the package's source files are read/write, i.e., `dev` and not `add`; this should reduce the memory consequences of this change.