### PR TITLE
Untrack files whose `include` was removed

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -103,6 +103,7 @@ Revise.revise_file_now
 Revise.hold_cache!
 Revise.cache_snapshot_is_valid
 Revise.cached_source_is_current
+Revise.include_targets
 ```
 
 Revise pins its own method dispatch to the world age captured at initialization, so that

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -341,6 +341,15 @@ accept a leading `mapexpr` of their own) or to `include(mapexpr, filename)` stat
 *added* to an already-loaded package, since those transforms are discovered without
 the load-time record.
 
+### A removed `include` is recognized only for literal paths
+
+When an `include` statement disappears from a revised file, Revise deletes the
+definitions the included file contributed to that module and stops tracking the
+inclusion; restoring the statement registers the file again. Revise recognizes
+only string-literal paths and literal destination-module names, as in
+`Base.include(Sub, "file.jl")`. Computed paths (for example, from a loop, variable,
+or constant) are not recognized.
+
 ### Precompilation by another process can discard Revise's baseline
 
 For a precompiled package, Revise reads the "before" state of a source file from the

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -916,12 +916,18 @@ function eval_with_signatures(mod::Module, ex::Expr; mode::Symbol=:eval, kwargs.
     return exinfos, exinfo.includes, thk
 end
 
-function instantiate_sigs!(mod_exs_infos::ModuleExprsInfos; mode::Symbol=:sigs, kwargs...)
+# `includes`, when supplied, collects the `include` statements encountered, which the
+# caller must register (they are not evaluated here).
+function instantiate_sigs!(mod_exs_infos::ModuleExprsInfos; mode::Symbol=:sigs,
+                           includes::Union{Nothing,Vector{Tuple{Module,Function,String}}}=nothing,
+                           kwargs...)
     for (mod, exs_infos) in mod_exs_infos
         for rex in keys(exs_infos)
             is_doc_expr(rex.ex) && continue
             try
-                exs_infos[rex], _, _ = eval_with_signatures(mod, rex.ex; mode, kwargs...)
+                exinfos, incs, _ = eval_with_signatures(mod, rex.ex; mode, kwargs...)
+                exs_infos[rex] = exinfos
+                includes === nothing || append!(includes, incs)
             catch err
                 if (mode !== :sigs || get(kwargs, :always_rethrow, false) ||
                     err isa InterruptException || err isa SignatureExtractionError)
@@ -1196,6 +1202,126 @@ function delete_for_revision(
             end
         end
         @warn("$filep no longer exists, deleted all methods")
+    end
+    return nothing
+end
+
+# The current source of `pkgdata`'s file at index `idx`: the pending parse when the
+# file is part of the revision under way, otherwise the stored expressions (reading
+# the precompile-cache snapshot if that has not been parsed yet).
+function source_view(pkgdata::PkgData, file::AbstractString, idx::Int,
+                     current::Dict{Tuple{String,Int},ModuleExprsInfos})
+    mod_exs_infos = get(current, (String(file)::String, idx), nothing)
+    mod_exs_infos === nothing || return mod_exs_infos
+    fi = fileinfo(pkgdata, idx)
+    if file != "." && !is_requires_file(file)
+        maybe_parse_from_cache!(pkgdata, file, fi)
+    end
+    return fi.mod_exs_infos
+end
+
+# Inclusions removed by the revision, as `(pkgdata, file, idx, unwatch)` tuples.
+# For files in `parsed`, use the pending parse rather than the stored `FileInfo`.
+#
+# Inclusions are identified by `(path, module)` (see `include_targets`), so a file
+# included into several modules loses only the inclusions the source dropped.
+# Removal is transitive: files included only by a removed inclusion are also
+# removed.
+function orphaned_includes(pkgdata::PkgData, parsed)
+    orphans = Tuple{PkgData,String,Int,Bool}[]
+    current = Dict{Tuple{String,Int},ModuleExprsInfos}()
+    candidates = Set{Tuple{String,Module}}()
+    for (pd, file, idx, mod_exs_infos_new, mod_exs_infos_old, _) in parsed
+        pd === pkgdata || continue
+        isa(mod_exs_infos_new, ModuleExprsInfos) || continue
+        current[(file, idx)] = mod_exs_infos_new
+        union!(candidates, setdiff(include_targets(pkgdata, file, mod_exs_infos_old),
+                                   include_targets(pkgdata, file, mod_exs_infos_new)))
+    end
+    isempty(candidates) && return orphans
+    gone = Set{Tuple{String,Module}}()
+    while !isempty(candidates)
+        live = Set{Tuple{String,Module}}()
+        for (i, file) in enumerate(srcfiles(pkgdata))
+            (file, includemodule(pkgdata, i)) ∈ gone && continue
+            union!(live, include_targets(pkgdata, file, source_view(pkgdata, file, i, current)))
+        end
+        newly = Tuple{String,Module,Int}[]
+        for target in candidates
+            (target ∈ gone || target ∈ live) && continue
+            path, mod = target
+            for idx in fileindices(pkgdata, path)
+                includemodule(pkgdata, idx) === mod && push!(newly, (path, mod, idx))
+            end
+        end
+        isempty(newly) && break
+        candidates = Set{Tuple{String,Module}}()
+        for (path, mod, idx) in newly
+            push!(gone, (path, mod))
+            union!(candidates, include_targets(pkgdata, path, source_view(pkgdata, path, idx, current)))
+            push!(orphans, (pkgdata, path, idx, false))
+        end
+    end
+    # Stop watching a path only after every inclusion of it has been removed.
+    norphaned = Dict{String,Int}()
+    for (_, path, _, _) in orphans
+        norphaned[path] = get(norphaned, path, 0) + 1
+    end
+    for (i, (pd, path, idx, _)) in enumerate(orphans)
+        orphans[i] = (pd, path, idx, norphaned[path] == length(fileindices(pkgdata, path)))
+    end
+    return orphans
+end
+
+# Return the removed inclusions for every package represented in `parsed`. Detection
+# is static and therefore conservative (see `include_targets`); if scanning a
+# package fails, keep all its files and log the error (or rethrow it under `throw`).
+function orphaned_includes(parsed; throw::Bool=false)
+    orphans = Tuple{PkgData,String,Int,Bool}[]
+    seen = PkgData[]
+    for (pkgdata, _, _, _, _, _) in parsed
+        any(pd -> pd === pkgdata, seen) && continue
+        push!(seen, pkgdata)
+        try
+            append!(orphans, orphaned_includes(pkgdata, parsed))
+        catch err
+            (throw || isa(err, InterruptException)) && rethrow()
+            @error "scan for removed `include`s failed for $(PkgId(pkgdata)); keeping its files tracked" exception=(err, catch_backtrace())
+        end
+    end
+    return orphans
+end
+
+# Delete definitions contributed by one inclusion and clear its stored expressions.
+# Stop watching the path only when `unwatch` indicates this was its last inclusion.
+function delete_orphaned_include!(
+        pkgdata::PkgData, file::AbstractString, idx::Int, unwatch::Bool,
+        reeval_list::IdSet{Union{Method,Type}}, handled_types::IdSet{Type}, world::UInt,
+        predictions::TypePredictions,
+    )
+    fi = fileinfo(pkgdata, idx)
+    maybe_parse_from_cache!(pkgdata, file, fi)
+    maybe_extract_sigs!(fi)
+    mod_exs_infos_old = fi.mod_exs_infos
+    mod_exs_infos_new = ModuleExprsInfos(first(keys(mod_exs_infos_old)))
+    delete_missing!(mod_exs_infos_old, mod_exs_infos_new, reeval_list, handled_types, world, predictions)
+    pkgdata.fileinfos[idx] = FileInfo(mod_exs_infos_new, fi)
+    unwatch && unwatch_file!(pkgdata, file)
+    @warn "$(joinpath(basedir(pkgdata), file)) is no longer `include`d into $(first(keys(mod_exs_infos_old))), deleted its methods"
+    return nothing
+end
+
+# Remove inclusions from their `PkgData`. Descending indices keep remaining ones valid.
+function deregister_orphaned_includes!(orphans)
+    seen = PkgData[]
+    for (pkgdata, _, _, _) in orphans
+        any(pd -> pd === pkgdata, seen) && continue
+        push!(seen, pkgdata)
+        indices = sort!(Int[idx for (pd, _, idx, _) in orphans if pd === pkgdata]; rev=true)
+        for idx in indices
+            deleteat!(srcfiles(pkgdata), idx)
+            deleteat!(pkgdata.fileinfos, idx)
+        end
     end
     return nothing
 end
@@ -1700,6 +1826,15 @@ function _revise(; throw::Bool=false)
             end
         end
 
+        # Do not evaluate files whose inclusions are being removed.
+        orphans = orphaned_includes(parsed; throw)
+        if !isempty(orphans)
+            filter!(parsed) do entry
+                pkgdata, file, idx = entry[1], entry[2], entry[3]
+                !any(o -> o[1] === pkgdata && o[2] == file && o[3] == idx, orphans)
+            end
+        end
+
         # Apply the deletions
         for (pkgdata, file, idx, mod_exs_infos_new, mod_exs_infos_old, fileok) in parsed
             try
@@ -1710,6 +1845,19 @@ function _revise(; throw::Bool=false)
                     push!(finished, (pkgdata, file))
                     push!(finished_idx, idx)
                 end
+            catch err
+                throw && Base.throw(err)
+                interrupt |= isa(err, InterruptException)
+                push!(revision_errors, (pkgdata, file))
+                queue_errors[(pkgdata, file)] = (err, catch_backtrace())
+            end
+        end
+        # Keep failed deletions registered so `queue_errors` can retry them.
+        deleted_orphans = empty(orphans)
+        for (pkgdata, file, idx, unwatch) in orphans
+            try
+                delete_orphaned_include!(pkgdata, file, idx, unwatch, reeval_list, handled_types, world, predictions)
+                push!(deleted_orphans, (pkgdata, file, idx, unwatch))
             catch err
                 throw && Base.throw(err)
                 interrupt |= isa(err, InterruptException)
@@ -1765,6 +1913,9 @@ function _revise(; throw::Bool=false)
                 queue_errors[(pkgdata, file)] = (err, catch_backtrace())
             end
         end
+
+        # Evaluation above relies on stable `pkgdata.fileinfos` indices.
+        isempty(deleted_orphans) || deregister_orphaned_includes!(deleted_orphans)
 
         # Keep `Base.pkgorigins` version in sync with revised source (issue #684)
         for pkgdata in unique!(first.(finished))

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1148,7 +1148,14 @@ function revise_file_queued(pkgdata::PkgData, file)
             # Check to see if we're still watching this file
             stillwatching = haskey(watched_files, dirfull)
             if PkgId(pkgdata) != NOPACKAGE
-                push!(revision_queue, (pkgdata, relpath(file, pkgdata)))
+                relfile = relpath(file, pkgdata)
+                if hasfile(pkgdata, relfile)
+                    push!(revision_queue, (pkgdata, relfile))
+                else
+                    # The file was dropped from `pkgdata` (its `include` was removed),
+                    # so there is nothing left to revise: stop watching it.
+                    stillwatching = false
+                end
             end
         end
     end
@@ -1231,8 +1238,12 @@ function orphaned_includes(pkgdata::PkgData, parsed)
     orphans = Tuple{PkgData,String,Int,Bool}[]
     current = Dict{Tuple{String,Int},ModuleExprsInfos}()
     candidates = Set{Tuple{String,Module}}()
-    for (pd, file, idx, mod_exs_infos_new, mod_exs_infos_old, _) in parsed
+    for (pd, file, idx, mod_exs_infos_new, mod_exs_infos_old, fileok) in parsed
         pd === pkgdata || continue
+        # A file that is missing from disk keeps its registration pending its return
+        # (see `delete_for_revision`), and its empty parse names no inclusions: the
+        # files it includes stay tracked.
+        fileok || continue
         isa(mod_exs_infos_new, ModuleExprsInfos) || continue
         current[(file, idx)] = mod_exs_infos_new
         union!(candidates, setdiff(include_targets(pkgdata, file, mod_exs_infos_old),
@@ -1950,8 +1961,14 @@ function _revise(; throw::Bool=false)
         else
             empty!(revision_queue)
             # Files missing within the grace period stay queued so the next
-            # `revise` revisits them (and `revise_first` keeps firing).
+            # `revise` revisits them (and `revise_first` keeps firing). A file that
+            # this revision untracked (its `include` was removed) has nothing to
+            # revisit.
             for pkgfile in deferred_missing
+                if isempty(fileindices(pkgfile[1], pkgfile[2]))
+                    delete!(missing_file_times, pkgfile)
+                    continue
+                end
                 push!(revision_queue, pkgfile)
             end
         end

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -319,18 +319,17 @@ function maybe_add_includes_to_pkgdata!(pkgdata::PkgData, file::AbstractString, 
         inc = joinpath(splitdir(file)[1], inc)
         incrp = relpath(inc, pkgdata)
         hasinclude = false
-        # An entry for the same path and destination module whose `mapexpr` differs:
-        # the `include(mapexpr, ...)` statement was edited (or its closure was
-        # recreated when the including statement was re-evaluated), so that entry
-        # describes a transform that is no longer in the source.
+        # Each `(path, module)` inclusion has its own entry (issue #730). A differing
+        # `mapexpr` for that pair makes the old entry stale.
         stale_idx = 0
         for (i, srcfile) in enumerate(srcfiles(pkgdata))
             srcfile == incrp || continue
             fi = pkgdata.fileinfos[i]
+            first(keys(fi.mod_exs_infos)) === mod || continue
             if fi.mapexpr === mapexpr
                 hasinclude = true
                 break
-            elseif stale_idx == 0 && first(keys(fi.mod_exs_infos)) === mod
+            elseif stale_idx == 0
                 stale_idx = i
             end
         end
@@ -378,7 +377,10 @@ function maybe_add_includes_to_pkgdata!(pkgdata::PkgData, file::AbstractString, 
                 if eval_now
                     # Pin to Revise's frozen world (issue #552); `frozen`'s runtime dispatch
                     # also reduces latency.
-                    frozen(instantiate_sigs!, fi.mod_exs_infos; mode=:eval)
+                    nested = Tuple{Module,Function,String}[]
+                    frozen(instantiate_sigs!, fi.mod_exs_infos; mode=:eval, includes=nested)
+                    # Register files included by this newly registered file.
+                    isempty(nested) || maybe_add_includes_to_pkgdata!(pkgdata, incrp, nested; eval_now)
                 end
             end
             # Add to watchlist
@@ -386,6 +388,111 @@ function maybe_add_includes_to_pkgdata!(pkgdata::PkgData, file::AbstractString, 
             yield()
         end
     end
+end
+
+# Does `f` name `include` in surface syntax? Both the bare name and a qualified
+# `Mod.include` are accepted; the lowered-code counterpart is `is_some_include`.
+function is_include_callee(@nospecialize(f))
+    f === :include && return true
+    isexpr(f, :.) || return false
+    f = f::Expr
+    length(f.args) == 2 || return false
+    name = f.args[2]
+    return isa(name, QuoteNode) && name.value === :include
+end
+
+# Collect the `include` calls within `ex` whose path is a string literal, as
+# `(path, modarg)` pairs. `modarg` is the expression in the position where a
+# destination module may appear — the first argument of `include(x, path)` (which
+# holds a mapexpr in the other reading of that form) or the second of
+# `include(mapexpr, mod, path)` — and `nothing` for the one-argument form.
+# Quoted code is skipped: it names no file until it is evaluated.
+function collect_includes!(incs::Vector{Tuple{String,Any}}, @nospecialize(ex))
+    isa(ex, Expr) || return incs
+    ex.head === :quote && return incs
+    if ex.head === :call && !isempty(ex.args) && is_include_callee(ex.args[1])
+        args = ex.args
+        if length(args) == 2
+            isa(args[2], String) && push!(incs, (args[2], nothing))
+        elseif length(args) == 3
+            isa(args[3], String) && push!(incs, (args[3], args[2]))
+        elseif length(args) == 4
+            isa(args[4], String) && push!(incs, (args[4], args[3]))
+        end
+    end
+    for arg in ex.args
+        collect_includes!(incs, arg)
+    end
+    return incs
+end
+
+# Resolve `x` as a literal module reference (a bare or dotted name) in `mod`,
+# returning `nothing` if it does not name a `Module`. Bindings resolve at the
+# latest world: the modules named postdate Revise's frozen world.
+function resolve_module_literal(mod::Module, @nospecialize(x))
+    if isa(x, Module)
+        return x
+    elseif isa(x, Symbol)
+        @invokelatest(isdefinedglobal(mod, x)) || return nothing
+        val = @invokelatest(getglobal(mod, x))
+        return isa(val, Module) ? val : nothing
+    elseif isexpr(x, :.)
+        x = x::Expr
+        length(x.args) == 2 || return nothing
+        name = x.args[2]
+        isa(name, QuoteNode) || return nothing
+        isa(name.value, Symbol) || return nothing
+        base = resolve_module_literal(mod, x.args[1])
+        base === nothing && return nothing
+        return resolve_module_literal(base, name.value::Symbol)
+    end
+    return nothing
+end
+
+"""
+    Revise.include_targets(pkgdata, file, mod_exs_infos) -> targets::Set{Tuple{String,Module}}
+
+Return the `(path, module)` inclusions found statically in `mod_exs_infos`.
+Paths are relative to `pkgdata`.
+
+Only literal paths and destination-module names are recognized. An unresolved
+two-argument form is treated as `include(mapexpr, path)` in the current module.
+"""
+function include_targets(pkgdata::PkgData, file::AbstractString, mod_exs_infos::ModuleExprsInfos)
+    targets = Set{Tuple{String,Module}}()
+    dir = splitdir(String(file)::String)[1]
+    incs = Tuple{String,Any}[]
+    for (mod, exs_infos) in mod_exs_infos
+        empty!(incs)
+        for rex in keys(exs_infos)
+            collect_includes!(incs, rex.ex)
+        end
+        for (inc, modarg) in incs
+            destmod = modarg === nothing ? mod : something(resolve_module_literal(mod, modarg), mod)
+            push!(targets, (relpath(joinpath(dir, inc), pkgdata), destmod))
+        end
+    end
+    return targets
+end
+
+# The module `pkgdata`'s file at index `idx` is `include`d into; with its path, this
+# is what `include_targets` reports.
+includemodule(pkgdata::PkgData, idx::Int) = first(keys(fileinfo(pkgdata, idx).mod_exs_infos))
+
+# Stop watching `file` (relative to `pkgdata`). Only correct once nothing tracked
+# reads that path: the watch is per path, while `pkgdata` has one entry per inclusion.
+function unwatch_file!(pkgdata::PkgData, file::AbstractString)
+    dir, basename = splitdir(String(file)::String)
+    dirfull = joinpath(basedir(pkgdata), dir)
+    @lock revise_lock begin
+        wl = get(watched_files, dirfull, nothing)
+        if isa(wl, WatchList)
+            delete!(wl.trackedfiles, basename)
+            delete!(wl.file_ctimes, basename)
+            delete!(wl.file_hashes, basename)
+        end
+    end
+    return nothing
 end
 
 # Is `file` (relative to `pkgdata`) registered with a directory watcher? A live

--- a/src/types.jl
+++ b/src/types.jl
@@ -434,7 +434,14 @@ end
 function pkgfileless((pkgdata1,file1)::Tuple{PkgData,String}, (pkgdata2,file2)::Tuple{PkgData,String})
     # implements a partial order
     PkgId(pkgdata1) ∈ pkgdata2.requirements && return true
-    PkgId(pkgdata1) == PkgId(pkgdata2) && return fileindex(pkgdata1, file1) < fileindex(pkgdata2, file2)
+    if PkgId(pkgdata1) == PkgId(pkgdata2)
+        i1, i2 = fileindex(pkgdata1, file1), fileindex(pkgdata2, file2)
+        # A queued file can be untracked by the time `revise` sorts the queue (its
+        # `include` was removed); order it last, where `revise` skips it.
+        i1 === nothing && return false
+        i2 === nothing && return true
+        return i1 < i2
+    end
     return false
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5996,6 +5996,9 @@ do_test("Removed include") && @testset "Removed include" begin
         child() = 10
         include("grandchild.jl")
         """)
+    # A per-file watcher (`Revise.watching_files[]`) must not queue it either.
+    sleep(1.0)
+    @test all(((pd, f),) -> Revise.hasfile(pd, f), Revise.revision_queue)
     @yry(expect_revision=false)
     @test_throws MethodError RemovedInclude.child()
 
@@ -6172,6 +6175,105 @@ do_test("Removed include, module argument") && @testset "Removed include, module
     @test !Revise.iswatched(pkgdata, joinpath("src", "impl.jl"))
 
     rm_precompile("ModArgInclude")
+    pop!(LOAD_PATH)
+end
+
+## An `include` removed while the file it named is also gone from disk (issue #1104)
+do_test("Removed include, missing file") && @testset "Removed include, missing file" begin
+    testdir = newtestdir()
+    dn = joinpath(testdir, "GoneInclude", "src")
+    mkpath(dn)
+    write(joinpath(dn, "GoneInclude.jl"), """
+        module GoneInclude
+        include("gone.jl")
+        f() = 1
+        end
+        """)
+    write(joinpath(dn, "gone.jl"), "gone() = 2")
+    sleep(mtimedelay)
+    @eval using GoneInclude
+    sleep(mtimedelay)
+    @test GoneInclude.gone() == 2
+    pkgdata = Revise.pkgdatas[Base.PkgId(GoneInclude)]
+
+    rm(joinpath(dn, "gone.jl"))
+    write(joinpath(dn, "GoneInclude.jl"), """
+        module GoneInclude
+        f() = 1
+        end
+        """)
+    # Queue both files as the watcher would on seeing the deletion and the edit,
+    # so that one `revise` both untracks "gone.jl" and finds it queued.
+    sleep(mtimedelay)
+    @lock Revise.revise_lock begin
+        push!(Revise.revision_queue, (pkgdata, joinpath("src", "gone.jl")))
+        push!(Revise.revision_queue, (pkgdata, joinpath("src", "GoneInclude.jl")))
+    end
+    logs, _ = Test.collect_test_logs() do
+        revise()
+    end
+    @latestworld
+    @test_throws MethodError GoneInclude.gone()
+    @test any(r -> occursin("no longer `include`d into GoneInclude", r.message), logs)
+    @test !Revise.hasfile(pkgdata, joinpath("src", "gone.jl"))
+    # A file missing within `missing_file_grace` is normally left queued for the next
+    # `revise`, but an untracked one has nothing to revisit and would break the sort.
+    @test all(((pd, f),) -> Revise.hasfile(pd, f), Revise.revision_queue)
+    @test Revise.pkgfileless((pkgdata, joinpath("src", "GoneInclude.jl")),
+                             (pkgdata, joinpath("src", "gone.jl")))
+    @test !Revise.pkgfileless((pkgdata, joinpath("src", "gone.jl")),
+                              (pkgdata, joinpath("src", "GoneInclude.jl")))
+
+    rm_precompile("GoneInclude")
+    pop!(LOAD_PATH)
+end
+
+## A file missing from disk keeps the files it `include`s (issue #1104)
+do_test("Missing file keeps its includes") && @testset "Missing file keeps its includes" begin
+    testdir = newtestdir()
+    dn = joinpath(testdir, "MissingParent", "src")
+    mkpath(dn)
+    write(joinpath(dn, "MissingParent.jl"), """
+        module MissingParent
+        include("mid.jl")
+        end
+        """)
+    write(joinpath(dn, "mid.jl"), """
+        mid() = 1
+        include("leaf.jl")
+        """)
+    write(joinpath(dn, "leaf.jl"), "leaf() = 2")
+    sleep(mtimedelay)
+    @eval using MissingParent
+    sleep(mtimedelay)
+    @test MissingParent.mid() == 1
+    @test MissingParent.leaf() == 2
+    pkgdata = Revise.pkgdatas[Base.PkgId(MissingParent)]
+
+    old_grace = Revise.missing_file_grace[]
+    Revise.missing_file_grace[] = 0.0
+    try
+        rm(joinpath(dn, "mid.jl"))
+        # Queue the deleted file as the watcher would, so the revision does not
+        # depend on the timing of a filesystem event.
+        sleep(mtimedelay)
+        @lock Revise.revise_lock push!(Revise.revision_queue, (pkgdata, joinpath("src", "mid.jl")))
+        logs, _ = Test.collect_test_logs() do
+            revise()
+        end
+        @latestworld
+        @test_throws MethodError MissingParent.mid()
+        @test any(r -> occursin("no longer exists, deleted all methods", r.message), logs)
+        # A file that vanished has no source, which is not the same as source that
+        # dropped an `include`: what it included stays tracked.
+        @test MissingParent.leaf() == 2
+        @test Revise.hasfile(pkgdata, joinpath("src", "leaf.jl"))
+        @test Revise.iswatched(pkgdata, joinpath("src", "leaf.jl"))
+    finally
+        Revise.missing_file_grace[] = old_grace
+    end
+
+    rm_precompile("MissingParent")
     pop!(LOAD_PATH)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5944,6 +5944,237 @@ do_test("Missing-file grace") && !Revise.watching_files[] && @testset "Missing-f
     pop!(LOAD_PATH)
 end
 
+## Removing and restoring an `include` (issue #1104)
+do_test("Removed include") && @testset "Removed include" begin
+    testdir = newtestdir()
+    dn = joinpath(testdir, "RemovedInclude", "src")
+    mkpath(dn)
+    write(joinpath(dn, "RemovedInclude.jl"), """
+        module RemovedInclude
+        include("child.jl")
+        include("kept.jl")
+        end
+        """)
+    write(joinpath(dn, "child.jl"), """
+        child() = 1
+        include("grandchild.jl")
+        """)
+    write(joinpath(dn, "grandchild.jl"), "grandchild() = 2")
+    write(joinpath(dn, "kept.jl"), "kept() = 3")
+    sleep(mtimedelay)
+    @eval using RemovedInclude
+    sleep(mtimedelay)
+    @test RemovedInclude.child() == 1
+    @test RemovedInclude.grandchild() == 2
+    @test RemovedInclude.kept() == 3
+    pkgdata = Revise.pkgdatas[Base.PkgId(RemovedInclude)]
+
+    # Drop one `include`. The removal is transitive: "grandchild.jl" was included
+    # only by the file that is also being removed.
+    write(joinpath(dn, "RemovedInclude.jl"), """
+        module RemovedInclude
+        include("kept.jl")
+        end
+        """)
+    logs, _ = Test.collect_test_logs() do
+        yry()
+    end
+    @latestworld
+    @test_throws MethodError RemovedInclude.child()
+    @test_throws MethodError RemovedInclude.grandchild()
+    @test RemovedInclude.kept() == 3
+    @test any(r -> occursin("no longer `include`d into RemovedInclude, deleted its methods", r.message), logs)
+    @test !Revise.hasfile(pkgdata, joinpath("src", "child.jl"))
+    @test !Revise.hasfile(pkgdata, joinpath("src", "grandchild.jl"))
+    @test !Revise.iswatched(pkgdata, joinpath("src", "child.jl"))
+    @test !Revise.iswatched(pkgdata, joinpath("src", "grandchild.jl"))
+    @test Revise.hasfile(pkgdata, joinpath("src", "kept.jl"))
+    @test Revise.iswatched(pkgdata, joinpath("src", "kept.jl"))
+
+    # A file that is no longer included is not revised into the module
+    write(joinpath(dn, "child.jl"), """
+        child() = 10
+        include("grandchild.jl")
+        """)
+    @yry(expect_revision=false)
+    @test_throws MethodError RemovedInclude.child()
+
+    # Restoring the `include` brings the file, and what it includes, back
+    write(joinpath(dn, "RemovedInclude.jl"), """
+        module RemovedInclude
+        include("child.jl")
+        include("kept.jl")
+        end
+        """)
+    @yry()
+    @latestworld
+    @test RemovedInclude.child() == 10
+    @test RemovedInclude.grandchild() == 2
+    @test Revise.hasfile(pkgdata, joinpath("src", "child.jl"))
+    @test Revise.hasfile(pkgdata, joinpath("src", "grandchild.jl"))
+    @test Revise.iswatched(pkgdata, joinpath("src", "child.jl"))
+    @test Revise.iswatched(pkgdata, joinpath("src", "grandchild.jl"))
+
+    rm_precompile("RemovedInclude")
+    pop!(LOAD_PATH)
+end
+
+## Removing one of several `(path, module)` inclusions
+do_test("Removed include, still included") && @testset "Removed include, still included" begin
+    testdir = newtestdir()
+    dn = joinpath(testdir, "SharedInclude", "src")
+    mkpath(dn)
+    write(joinpath(dn, "SharedInclude.jl"), """
+        module SharedInclude
+        module A
+        include("shared.jl")
+        end
+        module B
+        include("shared.jl")
+        end
+        end
+        """)
+    write(joinpath(dn, "shared.jl"), "shared() = 2")
+    sleep(mtimedelay)
+    @eval using SharedInclude
+    sleep(mtimedelay)
+    @test SharedInclude.A.shared() == 2
+    @test SharedInclude.B.shared() == 2
+    pkgdata = Revise.pkgdatas[Base.PkgId(SharedInclude)]
+
+    write(joinpath(dn, "SharedInclude.jl"), """
+        module SharedInclude
+        module A
+        end
+        module B
+        include("shared.jl")
+        end
+        end
+        """)
+    @yry()
+    @latestworld
+    @test_throws MethodError SharedInclude.A.shared()
+    @test SharedInclude.B.shared() == 2
+    @test Revise.iswatched(pkgdata, joinpath("src", "shared.jl"))   # B still includes it
+
+    rm_precompile("SharedInclude")
+    pop!(LOAD_PATH)
+end
+
+## Moving an `include` between modules (issues #730, #1104)
+do_test("Moved include") && @testset "Moved include" begin
+    testdir = newtestdir()
+    dn = joinpath(testdir, "MovedInclude", "src")
+    mkpath(dn)
+    write(joinpath(dn, "MovedInclude.jl"), """
+        module MovedInclude
+        module Inner
+        end
+        include("impl.jl")
+        end
+        """)
+    write(joinpath(dn, "impl.jl"), "impl() = 1")
+    sleep(mtimedelay)
+    @eval using MovedInclude
+    sleep(mtimedelay)
+    @test MovedInclude.impl() == 1
+    pkgdata = Revise.pkgdatas[Base.PkgId(MovedInclude)]
+
+    write(joinpath(dn, "MovedInclude.jl"), """
+        module MovedInclude
+        module Inner
+        include("impl.jl")
+        end
+        end
+        """)
+    @yry()
+    @latestworld
+    @test_throws MethodError MovedInclude.impl()
+    @test MovedInclude.Inner.impl() == 1
+    @test Revise.iswatched(pkgdata, joinpath("src", "impl.jl"))
+
+    # The file now belongs to `Inner`, and edits go there
+    write(joinpath(dn, "impl.jl"), "impl() = 2")
+    @yry()
+    @latestworld
+    @test MovedInclude.Inner.impl() == 2
+    @test_throws MethodError MovedInclude.impl()
+
+    rm_precompile("MovedInclude")
+    pop!(LOAD_PATH)
+end
+
+## Computed include paths remain tracked (issue #1104)
+do_test("Computed include path") && @testset "Computed include path" begin
+    testdir = newtestdir()
+    dn = joinpath(testdir, "ComputedInclude", "src")
+    mkpath(dn)
+    write(joinpath(dn, "ComputedInclude.jl"), """
+        module ComputedInclude
+        for f in ("impl.jl",)
+            include(f)
+        end
+        end
+        """)
+    write(joinpath(dn, "impl.jl"), "impl() = 1")
+    sleep(mtimedelay)
+    @eval using ComputedInclude
+    sleep(mtimedelay)
+    @test ComputedInclude.impl() == 1
+    pkgdata = Revise.pkgdatas[Base.PkgId(ComputedInclude)]
+
+    write(joinpath(dn, "ComputedInclude.jl"), """
+        module ComputedInclude
+        const files = ("impl.jl",)
+        for f in files
+            include(f)
+        end
+        end
+        """)
+    @yry()
+    @test ComputedInclude.impl() == 1
+    @test Revise.iswatched(pkgdata, joinpath("src", "impl.jl"))
+
+    rm_precompile("ComputedInclude")
+    pop!(LOAD_PATH)
+end
+
+## Removing an include with a literal destination module (issue #1104)
+do_test("Removed include, module argument") && @testset "Removed include, module argument" begin
+    testdir = newtestdir()
+    dn = joinpath(testdir, "ModArgInclude", "src")
+    mkpath(dn)
+    write(joinpath(dn, "ModArgInclude.jl"), """
+        module ModArgInclude
+        module Sub
+        end
+        Base.include(Sub, "impl.jl")
+        end
+        """)
+    write(joinpath(dn, "impl.jl"), "impl() = 1")
+    sleep(mtimedelay)
+    @eval using ModArgInclude
+    sleep(mtimedelay)
+    @test ModArgInclude.Sub.impl() == 1
+    pkgdata = Revise.pkgdatas[Base.PkgId(ModArgInclude)]
+    @test Revise.hasfile(pkgdata, joinpath("src", "impl.jl"))
+
+    write(joinpath(dn, "ModArgInclude.jl"), """
+        module ModArgInclude
+        module Sub
+        end
+        end
+        """)
+    @yry()
+    @latestworld
+    @test_throws MethodError ModArgInclude.Sub.impl()
+    @test !Revise.hasfile(pkgdata, joinpath("src", "impl.jl"))
+    @test !Revise.iswatched(pkgdata, joinpath("src", "impl.jl"))
+
+    rm_precompile("ModArgInclude")
+    pop!(LOAD_PATH)
+end
+
 do_test("New files & Requires.jl") && @testset "New files & Requires.jl" begin
     # Issue #107
     testdir = newtestdir()


### PR DESCRIPTION
Removing an `include` statement from a revised file now deletes the definitions contributed by the included file and stops watching it. Writing the statement back restores the old state. Multi-module includes and transfers from one module to another are handled correctly.

A file registered during revision now has its own `include` statements registered too, rather than discarded.

Detection reads the old and new source statically and recognizes only literal paths. An `include` assembled in a loop or read from a variable is not handled.

Fixes #1104.