### PR TITLE
signatures: Use Base default constructor helpers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,9 @@ name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
 version = "3.16.3"
 
+[workspace]
+projects = ["docs", "test"]
+
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -49,6 +52,3 @@ UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [targets]
 test = ["CatIndices", "Distributed", "EndpointRanges", "EponymTuples", "Example", "IndirectArrays", "InteractiveUtils", "MacroTools", "MappedArrays", "Pkg", "Random", "Requires", "RoundingIntegers", "Test", "UnsafeArrays"]
-
-[workspace]
-projects = ["docs", "test"]

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -60,7 +60,7 @@ function is_defaultctors(@nospecialize(f))
     return false
 end
 
-# Keep synchronized with `Base._fieldtypes_constrain_typevars` until Revise can require it.
+# Keep this fallback synchronized until Revise can require the Base implementation.
 function _fieldtypes_constrain_typevars(tvars::Array{Any,1}, fts::Core.SimpleVector)
     nparams = length(tvars)
     n = length(fts)
@@ -569,17 +569,26 @@ function _methods_by_execution!(
                     lnn = lookup(frame, callstmt.args[3])
                     if T isa Type && lnn isa LineNumberNode
                         empty!(signatures)
-                        uT = Base.unwrap_unionall(T)::DataType
-                        ft = uT.types
+                        @static if isdefinedglobal(Base, :_defaultctor_typeinfo)
+                            uT, tvars, ft = Base._defaultctor_typeinfo(T)
+                        else
+                            uT = Base.unwrap_unionall(T)::DataType
+                            tvars = Any[]
+                            ua = T
+                            while ua isa UnionAll
+                                push!(tvars, ua.var)
+                                ua = ua.body
+                            end
+                            ft = ccall(:jl_get_fieldtypes, Any, (Any,), uT)::Core.SimpleVector
+                        end
                         sig1 = Tuple{Base.rewrap_unionall(Type{uT}, T), Any[Any for _ in 1:length(ft)]...}
                         push!(signatures, MethodInfoKey(nothing, sig1))
-                        tvars = Any[]
-                        ua = T
-                        while ua isa UnionAll
-                            push!(tvars, ua.var)
-                            ua = ua.body
+                        @static if isdefinedglobal(Base, :_fieldtypes_constrain_typevars)
+                            constrains_all = Base._fieldtypes_constrain_typevars(tvars, ft)
+                        else
+                            constrains_all = _fieldtypes_constrain_typevars(tvars, ft)
                         end
-                        if _fieldtypes_constrain_typevars(tvars, ft)
+                        if constrains_all
                             sig2 = Base.rewrap_unionall(Tuple{Type{T}, ft...}, T)
                             sig1 == sig2 || push!(signatures, MethodInfoKey(nothing, sig2))
                         end


### PR DESCRIPTION
JuliaLang/julia#62670 exposes the constructor type decomposition and type-variable constraint check used by `Base._defaultctors`. Revise currently reconstructs that information while extracting the signatures handled by timholy/Revise.jl#1117.

Use `Base._defaultctor_typeinfo` and `Base._fieldtypes_constrain_typevars` when available. Keep local fallbacks for older Julia releases, and obtain field types through `jl_get_fieldtypes` so both paths model default constructors consistently.