### PR TITLE
Seed cache_src_id's hash with a UInt, not a UInt64

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -135,7 +135,10 @@ end
 # Julia 1.11+ records a size and a content hash; 1.10 records only the source file's
 # mtime, so on that version a file merely touched between two builds reads as changed.
 @static if VERSION >= v"1.11.0-DEV.683"    # https://github.com/JuliaLang/julia/pull/49866
-    cache_src_id(inc) = hash(inc.fsize, UInt64(inc.hash))
+    # The seed `hash` takes is a `UInt`, which is 32 bits wide on a 32 bit platform, while
+    # the content hash the cache header records is always a `UInt64` — so it is truncated
+    # rather than passed through, which only has to identify the snapshot.
+    cache_src_id(inc) = hash(inc.fsize, inc.hash % UInt)
 else
     cache_src_id(inc) = hash(inc.mtime)
 end


### PR DESCRIPTION
On a 32 bit platform `UInt` is 32 bits wide, so passing the cache header's `UInt64` content hash to `hash` as the seed throws:

```
MethodError: no method matching hash(::UInt64, ::UInt64)
  at cache_src_id (src/pkgs.jl:138)
  at parse_pkg_files (src/loading.jl:118)
  at watch_package (src/pkgs.jl:636)
```

That takes down the whole package callback, so on a 32 bit Julia every package loaded after Revise is active reports `Error during package callback`. We hit it on the `x86` legs of our CI, where it surfaced as unrelated test failures.

Truncating with `% UInt` keeps the value inside the type `hash` wants. It only has to identify a source snapshot within one session, and on 64 bit it is exactly the same value as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)