### PR TITLE
Fix cache_src_id MethodError on 32-bit Julia

### DIFF
--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -135,7 +135,7 @@ end
 # Julia 1.11+ records a size and a content hash; 1.10 records only the source file's
 # mtime, so on that version a file merely touched between two builds reads as changed.
 @static if VERSION >= v"1.11.0-DEV.683"    # https://github.com/JuliaLang/julia/pull/49866
-    cache_src_id(inc) = hash(inc.fsize, UInt64(inc.hash))
+    cache_src_id(inc) = hash(inc.fsize, UInt(inc.hash))
 else
     cache_src_id(inc) = hash(inc.mtime)
 end


### PR DESCRIPTION
`cache_src_id` hashes with a hardcoded `UInt64` seed, but `hash`'s seed argument must be word-size-native `UInt`. On 32-bit Julia this throws `MethodError: no method matching hash(::UInt64, ::UInt64)` whenever Revise's package-watching callback parses a newly precompiled package's cache header (Julia 1.11+), i.e. on almost every `using` of a new package.

Fix: `UInt64(inc.hash)` -> `UInt(inc.hash)`.

Tested on Julia 1.12.7 (i686-w64-mingw32): the error is gone, no change in behavior on 64-bit.