### PR TITLE
Add a 32-bit CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    name: Test Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    name: Test Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow_failure }}
     strategy:
@@ -27,11 +27,19 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        arch:
+          - x64
         allow_failure: [false]
         include:
           - version: 'nightly'
             os: ubuntu-latest
+            arch: x64
             allow_failure: true
+          # 32-bit run: catches `UInt`/`UInt64` conflations and other word-size assumptions
+          - version: '1'
+            os: ubuntu-latest
+            arch: x86
+            allow_failure: false
     env:
       REVISE_PRECOMPILE_ERROR: true
     steps:
@@ -39,6 +47,7 @@ jobs:
     - uses: julia-actions/setup-julia@latest
       with:
         version: ${{ matrix.version }}
+        arch: ${{ matrix.arch }}
         show-versioninfo: ${{ matrix.version == 'nightly' }}
     - uses: julia-actions/cache@v3
     - uses: julia-actions/julia-buildpkg@latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.16.4"
+version = "3.16.5"
 
 [workspace]
 projects = ["docs", "test"]


### PR DESCRIPTION
`UInt` is 32 bits wide on such platforms, so code that conflates it with `UInt64` fails there and nowhere else. See #1120.

v3.16.5

Assisted-by: Claude Opus 5 <noreply@anthropic.com>