### PR TITLE
Read __revise_mode__ in the latest world

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -893,13 +893,19 @@ function eval_new!(exs_infos_new::ExprsInfos, exs_infos_old::ExprsInfos, mod::Mo
     return exs_infos_new, includes
 end
 
+# A module's `__revise_mode__` binding postdates Revise's frozen world, so with
+# world-partitioned bindings (Julia 1.12+) it must be read in the latest world even
+# though revision itself runs under `frozen` (issue #1116).
+function revise_mode(mod::Module, default::Symbol)
+    @invokelatest(isdefinedglobal(mod, :__revise_mode__)) || return default
+    return (@invokelatest getglobal(mod, :__revise_mode__))::Symbol
+end
+
 function eval_new!(mod_exs_infos_new::ModuleExprsInfos, mod_exs_infos_old::ModuleExprsInfos; mode::Symbol=:eval)
     includes = Vector{Tuple{Module,Function,String}}()
     for (mod, exs_infos_new) in mod_exs_infos_new
         # Allow packages to override the supplied mode
-        if isdefined(mod, :__revise_mode__)
-            mode = getfield(mod, :__revise_mode__)::Symbol
-        end
+        mode = revise_mode(mod, mode)
         exs_infos_old = get(mod_exs_infos_old, mod, empty_exs_infos)
         _, _includes = eval_new!(exs_infos_new, exs_infos_old, mod; mode)
         append!(includes, _includes)
@@ -1888,11 +1894,8 @@ function _revise(; throw::Bool=false)
                 for (mod, exs_infos_new) in mod_exs_infos_new
                     mod ∈ modsremaining || continue
                     try
-                        mode = defaultmode
                         # Allow packages to override the supplied mode
-                        if isdefinedglobal(mod, :__revise_mode__)
-                            mode = getglobal(mod, :__revise_mode__)::Symbol
-                        end
+                        mode = revise_mode(mod, defaultmode)
                         mode ∈ (:sigs, :eval, :evalmeth, :evalassign) || error("unsupported mode ", mode)
                         exs_infos_old = get(fi.mod_exs_infos, mod, empty_exs_infos)
                         for rex in keys(exs_infos_new)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -502,6 +502,35 @@ end
         pop!(LOAD_PATH)
     end
 
+    do_test("__revise_mode__ override") && @testset "__revise_mode__ override" begin
+        # `__revise_mode__` bindings postdate Revise's frozen world and must still be
+        # honored when revision runs in that world (issue #1116)
+        testdir = newtestdir()
+        fn = joinpath(testdir, "revisemode.jl")
+        write(fn, """
+            module ReviseModeOverride
+            __revise_mode__ = :evalassign
+            flag = 1
+            end
+            """)
+        sleep(mtimedelay)
+        includet(fn)
+        @latestworld
+        @test ReviseModeOverride.flag == 1
+        sleep(mtimedelay)
+        write(fn, """
+            module ReviseModeOverride
+            __revise_mode__ = :evalassign
+            flag = 2
+            end
+            """)
+        @yry()
+        # Under the default `:evalmeth` mode the assignment would not be re-evaluated
+        @test ReviseModeOverride.flag == 2
+
+        pop!(LOAD_PATH)
+    end
+
     do_test("Display") && @testset "Display" begin
         io = IOBuffer()
         show(io, Revise.RelocatableExpr(:(@inbounds x[2])))


### PR DESCRIPTION
`revise()` runs pinned to Revise's frozen world (issue #552). On Julia 1.12+, bindings are world-partitioned, so a `__revise_mode__` defined after Revise's `__init__` — essentially always, since user modules load later — was invisible to the mode lookup and the documented override was silently ignored. Read the binding with `@invokelatest` at both lookup sites, and add a regression test.

Fixes #1116

Assisted-by: Claude Fable 5 (claude-fable-5) <noreply@anthropic.com>