### PR TITLE
Warn when a loaded package switches versions

### DIFF
--- a/src/logging.jl
+++ b/src/logging.jl
@@ -35,7 +35,9 @@ function CoreLogging.handle_message(logger::ReviseLogger, level, msg, _module,
             showerror(stderr, ex, bt; backtrace = bt!==nothing)
             println(stderr, "\nwhile evaluating\n", kwargs[:ex], "\nin module ", kwargs[:mod])
         else
-            show(stderr, rec)
+            # `show` ends with a newline only for records that carry an exception;
+            # normalize so the record always occupies its own line(s) on stderr.
+            println(stderr, chomp(sprint(show, rec)))
         end
     end
 end

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -881,6 +881,23 @@ end
 
 function switch_basepath(pkgdata::PkgData, newpath::String)
     oldpath = basedir(pkgdata)
+    # issue #1111: a Pkg operation can switch a *loaded* package to a different
+    # registered version (e.g., adding a package whose compat requirements force a
+    # downgrade of another). Revise follows the manifest, and most cross-version
+    # changes apply like ordinary revisions; a few cannot be applied (e.g., Julia
+    # refuses to redeclare a `public` name as `export`ed), and a failed evaluation
+    # leaves prior deletions in place, so the running package can end up partially
+    # updated. Announce the version switch up front so that any warnings or errors
+    # that follow are attributable to it.
+    if isdefined(Base, :get_pkgversion_from_path)
+        oldv = Base.get_pkgversion_from_path(oldpath)
+        newv = Base.get_pkgversion_from_path(newpath)
+        if oldv !== nothing && newv !== nothing && oldv != newv
+            @warn """$(PkgId(pkgdata).name) changed from version $oldv to $newv while loaded. \
+                Revise will attempt to update the running session to the new version; \
+                if errors follow, the update could not be fully applied and you should restart Julia."""
+        end
+    end
     # Stop all associated watching tasks
     for dir in unique_dirs(srcfiles(pkgdata))
         @debug "Pkg" _group="unwatch" dir=dir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5718,6 +5718,49 @@ do_test("Unchanged files across a path switch") && @testset "Unchanged files acr
     end
 end
 
+do_test("Version switch warning") && @testset "Version switch warning" begin
+    # A Pkg operation can point the manifest of a *loaded* package at a different
+    # registered version (issue #1111: adding PlotlyJS downgraded a loaded JSON from
+    # 1.x to 0.21). Revise follows the switch, but not every cross-version change can
+    # be applied to a running session (e.g., Julia refuses to redeclare a `public`
+    # name as `export`ed), so the switch itself is announced up front to make any
+    # errors that follow attributable.
+    mod = Module(:VersionSwitch)
+    Core.eval(mod, :(using Base))
+    id = Base.PkgId(Base.UUID("00000000-0000-0000-0000-000000001111"), "VersionSwitch")
+    olddir, newdir, patchdir = mktempdir(), mktempdir(), mktempdir()
+    for (dir, version, body) in ((olddir, "1.7.1", "f() = 1\n"),
+                                 (newdir, "0.21.4", "f() = 2\n"),
+                                 (patchdir, "0.21.4", "f() = 3\n"))
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "Project.toml"), """
+            name = "VersionSwitch"
+            uuid = "00000000-0000-0000-0000-000000001111"
+            version = "$version"
+            """)
+        write(joinpath(dir, "src", "VersionSwitch.jl"), body)
+    end
+    file = joinpath("src", "VersionSwitch.jl")
+    pkgdata = Revise.PkgData(id, olddir)
+    mei = Revise.ModuleExprsInfos(mod)
+    mei[mod][Revise.RelocatableExpr(:(f() = 1))] = nothing
+    push!(pkgdata, file=>Revise.FileInfo(mei))
+    try
+        @test_logs (:warn, r"VersionSwitch changed from version 1\.7\.1 to 0\.21\.4 while loaded") match_mode=:any Revise.switch_basepath(pkgdata, newdir)
+        @test Revise.basedir(pkgdata) == newdir
+        @test (pkgdata, file) ∈ Revise.revision_queue
+        # A switch that keeps the version (e.g., `Pkg.develop` of a copy of the
+        # loaded release) stays quiet.
+        @test_logs min_level=Base.CoreLogging.Warn Revise.switch_basepath(pkgdata, patchdir)
+        @test Revise.basedir(pkgdata) == patchdir
+    finally
+        filter!(pr -> first(pr) !== pkgdata, Revise.revision_queue)
+        for dir in (olddir, newdir, patchdir)
+            delete!(Revise.watched_files, joinpath(dir, "src"))
+        end
+    end
+end
+
 do_test("Path switch without a baseline") && @testset "Path switch without a baseline" begin
     # A file whose cached source snapshot is gone has no baseline to compare the new
     # location against, and the old location's source on disk is not one either. The file


### PR DESCRIPTION
A Pkg operation (e.g., adding a package whose compat requirements force a downgrade of another) can point the manifest of a loaded package at a different registered version. Revise follows the manifest, and most cross-version changes apply like ordinary revisions; a few cannot be applied (e.g., Julia refuses to redeclare a `public` name as `export`ed), and a failed evaluation leaves prior deletions in place, so the running package can end up partially updated, with method-deletion warnings and evaluation errors that carry no indication of what triggered them. Announce the version switch with a warning before revising, so the fallout is attributable and the user knows a restart may be needed.

Also terminate ReviseLogger's stderr records with a newline: the new warning is emitted while the manifest watcher's logger is active, and without the newline it runs together with subsequent Pkg output.

Fixes #1111

Assisted-by: Claude Fable 5 <noreply@anthropic.com>