### PR TITLE
Re-arm watches when missing paths reappear

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1007,7 +1007,8 @@ function init_watching(pkgdata::PkgData, files=srcfiles(pkgdata))
                                  to register.""" maxlog=1
                     end
                     fwatcher = TaskThunk(revise_file_queued, (pkgdata, file))
-                    schedule(Task(fwatcher))
+                    # Report watcher failures.
+                    errormonitor(schedule(Task(fwatcher)))
                 else
                     already_watching_dir || push!(udirs, dirfull)
                 end
@@ -1022,7 +1023,8 @@ function init_watching(pkgdata::PkgData, files=srcfiles(pkgdata))
             # which never deliver notifications.
             polling_files[] || nonnotifying_path(dirfull) || watch_folder(dirfull, 0)
             dwatcher = TaskThunk(revise_dir_queued, (dirfull,))
-            schedule(Task(dwatcher))
+            # Report watcher failures.
+            errormonitor(schedule(Task(dwatcher)))
         end
     end
     return nothing
@@ -1052,6 +1054,68 @@ function await_watched_path(exists, path::AbstractString, watchkey::AbstractStri
     return :reappeared
 end
 
+# Watches that were relinquished, mapping each absent path to its tracked files.
+# Entries are protected by `revise_lock`.
+const lost_watches = Dict{String,Vector{Pair{String,PkgId}}}()
+
+# Relinquish a watch and record its tracked files for `rearm_watching`.
+# For per-file watches, `path` identifies the file and `dirname` its directory.
+function relinquish_watch(dirname::AbstractString, path::AbstractString=dirname)
+    @lock revise_lock begin
+        wl = get(watched_files, dirname, nothing)
+        wl === nothing && return nothing
+        entries = get!(Vector{Pair{String,PkgId}}, lost_watches, path)
+        if path == dirname
+            for (basename, id) in wl.trackedfiles
+                push!(entries, joinpath(dirname, basename) => id)
+            end
+            delete!(watched_files, dirname)
+        else
+            _, basename = splitdir(path)
+            id = get(wl.trackedfiles, basename, nothing)
+            if id === nothing
+                isempty(entries) && delete!(lost_watches, path)
+                return nothing
+            end
+            push!(entries, path => id)
+            delete!(wl.trackedfiles, basename)
+            delete!(wl.file_ctimes, basename)
+            delete!(wl.file_hashes, basename)
+        end
+    end
+    return nothing
+end
+
+# Resume watches whose paths have reappeared and queue their files for revision.
+function rearm_watching()
+    lost = @lock revise_lock begin
+        isempty(lost_watches) && return nothing
+        collect(lost_watches)
+    end
+    for (path, entries) in lost
+        ispath(path) || continue
+        @lock revise_lock delete!(lost_watches, path)
+        requeue = Tuple{PkgData,String}[]
+        for (fullfile, id) in entries
+            pkgdata = getpkgdata(id)
+            pkgdata === nothing && continue
+            file = relpath(fullfile, pkgdata)
+            iswatched(pkgdata, file) && continue
+            if id != NOPACKAGE && !hasfile(pkgdata, file)
+                # Do not resume watching a file that was untracked meanwhile.
+                continue
+            end
+            init_watching(pkgdata, (file,))
+            id == NOPACKAGE || push!(requeue, (pkgdata, file))
+        end
+        if !isempty(requeue)
+            @lock revise_lock union!(revision_queue, requeue)
+            notify(revision_event)
+        end
+    end
+    return nothing
+end
+
 """
     revise_dir_queued(dirname::AbstractString)
 
@@ -1061,49 +1125,51 @@ This is generally called via a [`Revise.TaskThunk`](@ref).
 """
 @noinline function revise_dir_queued(dirname::AbstractString)
     @assert isabspath(dirname)
-    stillwatching = true
-    while stillwatching
-        if !isdir(dirname)
-            status = await_watched_path(isdir, dirname, dirname)
-            if status !== :reappeared
-                if status === :gone
-                    with_logger(SimpleLogger(stderr)) do
-                        @warn "$dirname is not an existing directory, Revise is not watching"
+    try
+        stillwatching = true
+        while stillwatching
+            if !isdir(dirname)
+                status = await_watched_path(isdir, dirname, dirname)
+                if status !== :reappeared
+                    if status === :gone
+                        with_logger(SimpleLogger(stderr)) do
+                            @warn "$dirname is not an existing directory, Revise is not watching (watching resumes if it reappears)"
+                        end
+                        relinquish_watch(dirname)
                     end
-                    # Drop the watch registration as we stop. Otherwise, if `dirname`
-                    # is recreated later (e.g. switching back to a branch that has it),
-                    # `init_watching` would see the stale entry, assume a watcher is
-                    # already running, and never start a replacement — so edits to the
-                    # reappeared files would go unnoticed.
-                    @lock revise_lock delete!(watched_files, dirname)
+                    break
                 end
-                break
+                # Reappeared: the directory was removed and recreated, so the existing
+                # monitor may be watching a stale inode. Drop it; the next
+                # `wait_changed_dir` re-registers a fresh one.
+                unwatch_folder(dirname)
             end
-            # Reappeared: the directory was removed and recreated, so the existing
-            # monitor may be watching a stale inode. Drop it; the next
-            # `wait_changed_dir` re-registers a fresh one.
-            unwatch_folder(dirname)
-        end
 
-        latestfiles, stillwatching = watch_files_via_dir(dirname)  # will block here until file(s) change
-        for (file, id) in latestfiles
-            key = joinpath(dirname, file)
-            @lock revise_lock begin
-                if key in keys(user_callbacks_by_file)
-                    union!(user_callbacks_queue, user_callbacks_by_file[key])
-                    notify(revision_event)
-                end
-                if id != NOPACKAGE
-                    pkgdata = pkgdatas[id]
-                    if hasfile(pkgdata, key)  # issue #228
-                        push!(revision_queue, (pkgdata, relpath(key, pkgdata)))
+            latestfiles, stillwatching = watch_files_via_dir(dirname)  # will block here until file(s) change
+            for (file, id) in latestfiles
+                key = joinpath(dirname, file)
+                @lock revise_lock begin
+                    if key in keys(user_callbacks_by_file)
+                        union!(user_callbacks_queue, user_callbacks_by_file[key])
                         notify(revision_event)
                     end
+                    if id != NOPACKAGE
+                        pkgdata = pkgdatas[id]
+                        if hasfile(pkgdata, key)  # issue #228
+                            push!(revision_queue, (pkgdata, relpath(key, pkgdata)))
+                            notify(revision_event)
+                        end
+                    end
                 end
             end
         end
+    catch
+        # Release the stale registration so the watch can be rearmed.
+        relinquish_watch(dirname)
+        rethrow()
+    finally
+        unwatch_folder(dirname)  # stop the OS watch now that we no longer watch this dir
     end
-    unwatch_folder(dirname)  # stop the OS watch now that we no longer watch this dir
     return
 end
 
@@ -1123,47 +1189,54 @@ function revise_file_queued(pkgdata::PkgData, file)
 
     dirfull, _ = splitdir(file)
     fileexists(f) = file_exists(f) || isdir(f)
-    stillwatching = true
-    while stillwatching
-        if !fileexists(file)
-            status = await_watched_path(fileexists, file, dirfull)
-            if status !== :reappeared
-                if status === :gone
-                    let file=file
-                        with_logger(SimpleLogger(stderr)) do
-                            @warn "$file is not an existing file, Revise is not watching"
+    try
+        stillwatching = true
+        while stillwatching
+            if !fileexists(file)
+                status = await_watched_path(fileexists, file, dirfull)
+                if status !== :reappeared
+                    if status === :gone
+                        let file=file
+                            with_logger(SimpleLogger(stderr)) do
+                                @warn "$file is not an existing file, Revise is not watching (watching resumes if it reappears)"
+                            end
                         end
+                        relinquish_watch(dirfull, file)
+                    end
+                    notify(revision_event)
+                    break
+                end
+            end
+            try
+                wait_changed(file)  # will block here until the file changes
+            catch e
+                # issue #459
+                (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
+            end
+
+            @lock revise_lock begin
+                if file in keys(user_callbacks_by_file)
+                    union!(user_callbacks_queue, user_callbacks_by_file[file])
+                    notify(revision_event)
+                end
+                # Check to see if we're still watching this file
+                stillwatching = haskey(watched_files, dirfull)
+                if PkgId(pkgdata) != NOPACKAGE
+                    relfile = relpath(file, pkgdata)
+                    if hasfile(pkgdata, relfile)
+                        push!(revision_queue, (pkgdata, relfile))
+                    else
+                        # The file was dropped from `pkgdata` (its `include` was removed),
+                        # so there is nothing left to revise: stop watching it.
+                        stillwatching = false
                     end
                 end
-                notify(revision_event)
-                break
             end
         end
-        try
-            wait_changed(file)  # will block here until the file changes
-        catch e
-            # issue #459
-            (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
-        end
-
-        @lock revise_lock begin
-            if file in keys(user_callbacks_by_file)
-                union!(user_callbacks_queue, user_callbacks_by_file[file])
-                notify(revision_event)
-            end
-            # Check to see if we're still watching this file
-            stillwatching = haskey(watched_files, dirfull)
-            if PkgId(pkgdata) != NOPACKAGE
-                relfile = relpath(file, pkgdata)
-                if hasfile(pkgdata, relfile)
-                    push!(revision_queue, (pkgdata, relfile))
-                else
-                    # The file was dropped from `pkgdata` (its `include` was removed),
-                    # so there is nothing left to revise: stop watching it.
-                    stillwatching = false
-                end
-            end
-        end
+    catch
+        # Release the stale registration so the watch can be rearmed.
+        relinquish_watch(dirfull, file)
+        rethrow()
     end
     return
 end
@@ -1758,6 +1831,9 @@ revise(; throw::Bool=false) = frozen(_revise; throw)
 
 function _revise(; throw::Bool=false)
     active[] || return nothing
+
+    # Restore relinquished watches before draining the revision queue.
+    rearm_watching()
 
     @lock revise_lock begin
         have_queue_errors = !isempty(queue_errors)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7136,6 +7136,120 @@ do_test("re-watch after reappearance") && !Revise.watching_files[] && Sys.islinu
     end
 end
 
+# This test exercises Linux directory-watching behavior.
+do_test("re-arm dropped watch") && !Revise.watching_files[] && Sys.islinux() &&
+        @testset "re-arm dropped watch" begin
+    # Reappearance must restore a relinquished watch and revise missed changes.
+    testdir = newtestdir()
+    dn = joinpath(testdir, "ReArm", "src")
+    subdir = joinpath(dn, "sub")
+    mkpath(subdir)
+    write(joinpath(dn, "ReArm.jl"), """
+        module ReArm
+        include("sub/extra.jl")
+        f() = 1
+        end
+        """)
+    write(joinpath(subdir, "extra.jl"), "g() = 2")
+    sleep(mtimedelay)
+    @eval using ReArm
+    sleep(mtimedelay)
+    @test ReArm.g() == 2
+    @test haskey(Revise.watched_files, subdir)
+
+    old_grace = Revise.watch_reappear_grace[]
+    Revise.watch_reappear_grace[] = 0.0   # give up promptly so the round-trip is quick
+    try
+        rm(subdir; recursive=true)
+        @test timedwait(() -> !haskey(Revise.watched_files, subdir), event_timeout) === :ok
+        @yry
+
+        # The directory returns without a change to its `include`.
+        mkdir(subdir)
+        write(joinpath(subdir, "extra.jl"), "g() = 3")
+        sleep(mtimedelay)
+        revise()
+        @latestworld
+        @test haskey(Revise.watched_files, subdir)
+        @test ReArm.g() == 3
+
+        # The resumed watch detects later edits.
+        write(joinpath(subdir, "extra.jl"), "g() = 99")
+        @yry
+        @test ReArm.g() == 99
+    finally
+        Revise.watch_reappear_grace[] = old_grace
+    end
+    rm_precompile("ReArm")
+end
+
+# This test exercises Linux directory-watching behavior.
+do_test("re-arm skips untracked files") && !Revise.watching_files[] && Sys.islinux() &&
+        @testset "re-arm skips untracked files" begin
+    # Reappearance must not restore a file that was untracked meanwhile.
+    testdir = newtestdir()
+    dn = joinpath(testdir, "ReArmGone", "src")
+    subdir = joinpath(dn, "sub")
+    mkpath(subdir)
+    write(joinpath(dn, "ReArmGone.jl"), """
+        module ReArmGone
+        include("sub/extra.jl")
+        f() = 1
+        end
+        """)
+    write(joinpath(subdir, "extra.jl"), "g() = 2")
+    sleep(mtimedelay)
+    @eval using ReArmGone
+    sleep(mtimedelay)
+    @test ReArmGone.g() == 2
+    pkgdata = Revise.pkgdatas[Base.PkgId(ReArmGone)]
+
+    old_grace = Revise.watch_reappear_grace[]
+    Revise.watch_reappear_grace[] = 0.0   # give up promptly so the round-trip is quick
+    try
+        rm(subdir; recursive=true)
+        @test timedwait(() -> !haskey(Revise.watched_files, subdir), event_timeout) === :ok
+
+        # Remove the `include` while the watch is down.
+        write(joinpath(dn, "ReArmGone.jl"), """
+            module ReArmGone
+            f() = 1
+            end
+            """)
+        logs, _ = Test.collect_test_logs() do
+            yry()
+        end
+        @latestworld
+        @test any(r -> occursin("no longer `include`d into ReArmGone, deleted its methods", r.message), logs)
+        @test_throws MethodError ReArmGone.g()
+        @test !Revise.hasfile(pkgdata, joinpath("src", "sub", "extra.jl"))
+
+        # The untracked file remains unwatched and unrevised.
+        mkdir(subdir)
+        write(joinpath(subdir, "extra.jl"), "g() = 3")
+        sleep(mtimedelay)
+        revise()
+        @latestworld
+        @test !haskey(Revise.watched_files, subdir)
+        @test_throws MethodError ReArmGone.g()
+
+        # Restoring the `include` registers the file again.
+        write(joinpath(dn, "ReArmGone.jl"), """
+            module ReArmGone
+            include("sub/extra.jl")
+            f() = 1
+            end
+            """)
+        @yry()
+        @latestworld
+        @test ReArmGone.g() == 3
+        @test haskey(Revise.watched_files, subdir)
+    finally
+        Revise.watch_reappear_grace[] = old_grace
+    end
+    rm_precompile("ReArmGone")
+end
+
 do_test("Frozen world") && @testset "Frozen world" begin
     # Revise pins its own method dispatch to the world it froze at `__init__` (issue #552),
     # so revising a method Revise itself uses cannot invalidate Revise mid-operation. The rest


### PR DESCRIPTION
Record files whose watches are relinquished after a path remains missing. When the path returns, restore its watch and queue tracked files, except those untracked meanwhile.

Release stale registrations when watcher tasks fail so they can also be rearmed.
