### PR TITLE
Retract bindings removed from source

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -76,7 +76,9 @@ your methods and/or data. `__revise_mode__` must be a `Symbol` taking one of the
 - `:evalassign`: evaluate method definitions and assignment statements. A top-level expression
   `a = Int[]` would be evaluated, but `push!(a, 1)` would not because the latter is not an assignment.
 - `:sigs`: do not implement any changes, only scan method definitions for their signatures so that
-  their location can be updated as changes to the file(s) are made.
+  their location can be updated as changes to the file(s) are made. `using`, `import`, and `export`
+  statements added by a revision are still executed, because a signature may be written in terms of
+  a name the new statement brings into scope.
 
 If you're using `includet` from the REPL, you can enter `__revise_mode__ = :eval` to set
 it throughout `Main`. `__revise_mode__` can be set independently in each module.

--- a/src/lowered.jl
+++ b/src/lowered.jl
@@ -118,13 +118,30 @@ function matches_eval(stmt::Expr)
            (isa(f, GlobalRef) && f.name === :eval) || is_quotenode_egal(f, Core.eval)
 end
 
+is_namespace_head(head::Symbol) = head === :export || head === :import || head === :using
+
+# On Julia 1.13+, `using`/`import` statements lower to calls to these `Base` functions
+# rather than surviving as `Expr(:using)`/`Expr(:import)` statements (`export` still
+# lowers unwrapped).
+@static if isdefined(Base, :_eval_import) && isdefined(Base, :_eval_using)
+    function is_namespace_call(@nospecialize(f))
+        if isa(f, GlobalRef)
+            return f.mod === Base && (f.name === :_eval_import || f.name === :_eval_using)
+        end
+        return f === Base._eval_import || f === Base._eval_using ||
+               is_quotenode_egal(f, Base._eval_import) || is_quotenode_egal(f, Base._eval_using)
+    end
+else
+    is_namespace_call(@nospecialize(f)) = false
+end
+
 function categorize_stmt(@nospecialize(stmt), code::Vector{Any})
     ismeth, haseval, isinclude, isnamespace, istoplevel = false, false, false, false, false
     if isa(stmt, Expr)
         haseval = matches_eval(stmt)
         ismeth = stmt.head === :method || (stmt.head === :thunk && defines_function(only(stmt.args)))
         istoplevel = stmt.head === :toplevel
-        isnamespace = stmt.head === :export || stmt.head === :import || stmt.head === :using
+        isnamespace = is_namespace_head(stmt.head)
         isinclude = false
         if stmt.head === :call && length(stmt.args) >= 1
             callee = stmt.args[1]
@@ -133,6 +150,7 @@ function categorize_stmt(@nospecialize(stmt), code::Vector{Any})
             end
             isinclude = is_some_include(callee)
             ismeth = is_defaultctors(callee) || is_define_method_ref(callee)
+            isnamespace |= is_namespace_call(callee)
         end
     end
     return ismeth, haseval, isinclude, isnamespace, istoplevel
@@ -222,11 +240,11 @@ end
 @noinline minimal_evaluation!(@nospecialize(predicate), frame::Frame, mode::Symbol) =
     minimal_evaluation!(predicate, moduleof(frame), frame.framecode.src, mode)
 
-function minimal_evaluation!(frame::Frame, mode::Symbol)
+function minimal_evaluation!(frame::Frame, mode::Symbol; eval_namespace::Bool=mode!==:sigs)
     minimal_evaluation!(frame, mode) do @nospecialize(stmt), code::Vector{Any}
         ismeth, haseval, isinclude, isnamespace, istoplevel = categorize_stmt(stmt, code)
-        isreq = ismeth | isinclude | istoplevel
-        return mode === :sigs ? (isreq, haseval) : (isreq | isnamespace, haseval)
+        isreq = ismeth | isinclude | istoplevel | (isnamespace & eval_namespace)
+        return (isreq, haseval)
     end
 end
 
@@ -239,7 +257,8 @@ end
 """
     methods_by_execution!(
         [interp::Interpreter=JuliaInterpreter.Compiled(),] exinfo::ExInfo, mod::Module, ex::Expr;
-        mode::Symbol = :eval, disablebp::Bool = true, skip_include::Bool = mode!==:eval, always_rethrow::Bool = false
+        mode::Symbol = :eval, disablebp::Bool = true, skip_include::Bool = mode!==:eval,
+        eval_namespace::Bool = mode!==:sigs, always_rethrow::Bool = false
     )
 
 Evaluate or analyze `ex` in the context of `mod`.
@@ -277,13 +296,17 @@ The other keyword arguments are more straightforward:
   They are restored on exit.
 - `skip_include` prevents execution of `include` statements, instead inserting them into `exinfo`'s
   cache. This defaults to `true` unless `mode` is `:eval`.
+- `eval_namespace` controls whether `using`/`import`/`export` statements are executed. It defaults
+  to `true` except in `:sigs` mode. Set it for revised source whose signatures depend on new
+  namespace statements. Leave it unset when cataloging loaded source to avoid loading packages.
 - `always_rethrow`, if true, causes an error to be thrown if evaluating `ex` triggered an error.
   If false, the error is logged with `@error`. `InterruptException`s are always rethrown.
   This is primarily useful for debugging.
 """
 function methods_by_execution!(
         interp::Interpreter, exinfo::ExInfo, mod::Module, ex::Expr;
-        mode::Symbol = :eval, disablebp::Bool = true, always_rethrow::Bool = false, kwargs...
+        mode::Symbol = :eval, disablebp::Bool = true, eval_namespace::Bool = mode!==:sigs,
+        always_rethrow::Bool = false, kwargs...
     )
     mode ∈ (:sigs, :eval, :evalmeth, :evalassign) || error("unsupported mode ", mode)
     lwr = Meta.lower(mod, ex)
@@ -292,7 +315,10 @@ function methods_by_execution!(
         throw(LoweringException(lwr))
     end
     if lwr.head !== :thunk
-        mode === :sigs && return Pair{Any,Union{Nothing,Expr}}(nothing, nothing)
+        # A namespace statement can survive lowering unwrapped (e.g. a bare `export foo`).
+        if mode === :sigs && !(eval_namespace && is_namespace_head(lwr.head))
+            return Pair{Any,Union{Nothing,Expr}}(nothing, nothing)
+        end
         return Pair{Any,Union{Nothing,Expr}}(Core.eval(mod, lwr), nothing)
     end
     # Interpret user code at the latest world (JuliaInterpreter dispatches it at `frame.world`),
@@ -301,7 +327,7 @@ function methods_by_execution!(
     frame = Frame(mod, lwr.args[1]::CodeInfo; world=Base.get_world_counter())
     mode === :eval || LoweredCodeUtils.rename_framemethods!(interp, frame)
     # Determine whether we need interpreted mode
-    isrequired, evalassign = minimal_evaluation!(frame, mode)
+    isrequired, evalassign = minimal_evaluation!(frame, mode; eval_namespace)
     # LoweredCodeUtils.print_with_code(stdout, frame.framecode.src, isrequired)
     if !any(isrequired) && (mode === :eval || !evalassign)
         # We can evaluate the entire expression in compiled mode
@@ -330,7 +356,7 @@ function methods_by_execution!(
             foreach(disable, active_bp_refs)
         end
         ret = try
-            _methods_by_execution!(interp, exinfo, frame, isrequired; mode, kwargs...)
+            _methods_by_execution!(interp, exinfo, frame, isrequired; mode, eval_namespace, kwargs...)
         catch err
             (always_rethrow || isa(err, InterruptException)) && (@isdefined(active_bp_refs) && foreach(enable, active_bp_refs); rethrow(err))
             loc = location_string(whereis(frame))
@@ -353,7 +379,7 @@ methods_by_execution!(exinfo::ExInfo, mod::Module, ex::Expr; kwargs...) =
 
 function _methods_by_execution!(
         interp::Interpreter, exinfo::ExInfo, frame::Frame, isrequired::AbstractVector{Bool};
-        mode::Symbol = :eval, skip_include::Bool = true
+        mode::Symbol = :eval, skip_include::Bool = true, eval_namespace::Bool = mode!==:sigs
     )
     isok(lnn::LineTypes) = !iszero(lnn.line) || lnn.file !== :none   # might fail either one, but accept anything
 
@@ -385,7 +411,7 @@ function _methods_by_execution!(
                 local value
                 for ex in stmt.args
                     ex isa Expr || continue
-                    value, _ = methods_by_execution!(interp, exinfo, mod, ex; mode, disablebp=false, skip_include)
+                    value, _ = methods_by_execution!(interp, exinfo, mod, ex; mode, disablebp=false, skip_include, eval_namespace)
                 end
                 isassign(frame, pc) && @isdefined(value) && assign_this!(frame, value)
                 pc = next_or_nothing!(frame)
@@ -612,7 +638,7 @@ function _methods_by_execution!(
                         end
                         newex = unwrap(newex)
                         push!(exinfo.exprstack, newex)
-                        value, _ = methods_by_execution!(interp, exinfo, newmod, newex; mode, skip_include, disablebp=false)
+                        value, _ = methods_by_execution!(interp, exinfo, newmod, newex; mode, skip_include, eval_namespace, disablebp=false)
                         pop!(exinfo.exprstack)
                     end
                     assign_this!(frame, value)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -670,6 +670,140 @@ else
     retract_dropped_exports!(::Module, ::ExprsInfos, ::ExprsInfos) = nothing
 end
 
+# Retract globals removed from a file (issues #1106 and #1107). Requires
+# `Base.delete_binding` (Julia 1.12+); the fallback is a no-op.
+@static if isdefined(Base, :delete_binding)
+    function retract_removed_bindings!(
+            mod_exs_infos_old::ModuleExprsInfos, mod_exs_infos_new::ModuleExprsInfos,
+            world::UInt, defaultmode::Symbol,
+        )
+        for (mod, exs_infos_old) in mod_exs_infos_old
+            exs_infos_new = get(mod_exs_infos_new, mod, empty_exs_infos)
+            mode = revise_mode(mod, defaultmode)
+            # Retract assignments only when the mode can re-evaluate them.
+            retract_assigns = mode === :eval || mode === :evalassign
+            removed = Set{Symbol}()
+            for rex in keys(exs_infos_old)
+                haskey(exs_infos_new, rex) && continue
+                add_imported_names!(removed, rex.ex)
+                retract_assigns && add_assigned_names!(removed, rex.ex)
+            end
+            isempty(removed) && continue
+            # Preserve bindings from unchanged statements.
+            kept, reestablished = Set{Symbol}(), Set{Symbol}()
+            for rex in keys(exs_infos_new)
+                names = haskey(exs_infos_old, rex) ? kept : reestablished
+                add_imported_names!(names, rex.ex)
+                retract_assigns && add_assigned_names!(names, rex.ex)
+            end
+            with_logger(_debug_logger) do
+                for name in removed
+                    name in kept && continue
+                    Base.invoke_in_world(world, isdefinedglobal, mod, name) || continue
+                    @debug "DeleteBinding" _group="Action" time=time() deltainfo=(mod, name)
+                    Base.delete_binding(mod, name)
+                    name in reestablished && continue
+                    # Restore an implicit import shadowed by the removed binding.
+                    src = implicit_export_source(mod, name)
+                    if src !== nothing
+                        Core.eval(mod, Expr(:using, Expr(:(:), Expr(:., fullname(src)...), Expr(:., name))))
+                    end
+                end
+            end
+        end
+        return nothing
+    end
+
+    # Collect names explicitly bound by `import` and `using` statements.
+    function add_imported_names!(names::Set{Symbol}, @nospecialize(ex))
+        isa(ex, Expr) || return names
+        if ex.head === :import || ex.head === :using
+            for a in ex.args
+                if isexpr(a, :(:))
+                    aargs = (a::Expr).args
+                    for i in 2:length(aargs)
+                        add_import_binding!(names, aargs[i])
+                    end
+                elseif ex.head === :import
+                    add_import_binding!(names, a)
+                end
+            end
+        elseif ex.head === :block || ex.head === :toplevel
+            for a in ex.args
+                add_imported_names!(names, a)
+            end
+        end
+        return names
+    end
+
+    function add_import_binding!(names::Set{Symbol}, @nospecialize(a))
+        if isexpr(a, :as)
+            b = (a::Expr).args[2]
+            b isa Symbol && push!(names, b)
+        elseif isexpr(a, :.)
+            b = last((a::Expr).args)
+            b isa Symbol && push!(names, b)
+        end
+        return names
+    end
+
+    # Collect top-level assignment targets without descending into local scopes.
+    function add_assigned_names!(names::Set{Symbol}, @nospecialize(ex))
+        isa(ex, Expr) || return names
+        if is_doc_expr(ex)
+            return add_assigned_names!(names, ex.args[4])
+        end
+        head = ex.head
+        if head === :block || head === :toplevel || head === :const || head === :global
+            for a in ex.args
+                if a isa Symbol
+                    (head === :const || head === :global) && push!(names, a)
+                else
+                    add_assigned_names!(names, a)
+                end
+            end
+        elseif head === :(=)
+            lhs = ex.args[1]
+            # `:call` and `:where` targets define methods.
+            if !(isexpr(lhs, :call) || isexpr(lhs, :where))
+                add_assignment_target!(names, lhs)
+                rhs = ex.args[2]
+                isexpr(rhs, :(=)) && add_assigned_names!(names, rhs)   # chained `a = b = …`
+            end
+        end
+        return names
+    end
+
+    function add_assignment_target!(names::Set{Symbol}, @nospecialize(lhs))
+        if lhs isa Symbol
+            push!(names, lhs)
+        elseif isexpr(lhs, :(::), 2)
+            add_assignment_target!(names, (lhs::Expr).args[1])
+        elseif isexpr(lhs, :tuple) || isexpr(lhs, :parameters)
+            for a in (lhs::Expr).args
+                add_assignment_target!(names, a)
+            end
+        elseif isexpr(lhs, :curly)
+            a = (lhs::Expr).args[1]
+            a isa Symbol && push!(names, a)
+        end
+        return names
+    end
+
+    # Return the module supplying an implicit binding, if any.
+    function implicit_export_source(mod::Module, n::Symbol)
+        for used in ccall(:jl_module_usings, Any, (Any,), mod)::Vector{Any}
+            used isa Module || continue
+            Base.isexported(used, n) || continue
+            isdefined(used, n) || continue
+            return used
+        end
+        return nothing
+    end
+else
+    retract_removed_bindings!(::ModuleExprsInfos, ::ModuleExprsInfos, ::UInt, ::Symbol) = nothing
+end
+
 # `true` if diffing old against new will delete at least one expression that defined
 # a type. This gates the prediction pass: when no type deletion is pending, there is
 # nothing for a prediction to save.
@@ -901,6 +1035,9 @@ function revise_mode(mod::Module, default::Symbol)
     @invokelatest(isdefinedglobal(mod, :__revise_mode__)) || return default
     return (@invokelatest getglobal(mod, :__revise_mode__))::Symbol
 end
+
+# Avoid re-evaluating assignments accumulated in `Main`.
+default_revise_mode(pkgdata::PkgData) = PkgId(pkgdata).name == "Main" ? :evalmeth : :eval
 
 function eval_new!(mod_exs_infos_new::ModuleExprsInfos, mod_exs_infos_old::ModuleExprsInfos; mode::Symbol=:eval)
     includes = Vector{Tuple{Module,Function,String}}()
@@ -1278,6 +1415,7 @@ function delete_for_revision(
     )
     if mod_exs_infos_new !== nothing
         delete_missing!(mod_exs_infos_old, mod_exs_infos_new::ModuleExprsInfos, reeval_list, handled_types, world, predictions)
+        retract_removed_bindings!(mod_exs_infos_old, mod_exs_infos_new::ModuleExprsInfos, world, default_revise_mode(pkgdata))
     end
     if !fileok && any(!isempty, values(mod_exs_infos_old))
         filep = pkgdata.info.files[idx]
@@ -1396,6 +1534,7 @@ function delete_orphaned_include!(
     mod_exs_infos_old = fi.mod_exs_infos
     mod_exs_infos_new = ModuleExprsInfos(first(keys(mod_exs_infos_old)))
     delete_missing!(mod_exs_infos_old, mod_exs_infos_new, reeval_list, handled_types, world, predictions)
+    retract_removed_bindings!(mod_exs_infos_old, mod_exs_infos_new, world, default_revise_mode(pkgdata))
     pkgdata.fileinfos[idx] = FileInfo(mod_exs_infos_new, fi)
     unwatch && unwatch_file!(pkgdata, file)
     @warn "$(joinpath(basedir(pkgdata), file)) is no longer `include`d into $(first(keys(mod_exs_infos_old))), deleted its methods"
@@ -1962,7 +2101,7 @@ function _revise(; throw::Bool=false)
 
         # Do the evaluation
         for ((pkgdata, file), i, mod_exs_infos_new) in zip(finished, finished_idx, mod_exs_infos)
-            defaultmode = PkgId(pkgdata).name == "Main" ? :evalmeth : :eval
+            defaultmode = default_revise_mode(pkgdata)
             fi = fileinfo(pkgdata, i)
             modsremaining = Set(keys(mod_exs_infos_new))
             changed, err = true, nothing

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -836,7 +836,8 @@ function eval_rex(rex_new::RelocatableExpr, exs_infos_old::ExprsInfos, mod::Modu
             ex = rex_new.ex
             # ex is not present in old
             @debug titlecase(String(mode)) _group="Action" time=time() deltainfo=(mod, ex, mode)
-            exinfos, includes, thunk = eval_with_signatures(mod, ex; mode)  # All signatures defined by `ex`
+            # Revised signatures may depend on new namespace statements.
+            exinfos, includes, thunk = eval_with_signatures(mod, ex; mode, eval_namespace=true)  # All signatures defined by `ex`
             if !isexpr(thunk, :thunk)
                 thunk = ex
             end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -73,15 +73,15 @@ function _precompile_()
     mex = which(methods_by_execution!, (Compiled, MI, Module, Expr))
     mbody = bodymethod(mex)
     # use `typeof(pairs(NamedTuple()))` here since it actually differs between Julia versions
-    @warnpcfail precompile(Tuple{mbody.sig.parameters[1], Symbol, Bool, Bool, typeof(pairs(NamedTuple())), typeof(methods_by_execution!), Compiled, MI, Module, Expr})
+    @warnpcfail precompile(Tuple{mbody.sig.parameters[1], Symbol, Bool, Bool, Bool, typeof(pairs(NamedTuple())), typeof(methods_by_execution!), Compiled, MI, Module, Expr})
     if VERSION >= v"1.12-"
-        @warnpcfail precompile(Tuple{mbody.sig.parameters[1], Symbol, Bool, Bool, Iterators.Pairs{Symbol,Bool,Nothing,NamedTuple{(:skip_include,),Tuple{Bool}}}, typeof(methods_by_execution!), Compiled, MI, Module, Expr})
+        @warnpcfail precompile(Tuple{mbody.sig.parameters[1], Symbol, Bool, Bool, Bool, Iterators.Pairs{Symbol,Bool,Nothing,NamedTuple{(:skip_include,),Tuple{Bool}}}, typeof(methods_by_execution!), Compiled, MI, Module, Expr})
     else
-        @warnpcfail precompile(Tuple{mbody.sig.parameters[1], Symbol, Bool, Bool, Iterators.Pairs{Symbol,Bool,Tuple{Symbol},NamedTuple{(:skip_include,),Tuple{Bool}}}, typeof(methods_by_execution!), Compiled, MI, Module, Expr})
+        @warnpcfail precompile(Tuple{mbody.sig.parameters[1], Symbol, Bool, Bool, Bool, Iterators.Pairs{Symbol,Bool,Tuple{Symbol},NamedTuple{(:skip_include,),Tuple{Bool}}}, typeof(methods_by_execution!), Compiled, MI, Module, Expr})
     end
     mfr = which(_methods_by_execution!, (Compiled, MI, Frame, Vector{Bool}))
     mbody = bodymethod(mfr)
-    @warnpcfail precompile(Tuple{mbody.sig.parameters[1], Symbol, Bool, typeof(_methods_by_execution!), Compiled, MI, Frame, Vector{Bool}})
+    @warnpcfail precompile(Tuple{mbody.sig.parameters[1], Symbol, Bool, Bool, typeof(_methods_by_execution!), Compiled, MI, Frame, Vector{Bool}})
 
     @warnpcfail precompile(Tuple{typeof(get_def), Method})
     @warnpcfail precompile(Tuple{typeof(parse_pkg_files), PkgId})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1117,6 +1117,96 @@ end
         pop!(LOAD_PATH)
     end
 
+    do_test("Retract removed bindings") && isdefined(Base, :delete_binding) &&
+            @testset "Retract removed bindings" begin
+        # Issue #1107: remove the binding with its defining statement.
+        testdir = newtestdir()
+        dn = joinpath(testdir, "RetractGlobals", "src")
+        mkpath(dn)
+        fn = joinpath(dn, "RetractGlobals.jl")
+        write(fn, """
+            module RetractGlobals
+            module Sub
+            export tag
+            tag() = :sub
+            end
+            using .Sub: tag
+            using .Sub
+            const SETTING = 17
+            const CHANGED = 1
+            const MOVING = :was_in_root
+            const view = "shadow"
+            read_setting() = SETTING
+            include("more.jl")
+            end
+            """)
+        write(joinpath(dn, "more.jl"), "\n")
+        sleep(mtimedelay)
+        @eval using RetractGlobals
+        @test RetractGlobals.SETTING == 17
+        @test RetractGlobals.view == "shadow"
+        sleep(mtimedelay)
+        write(fn, """
+            module RetractGlobals
+            module Sub
+            export tag
+            tag() = :sub
+            end
+            using .Sub
+            const CHANGED = 2
+            include("more.jl")
+            end
+            """)
+        write(joinpath(dn, "more.jl"), "const MOVING = :now_in_more\n")
+        @yry()
+        @test isempty(Revise.queue_errors)
+        @test !isdefined(RetractGlobals, :SETTING)
+        @test isempty(methods(RetractGlobals.read_setting))
+        @test RetractGlobals.CHANGED == 2
+        @test RetractGlobals.MOVING === :now_in_more
+        @test RetractGlobals.view === Base.view
+        @test RetractGlobals.tag() === :sub
+
+        rm_precompile("RetractGlobals")
+        pop!(LOAD_PATH)
+    end
+
+    do_test("Import switch (issue #1106)") && isdefined(Base, :delete_binding) &&
+            @testset "Import switch (issue #1106)" begin
+        # Issue #1106: replace a conflicting explicit import.
+        testdir = newtestdir()
+        dn = joinpath(testdir, "ImportSwitch", "src")
+        mkpath(dn)
+        fn = joinpath(dn, "ImportSwitch.jl")
+        importswitch_src(which) = """
+            module ImportSwitch
+            module A
+            export tag
+            tag() = :A
+            end
+            module B
+            export tag
+            tag() = :B
+            end
+            using .$which: tag
+            call_tag() = tag()
+            end
+            """
+        write(fn, importswitch_src("A"))
+        sleep(mtimedelay)
+        @eval using ImportSwitch
+        @test ImportSwitch.call_tag() === :A
+        sleep(mtimedelay)
+        write(fn, importswitch_src("B"))
+        @yry()
+        @test isempty(Revise.queue_errors)
+        @test ImportSwitch.tag === ImportSwitch.B.tag
+        @test ImportSwitch.call_tag() === :B
+
+        rm_precompile("ImportSwitch")
+        pop!(LOAD_PATH)
+    end
+
     do_test("Multiple definitions") && @testset "Multiple definitions" begin
         # This simulates a copy/paste/save "error" from one file to another
         # ref https://github.com/timholy/CodeTracking.jl/issues/55

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1033,6 +1033,90 @@ end
         pop!(LOAD_PATH)
     end
 
+    do_test("Revise mode :sigs") && @testset "Revise mode :sigs" begin
+        testdir = newtestdir()
+        # Sibling helper packages, so the test depends on nothing outside `testdir`.
+        # `SigsHelper2` is not loaded until a revision adds a `using` for it.
+        for (helper, def) in (("SigsHelper1", "export dmean\ndmean(x) = sum(x)/length(x)"),
+                              ("SigsHelper2", "export DiagLike\nstruct DiagLike end"))
+            hn = joinpath(testdir, helper, "src")
+            mkpath(hn)
+            write(joinpath(hn, helper*".jl"), "module $helper\n$def\nend\n")
+        end
+        dn = joinpath(testdir, "SigsMode", "src")
+        mkpath(dn)
+        fn = joinpath(dn, "SigsMode.jl")
+        write(fn, """
+            module SigsMode
+            __revise_mode__ = :sigs
+            using SigsHelper1: dmean
+            f(x) = dmean(x)
+            end
+            """)
+        sleep(mtimedelay)
+        @eval using SigsMode
+        @test SigsMode.f([1,2,3]) == 2.0
+        @test whereis(only(methods(SigsMode.f))) == (fn, 4)
+        sleep(mtimedelay)
+        write(fn, """
+            module SigsMode
+            __revise_mode__ = :sigs
+
+            using SigsHelper1: dmean
+            using SigsHelper2: DiagLike
+            export h
+
+            f(x) = dmean(x)
+            h(x::DiagLike) = 1
+            end
+            """)
+        @yry()
+        @test isempty(Revise.queue_errors)
+        # Revised namespace statements take effect before later expressions.
+        @eval using SigsHelper2
+        @test SigsMode.DiagLike === SigsHelper2.DiagLike
+        @test :h ∈ names(SigsMode)
+        # `:sigs` updates signatures without installing method bodies.
+        @test length(methods(getglobal(SigsMode, :h))) == 0
+        @test SigsMode.f([1,2,3]) == 2.0
+        @test whereis(only(methods(SigsMode.f))) == (fn, 8)
+
+        rm_precompile("SigsMode")
+        rm_precompile("SigsHelper1")
+        rm_precompile("SigsHelper2")
+        pop!(LOAD_PATH)
+    end
+
+    do_test("Signature instantiation") && @testset "Signature instantiation" begin
+        # Cataloging loaded source must not execute namespace statements.
+        testdir = newtestdir()
+        dn = joinpath(testdir, "SigsUnloaded", "src")
+        mkpath(dn)
+        write(joinpath(dn, "SigsUnloaded.jl"), """
+            module SigsUnloaded
+            struct Marker end
+            end
+            """)
+        sleep(mtimedelay)
+        host = Core.eval(Main, :(module SigsHost
+                                 q(x::Int) = 1
+                                 end))
+        src = """
+            using SigsUnloaded
+            q(x::Int) = 1
+            """
+        fn = joinpath(testdir, "sigs_host.jl")
+        write(fn, src)
+        mexs = Revise.ModuleExprsInfos(host)
+        parse_source!(mexs, src, fn, host)
+        Revise.instantiate_sigs!(mexs)
+        @test !isdefined(host, :SigsUnloaded)
+        @test !any(id -> id.name == "SigsUnloaded", keys(Base.loaded_modules))
+        @test any(k -> k.sig === Tuple{typeof(host.q),Int}, keys(CodeTracking.method_info))
+
+        pop!(LOAD_PATH)
+    end
+
     do_test("Multiple definitions") && @testset "Multiple definitions" begin
         # This simulates a copy/paste/save "error" from one file to another
         # ref https://github.com/timholy/CodeTracking.jl/issues/55

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5152,8 +5152,11 @@ end
 
         write(joinpath(dn, modname*".jl"), s527_old)
 
-        sleep(mtimedelay)
-        @test !Distributed.remotecall_eval(Main, favorite_proc, :(Revise.revision_queue |> isempty))
+        # The worker's queue fills when its watcher task delivers the event; wait for
+        # it (with `event_timeout` slack for slow FSEvents delivery on macOS CI).
+        @test timedwait(event_timeout; pollint=0.05) do
+            !Distributed.remotecall_eval(Main, favorite_proc, :(Revise.revision_queue |> isempty))
+        end === :ok
         @test Distributed.remotecall_eval(Main, boring_proc, :(Revise.revision_queue |> isempty))
 
         Distributed.remotecall_eval(Main, [favorite_proc, boring_proc], :(Revise.revise()))


### PR DESCRIPTION
On Julia 1.12+, delete bindings for removed assignments and explicit imports. Restore implicit imports that had been shadowed.

Fixes #1106 and #1107.
