### PR TITLE
Enable struct revision by default on Julia 1.12+; bump to 3.17.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@ cleanups, or minor enhancements.
 
 ## [Revise 3.17]
 
+- **Struct revision is on by default** (Julia 1.12+): the automatic revision of
+  `struct` definitions introduced in Revise 3.13 no longer requires opting in.
+  To disable it, set the `revise_structs` preference to `false` (see the
+  "Disabling struct revision" section of the documentation).
+
 - **`include(mapexpr, file)` support**: revising a file that was included with a
   transform now re-applies the same transform to each top-level expression, instead of
   silently dropping it. For files included while a package loads, discovering the

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Revise"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.16.5"
+version = "3.17.0"
 
 [workspace]
 projects = ["docs", "test"]

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -124,23 +124,22 @@ string `"1"` (e.g., `JULIA_REVISE_INCLUDE=1` in a bash script).
     Most users should avoid setting `JULIA_REVISE_INCLUDE`.
     Try `includet` instead.
 
-### Enabling struct revision
+### Disabling struct revision
 
-On Julia 1.12+, Revise can automatically revise `struct` definitions in a
-running session.  This feature requires scanning the global method table and
-type hierarchy at startup, which can be slow so it's disabled by default. If you
-would like to enable it you can set the `revise_structs` preference to `true`
-via [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl).
+On Julia 1.12+, Revise automatically revises `struct` definitions in a running
+session; see [Limitations](@ref) for details. When a changed definition
+requires deleting a type, Revise scans the session's method tables and type
+hierarchy to find dependents, which can make such revisions slower than
+ordinary ones. To disable struct revision (so that struct changes once again
+require a session restart), set the `revise_structs` preference to `false` via
+[Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl).
 
 Add the following to the `LocalPreferences.toml` file in your active project:
 
 ```toml
 [Revise]
-revise_structs = true
+revise_structs = false
 ```
-
-!!! warning
-    The default for this preference may change in the future.
 
 ## Configurations for fixing errors
 

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -2896,7 +2896,7 @@ function __init__()
     for pkg in silenced
         push!(silence_pkgs, pkg)
     end
-    __bpart__[] = Base.VERSION >= v"1.12.0-DEV.2047" && Preferences.@load_preference("revise_structs", false)
+    __bpart__[] = Base.VERSION >= v"1.12.0-DEV.2047" && Preferences.@load_preference("revise_structs", true)
     polling = get(ENV, "JULIA_REVISE_POLL", "0")
     if polling == "1"
         polling_files[] = watching_files[] = true

--- a/src/stale_load.jl
+++ b/src/stale_load.jl
@@ -26,10 +26,10 @@ Precompile the package when convenient to establish a fresh checkpoint.
 # Limitations
 
 - Revision is subject to the usual restrictions; in particular, redefining a
-  `struct` requires Julia 1.12+ with struct revision enabled (see the
-  `revise_structs` preference). Errors during revision are logged and can be
-  inspected with [`Revise.errors`](@ref); pass `throw=true` to raise them
-  instead.
+  `struct` requires Julia 1.12+ with struct revision enabled (the default
+  there; see the `revise_structs` preference). Errors during revision are
+  logged and can be inspected with [`Revise.errors`](@ref); pass `throw=true`
+  to raise them instead.
 - On Julia 1.10, only `pkg` itself may be stale: dependencies whose sources
   have also been edited must be `stale_load`ed first (in dependency order) or
   freshly precompiled. On Julia 1.11+, edited dependencies are loaded from

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3671,7 +3671,7 @@ end
     end
 
     # Struct revision tests require __bpart__[] = true. Enable it based on the Julia version
-    # alone: the LocalPreferences setting (which defaults to false for end users) should not
+    # alone: an ambient LocalPreferences setting of `revise_structs = false` should not
     # suppress these tests on CI.
     if Base.VERSION >= v"1.12.0-DEV.2047"
         Revise.__bpart__[] = true


### PR DESCRIPTION
Heads-up maintainers, a new minor bump on its way; I'd urge avoiding a patch release since there are some minor behavior changes.

------------------

The `revise_structs` preference now defaults to `true`, so on Julia 1.12+ changes to `struct` definitions are applied automatically; setting the preference to `false` restores the previous behavior (struct changes require a session restart). The version bump to 3.17.0 makes this default change a minor release.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>
