### PR TITLE
Close the polling-mode startup gap in revise_file_queued

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -84,6 +84,7 @@ then call themselves on the same directory or file to wait for the next set of c
 ```@docs
 Revise.revise_dir_queued
 Revise.revise_file_queued
+Revise.poll_from_saved_state
 ```
 
 The following functions support user callbacks, and are used in the implementation of `entr`

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1345,10 +1345,10 @@ This is generally called via a [`Revise.TaskThunk`](@ref).
 
 This is used only on platforms (like BSD) which cannot use [`Revise.revise_dir_queued`](@ref).
 """
-function revise_file_queued(pkgdata::PkgData, file)
-    if !isabspath(file)
-        file = joinpath(basedir(pkgdata), file)
-    end
+function revise_file_queued(pkgdata::PkgData, filename)
+    # `file` is captured by closures below, so it must be assigned exactly once
+    # (a second assignment would force it into a `Core.Box`).
+    file = isabspath(filename) ? filename : joinpath(basedir(pkgdata), filename)
 
     dirfull, filebase = splitdir(file)
     fileexists(f) = file_exists(f) || isdir(f)
@@ -1375,10 +1375,8 @@ function revise_file_queued(pkgdata::PkgData, file)
                 status = await_watched_path(fileexists, file, dirfull)
                 if status !== :reappeared
                     if status === :gone
-                        let file=file
-                            with_logger(SimpleLogger(stderr)) do
-                                @warn "$file is not an existing file, Revise is not watching (watching resumes if it reappears)"
-                            end
+                        with_logger(SimpleLogger(stderr)) do
+                            @warn "$file is not an existing file, Revise is not watching (watching resumes if it reappears)"
                         end
                         relinquish_watch(dirfull, file)
                     end

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -179,6 +179,27 @@ function nonnotifying_path(path::AbstractString)
     return fstype == "9p" || fstype == "drvfs"
 end
 
+# Matches the default polling interval of `Base.poll_file`.
+const saved_state_poll_interval = 5.007
+
+"""
+    poll_from_saved_state(file, prev_ctime)
+
+Block until `file`'s ctime differs from `prev_ctime`, the value recorded by
+`init_watching`.
+
+This exists because `poll_file` samples its own baseline when the poll starts: a change
+that landed between `init_watching` and the first poll becomes the baseline, and the poll
+then waits for the *next* change. Seeding the comparison with the recorded ctime leaves no
+window in which a change can be adopted as the starting state.
+"""
+function poll_from_saved_state(file, prev_ctime)
+    while ctime(file) == prev_ctime
+        sleep(saved_state_poll_interval)
+    end
+    return nothing
+end
+
 function wait_changed(file)
     poll = polling_files[] || nonnotifying_path(file)
     try
@@ -1331,13 +1352,12 @@ function revise_file_queued(pkgdata::PkgData, file)
 
     dirfull, filebase = splitdir(file)
     fileexists(f) = file_exists(f) || isdir(f)
-    # Baseline recorded by `init_watching`. In per-file (polling) mode a change
-    # that lands between `init_watching` and this task's first `wait_changed`
-    # would otherwise be lost forever: `poll_file` takes its own baseline when
-    # the poll starts, and the buffered directory monitor that closes this
-    # startup gap for the notification path is unavailable here. So before
-    # blocking, compare the file's ctime against the recorded baseline and
-    # treat a mismatch as a change that already happened.
+    # `init_watching` saved the file's ctime before scheduling this task.
+    # The file may have changed before this task starts. `poll_file` would
+    # then use the changed file as its starting point and wait for another
+    # change, so on the polling path start from the saved value instead.
+    # (The notification path has no such gap: `init_watching` registers a
+    # buffered `watch_folder` that queues changes from that moment on.)
     stored_ctime() = @lock revise_lock begin
         wl = get(watched_files, dirfull, nothing)
         wl === nothing ? nothing : get(wl.file_ctimes, filebase, nothing)
@@ -1367,16 +1387,18 @@ function revise_file_queued(pkgdata::PkgData, file)
                 end
             end
             prev = stored_ctime()
-            if prev === nothing || prev == 0.0 || ctime(file) == prev
-                try
+            try
+                if (polling_files[] || nonnotifying_path(file)) &&
+                        prev !== nothing && prev != 0.0
+                    poll_from_saved_state(file, prev)
+                else
                     wait_changed(file)  # will block here until the file changes
-                catch e
-                    # issue #459
-                    (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
                 end
+            catch e
+                # issue #459
+                (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
             end
-            # Keep the baseline current so the pre-block check above only fires
-            # for genuinely missed changes, never for the one just delivered.
+            # Save the ctime observed after this change so it is not queued again.
             record_ctime!()
 
             @lock revise_lock begin

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1329,8 +1329,25 @@ function revise_file_queued(pkgdata::PkgData, file)
         file = joinpath(basedir(pkgdata), file)
     end
 
-    dirfull, _ = splitdir(file)
+    dirfull, filebase = splitdir(file)
     fileexists(f) = file_exists(f) || isdir(f)
+    # Baseline recorded by `init_watching`. In per-file (polling) mode a change
+    # that lands between `init_watching` and this task's first `wait_changed`
+    # would otherwise be lost forever: `poll_file` takes its own baseline when
+    # the poll starts, and the buffered directory monitor that closes this
+    # startup gap for the notification path is unavailable here. So before
+    # blocking, compare the file's ctime against the recorded baseline and
+    # treat a mismatch as a change that already happened.
+    stored_ctime() = @lock revise_lock begin
+        wl = get(watched_files, dirfull, nothing)
+        wl === nothing ? nothing : get(wl.file_ctimes, filebase, nothing)
+    end
+    record_ctime!() = @lock revise_lock begin
+        wl = get(watched_files, dirfull, nothing)
+        if wl !== nothing && haskey(wl.trackedfiles, filebase)
+            wl.file_ctimes[filebase] = ctime(file)
+        end
+    end
     try
         stillwatching = true
         while stillwatching
@@ -1349,12 +1366,18 @@ function revise_file_queued(pkgdata::PkgData, file)
                     break
                 end
             end
-            try
-                wait_changed(file)  # will block here until the file changes
-            catch e
-                # issue #459
-                (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
+            prev = stored_ctime()
+            if prev === nothing || prev == 0.0 || ctime(file) == prev
+                try
+                    wait_changed(file)  # will block here until the file changes
+                catch e
+                    # issue #459
+                    (isa(e, InterruptException) && throwto_repl(e)) || throw(e)
+                end
             end
+            # Keep the baseline current so the pre-block check above only fires
+            # for genuinely missed changes, never for the one just delivered.
+            record_ctime!()
 
             @lock revise_lock begin
                 if file in keys(user_callbacks_by_file)

--- a/test/polling.jl
+++ b/test/polling.jl
@@ -49,3 +49,43 @@ end
 
     rm(testdir; force=true, recursive=true)
 end
+
+@testset "Polling startup gap" begin
+    testdir = randtmp()
+    mkdir(testdir)
+    push!(LOAD_PATH, testdir)
+    dn = joinpath(testdir, "PollGap", "src")
+    mkpath(dn)
+    srcfile = joinpath(dn, "PollGap.jl")
+    write(srcfile, """
+__precompile__(false)
+
+module PollGap
+
+f() = 1
+
+end
+""")
+    sleep(0.5) # let the source file age a bit
+    @eval using PollGap
+    @test PollGap.f() == 1
+    # Edit immediately, with no yield since loading: the per-file poll tasks
+    # scheduled by init_watching have not run yet, so poll_file would baseline
+    # on the already-edited file. The change must instead be caught by
+    # comparing against the ctime recorded at init_watching time.
+    write(srcfile, """
+__precompile__(false)
+
+module PollGap
+
+f() = 2
+
+end
+""")
+    yry()
+    sleep(7)
+    yry()
+    @test PollGap.f() == 2
+
+    rm(testdir; force=true, recursive=true)
+end


### PR DESCRIPTION
Fixes #1129.

In `revise_file_queued`, compare the file's ctime against the baseline `init_watching` recorded in `WatchList.file_ctimes` before blocking in `wait_changed`, and treat a mismatch as an already-delivered change. The baseline is kept current on every detected change, so the check only fires for genuinely missed ones.

The new "Polling startup gap" testset fails on master and passes with this change; the existing polling testset still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjiTcmuU8NCBHp5vJfNnR9
