### PR TITLE
Keep Revise's world pin effective at compile time

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -490,12 +490,17 @@ const silence_pkgs = Set{String}()
 # so that revising a method Revise itself calls (e.g. via `track(Base)`) cannot invalidate
 # Revise's machinery mid-operation (issue #552). User code is still evaluated at the latest
 # world: JuliaInterpreter threads the latest world through each `Frame`. `worldage[]` is
-# `nothing` until `__init__` runs, in which case `frozen` degrades to a plain call.
+# `nothing` until `__init__` runs, in which case `frozen` degrades to `invokelatest`.
 const worldage = Ref{Union{Nothing,UInt}}(nothing)
 
+# Both branches must reach `f` through a runtime dispatch. A direct call `f(args...)` would
+# give the *caller's* compiled code inference edges into everything `f` calls; a package
+# loaded later that invalidates any of that would then invalidate the caller too, and
+# recompiling the caller re-infers `f`'s whole call graph in the latest world -- the very
+# cost the world pin exists to avoid (issue #1134).
 @inline function frozen(f, args...; kwargs...)
     w = worldage[]
-    return w === nothing ? f(args...; kwargs...) : Base.invoke_in_world(w, f, args...; kwargs...)
+    return w === nothing ? Base.invokelatest(f, args...; kwargs...) : Base.invoke_in_world(w, f, args...; kwargs...)
 end
 
 """

--- a/src/pkgs.jl
+++ b/src/pkgs.jl
@@ -517,8 +517,15 @@ const requires_suffix = "__@require__"
 is_requires_file(file::AbstractString) = endswith(file, requires_suffix)
 
 # This is used by Requires.jl: therefore even if it appears unused by Revise.jl,
-# it cannot be removed as long as we support integration with Requires.jl
-function add_require(sourcefile::String, modcaller::Module, idmod::String, ::String, expr::Expr)
+# it cannot be removed as long as we support integration with Requires.jl.
+# Requires.jl calls it from the loading package's `__init__` (or from a later package-load
+# callback), i.e. in the latest world. Like Revise's other entry points, run it in Revise's
+# frozen world so that method definitions made by packages loaded after Revise cannot force
+# recompilation of Revise's machinery (issue #1134).
+add_require(sourcefile::String, modcaller::Module, idmod::String, id::String, expr::Expr) =
+    frozen(_add_require, sourcefile, modcaller, idmod, id, expr)
+
+function _add_require(sourcefile::String, modcaller::Module, idmod::String, ::String, expr::Expr)
     id = PkgId(modcaller)
     # If this fires when the module is first being loaded (because the dependency
     # was already loaded), Revise may not yet have the pkgdata for this package.

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -99,6 +99,7 @@ function _precompile_()
     @warnpcfail precompile(Tuple{Type{PkgData}, PkgId})
     @warnpcfail precompile(Tuple{typeof(Base._deleteat!), Vector{Tuple{Module,String,Float64}}, Vector{Int}})
     @warnpcfail precompile(Tuple{typeof(add_require), String, Module, String, String, Expr})
+    @warnpcfail precompile(Tuple{typeof(_add_require), String, Module, String, String, Expr})
     @warnpcfail precompile(Tuple{Core.kwftype(typeof(maybe_add_includes_to_pkgdata!)),NamedTuple{(:eval_now,), Tuple{Bool}},typeof(maybe_add_includes_to_pkgdata!),PkgData,String,Vector{Tuple{Module, Function, String}}})
 
     for TT in (Tuple{Module,Expr}, Tuple{DataType,MethodSummary})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7545,6 +7545,23 @@ do_test("Frozen world") && @testset "Frozen world" begin
     finally
         Revise.worldage[] = saved
     end
+
+    # The pin protects execution only if it also protects *compilation*: a caller of
+    # `frozen(f, ...)` compiled in the latest world must carry no inference edges into
+    # `f`, or invalidations from later-loaded packages propagate to the caller and
+    # recompiling it re-infers `f`'s entire call graph in the latest world (issue #1134).
+    # Any static call to `f` shows up as an `:invoke` of a Revise method.
+    src, _ = only(code_typed(Revise.frozen, (typeof(Revise._revise),); optimize=true))
+    static_revise_calls = Method[]
+    for stmt in src.code
+        Meta.isexpr(stmt, :invoke) || continue
+        target = stmt.args[1]
+        target isa Core.CodeInstance && (target = target.def)
+        isdefined(Core, :ABIOverride) && target isa Core.ABIOverride && (target = target.def)
+        target isa Core.MethodInstance || continue
+        target.def.module === Revise && push!(static_revise_calls, target.def)
+    end
+    @test isempty(static_revise_calls)
 end
 
 do_test("Frozen world user-code frame") && @testset "Frozen world user-code frame" begin


### PR DESCRIPTION
`frozen` reaches `f` through a runtime dispatch on both branches. Its fallback branch called `f(args...)` directly, which gave every caller compiled in the latest world inference edges into `f`'s call graph. A package loaded after Revise that invalidates any of that code (Makie adds methods to `write(::IO, ::String)`, `convert(::Type{Symbol}, ::Any)`, `>(::Any, ::Any)`, ...) then invalidated the wrapper too, and recompiling the wrapper re-inferred the whole revision engine in the latest world even though execution took the `invoke_in_world` branch.

`add_require`, the entry point Requires.jl calls from a loading package's `__init__`, now runs in the frozen world like the other entry points. Since 3.15 `maybe_add_includes_to_pkgdata!` statically reaches `revise_file_now`, so an unpinned `add_require` pulled the entire engine into latest-world compilation on every `@require` block.

With Makie loaded first, `@time using HDF5` on Julia 1.12.7 drops from 2.2 s (97% recompilation) to 0.09 s.

The "Frozen world" testset now checks that `code_typed` of `frozen` has no static `:invoke` of a Revise method.

Fixes #1134

Assisted-by: Claude Fable 5 <noreply@anthropic.com>