### PR TITLE
Run every public entry point in Revise's frozen world

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -46,10 +46,12 @@ You can use the return value `key` to remove the callback later
 (`Revise.remove_callback`) or to update it using another call
 to `Revise.add_callback` with `key=key`.
 """
-function add_callback(f, files, modules=nothing; all=false, key=gensym())
+add_callback(f, files, modules=nothing; kwargs...) = frozen(_add_callback, f, files, modules; kwargs...)
+
+function _add_callback(f, files, modules; all=false, key=gensym())
     fix_trailing(path) = isdir(path) ? joinpath(path, "") : path   # insert a trailing '/' if missing, see https://github.com/timholy/Revise.jl/issues/470#issuecomment-633298553
 
-    remove_callback(key)
+    _remove_callback(key)
 
     files = map(fix_trailing, map(abspath, files))
     init_watching(files)
@@ -94,7 +96,9 @@ end
 Remove a callback previously installed by a call to `Revise.add_callback(...)`.
 See its docstring for details.
 """
-function remove_callback(key)
+remove_callback(key) = frozen(_remove_callback, key)
+
+function _remove_callback(key)
     @lock revise_lock begin
         for cbs in values(user_callbacks_by_file)
             delete!(cbs, key)
@@ -157,9 +161,11 @@ end
 This will print "update" every time `"/tmp/watched.txt"` or any of the code defining
 `Pkg1` or `Pkg2` gets updated.
 """
-function entr(f::Function, files, modules=nothing; all=false, postpone=false, pause=0.02)
+entr(f::Function, files, modules=nothing; kwargs...) = frozen(_entr, f, files, modules; kwargs...)
+
+function _entr(f::Function, files, modules; all=false, postpone=false, pause=0.02)
     yield()
-    postpone || f()
+    postpone || Base.invokelatest(f)  # `f` is user code, typically newer than Revise's frozen world
     # `entr` runs `f` on a trailing-edge debounce: a change schedules `f` for
     # `pause` seconds later, and any further change before then pushes the
     # deadline out. A burst of changes no more than `pause` apart therefore
@@ -197,7 +203,7 @@ function entr(f::Function, files, modules=nothing; all=false, postpone=false, pa
     # extend itself, so spawn one only when `dtask` is empty. Pairing this with
     # the task clearing `dtask` as it commits to exit (both under `lk`) means a
     # change racing an expiring task either extends it or spawns its successor.
-    key = add_callback(files, modules; all=all) do
+    key = _add_callback(files, modules; all) do
         @lock lk begin
             deadline[] = time() + pause
             if dtask[] === nothing
@@ -216,7 +222,7 @@ function entr(f::Function, files, modules=nothing; all=false, postpone=false, pa
         isa(e, InterruptException) || rethrow(e)
     finally
         stopped[] = true
-        remove_callback(key)
+        _remove_callback(key)
     end
     nothing
 end

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -491,6 +491,13 @@ const silence_pkgs = Set{String}()
 # Revise's machinery mid-operation (issue #552). User code is still evaluated at the latest
 # world: JuliaInterpreter threads the latest world through each `Frame`. `worldage[]` is
 # `nothing` until `__init__` runs, in which case `frozen` degrades to `invokelatest`.
+#
+# Every entry point that user code or Julia itself calls in the latest world (`revise`,
+# `track`, `includet`, `entr`, `errors`, `retry`, `add_callback`, `remove_callback`,
+# `add_require`, `watch_package_callback`) is a thin shim `f(args...) = frozen(_f, args...)`
+# whose `_f` body does the work. Inside a pinned body, anything supplied by user code
+# (callbacks, `mapexpr`, exception display) must be reached via `invokelatest`. The
+# "Frozen world" testset checks that no entry point has static edges into the engine.
 const worldage = Ref{Union{Nothing,UInt}}(nothing)
 
 # Both branches must reach `f` through a runtime dispatch. A direct call `f(args...)` would
@@ -1841,7 +1848,9 @@ Report the errors represented in [`Revise.queue_errors`](@ref).
 Errors are automatically reported the first time they are encountered, but this function
 can be used to report errors again.
 """
-function errors(revision_errors=keys(queue_errors))
+errors(revision_errors=keys(queue_errors)) = frozen(_errors, revision_errors)
+
+function _errors(revision_errors)
     printed = Set{eltype(revision_errors)}()
     for item in revision_errors
         item in printed && continue
@@ -1863,7 +1872,9 @@ end
 
 Attempt to perform previously-failed revisions. This can be useful in cases of order-dependent errors.
 """
-function retry()
+retry() = frozen(_retry)
+
+function _retry()
     @lock revise_lock begin
         for k in keys(queue_errors)
             push!(revision_queue, k)
@@ -2436,7 +2447,9 @@ they will not be automatically tracked.
 Multi-file code that needs all of its files tracked is better organized as a package loaded with
 `using`/`import`, which Revise tracks recursively and which gives you a proper module namespace.
 """
-function includet(mapexpr::Function, mod::Module, file::AbstractString)
+includet(mapexpr::Function, mod::Module, file::AbstractString) = frozen(_includet, mapexpr, mod, file)
+
+function _includet(mapexpr::Function, mod::Module, file::AbstractString)
     prev = Base.source_path(nothing)
     file = if prev === nothing
         abspath(file)
@@ -2772,9 +2785,11 @@ function revise_first(ex)
 
         if isa(exu, Expr)
             exu.head === :call && length(exu.args) == 1 && exu.args[1] === :exit && return ex
-            lhsrhs = LoweredCodeUtils.get_lhs_rhs(exu)
-            if lhsrhs !== nothing
-                lhs, _ = lhsrhs
+            # `Revise.active[] = ...` must not trigger a revision. This is surface syntax,
+            # so a plain `:(=)` check suffices; using `LoweredCodeUtils.get_lhs_rhs` here
+            # would give this latest-world function static edges into that package.
+            if isexpr(exu, :(=), 2)
+                lhs = exu.args[1]
                 if isexpr(lhs, :ref) && length(lhs.args) == 1
                     arg1 = lhs.args[1]
                     isexpr(arg1, :(.), 2) && arg1.args[1] === :Revise && is_quotenode_egal(arg1.args[2], :active) && return ex

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -39,6 +39,7 @@ function _precompile_()
     @warnpcfail precompile(Tuple{typeof(revise)})
     @warnpcfail precompile(Tuple{typeof(revise_first), Expr})
     @warnpcfail precompile(Tuple{typeof(includet), String})
+    @warnpcfail precompile(Tuple{typeof(_includet), typeof(identity), Module, String})
     @warnpcfail precompile(Tuple{typeof(track), Module, String})
     # setindex! doesn't fully precompile, but it's still beneficial to do it
     # (it shaves off a bit of the time)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -15,7 +15,9 @@ usual package callback never fires and any source edits made since the image was
 built go unnoticed. Calling `Revise.track` on such a package starts watching it and
 applies any pending edits.
 """
-function track(mod::Module; modified_files=revision_queue, revise_throw::Bool=!isinteractive())
+track(mod::Module; kwargs...) = frozen(_track, mod; kwargs...)
+
+function _track(mod::Module; modified_files=revision_queue, revise_throw::Bool=!isinteractive())
     id = pkgidid_for_mod(mod)
     modname = nameof(mod)
     ret = _track(id, modname; modified_files=modified_files)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7551,17 +7551,61 @@ do_test("Frozen world") && @testset "Frozen world" begin
     # `f`, or invalidations from later-loaded packages propagate to the caller and
     # recompiling it re-infers `f`'s entire call graph in the latest world (issue #1134).
     # Any static call to `f` shows up as an `:invoke` of a Revise method.
-    src, _ = only(code_typed(Revise.frozen, (typeof(Revise._revise),); optimize=true))
-    static_revise_calls = Method[]
-    for stmt in src.code
-        Meta.isexpr(stmt, :invoke) || continue
+    # Any static call to `f` shows up as an `:invoke` of a Revise method.
+    function invoke_target(stmt)
+        Meta.isexpr(stmt, :invoke) || return nothing
         target = stmt.args[1]
         target isa Core.CodeInstance && (target = target.def)
         isdefined(Core, :ABIOverride) && target isa Core.ABIOverride && (target = target.def)
-        target isa Core.MethodInstance || continue
-        target.def.module === Revise && push!(static_revise_calls, target.def)
+        return target isa Core.MethodInstance ? target : nothing
     end
+    src, _ = only(code_typed(Revise.frozen, (typeof(Revise._revise),); optimize=true))
+    static_revise_calls = [mi.def for mi in filter(!isnothing, map(invoke_target, src.code)) if mi.def.module === Revise]
     @test isempty(static_revise_calls)
+
+    # The same requirement applies to every entry point that user code or Julia calls in
+    # the latest world: each must reach the revision engine only through `frozen` (or
+    # `invokelatest`). Follow static `:invoke`s transitively through Revise's own methods
+    # from each entry point and check that the closure never reaches engine code.
+    ourmods = (Revise, Revise.JuliaInterpreter, Revise.LoweredCodeUtils, Revise.CodeTracking)
+    function static_invoke_closure!(seen, codes)
+        for (src, _) in codes, stmt in src.code
+            mi = invoke_target(stmt)
+            mi === nothing && continue
+            mi in seen && continue
+            push!(seen, mi)
+            Base.moduleroot(mi.def.module) in ourmods || continue
+            static_invoke_closure!(seen, Base.code_typed_by_type(mi.specTypes; optimize=true))
+        end
+        return seen
+    end
+    engine_names = ("_revise", "_track", "_includet", "_entr", "_add_callback", "_errors", "_retry",
+                    "_add_require", "eval_require_now", "watch_package", "revise_file_now",
+                    "instantiate_sigs!", "methods_by_execution!", "parse_and_maybe_eval_source!",
+                    "init_watching")
+    function is_engine(m::Method)
+        Base.moduleroot(m.module) in (Revise.JuliaInterpreter, Revise.LoweredCodeUtils) && return true
+        name = String(m.name)
+        return any(n -> name == n || startswith(name, "#" * n * "#"), engine_names)
+    end
+    entries = [
+        (revise, ()), (revise, (Module,)),
+        (Revise.track, (Module,)), (Revise.track, (Module, String)), (Revise.track, (String,)),
+        (includet, (String,)), (includet, (typeof(identity), Module, String)),
+        (entr, (typeof(identity), Vector{String})), (entr, (typeof(identity), Vector{String}, Vector{Module})),
+        (Revise.errors, ()), (Revise.retry, ()),
+        (Revise.add_callback, (typeof(identity), Vector{String})), (Revise.remove_callback, (Symbol,)),
+        (Revise.add_require, (String, Module, String, String, Expr)),
+        (Revise.watch_package_callback, (Base.PkgId,)),
+        (Revise.revise_first, (Expr,)),
+    ]
+    leaks = Dict{Any,Vector{Method}}()
+    for (f, argtypes) in entries
+        seen = static_invoke_closure!(Set{Core.MethodInstance}(), code_typed(f, argtypes; optimize=true))
+        leaked = [mi.def for mi in seen if is_engine(mi.def)]
+        isempty(leaked) || (leaks[(f, argtypes)] = leaked)
+    end
+    @test isempty(leaks)
 end
 
 do_test("Frozen world user-code frame") && @testset "Frozen world user-code frame" begin


### PR DESCRIPTION
`includet`, `entr`, `Revise.track(::Module)`, `Revise.errors`, `Revise.retry`, `Revise.add_callback`, and `Revise.remove_callback` are now shims that dispatch to `_`-prefixed bodies through `frozen`, like `revise`, `track(::Module, file)`, and `add_require` already do. The pinned bodies reach user-supplied code through `invokelatest`: `entr`'s initial `f()` now does so (the debounced calls already did), and `includet`'s `mapexpr` and `@error` display already went that way.

`revise_first` no longer calls `LoweredCodeUtils.get_lhs_rhs`: it is compiled in the latest world and only needs to recognize the surface form `Revise.active[] = ...`, so a plain `:(=)` check keeps it free of static edges into that package.

The "Frozen world" testset now follows static `:invoke`s transitively from each entry point through Revise's own methods and checks that the closure never reaches engine code, JuliaInterpreter, or LoweredCodeUtils. This is what an unpinned wrapper looks like at compile time (the `add_require` case in #1134), so the check catches any future static call added to a wrapper body.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>