### PR TITLE
Stop per-file watchers quietly once a file is untracked

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1214,14 +1214,16 @@ init_watching(files) = init_watching((@lock revise_lock pkgdatas[NOPACKAGE]), fi
 const watch_reappear_grace = Ref(5.0)
 
 # Block while a watched path is missing. `exists(path)` reports whether it is
-# currently present; `watchkey` is its entry in `watched_files`. Returns:
+# currently present; `stillwatched()` whether it is still registered in
+# `watched_files`. Returns:
 #   :reappeared — came back within the grace period (resume watching)
-#   :removed    — no longer in the watch list, e.g. the package moved (stop quietly)
+#   :removed    — no longer registered, e.g. the package moved or the file was
+#                 untracked by a `revise` (stop quietly)
 #   :gone       — stayed missing past the grace period (stop and warn)
-function await_watched_path(exists, path::AbstractString, watchkey::AbstractString)
+function await_watched_path(exists, stillwatched, path::AbstractString)
     waited = 0.0
     while !exists(path)
-        @lock revise_lock haskey(watched_files, watchkey) || return :removed
+        stillwatched() || return :removed
         waited ≥ watch_reappear_grace[] && return :gone
         sleep(0.1)
         waited += 0.1
@@ -1300,11 +1302,12 @@ This is generally called via a [`Revise.TaskThunk`](@ref).
 """
 @noinline function revise_dir_queued(dirname::AbstractString)
     @assert isabspath(dirname)
+    dirwatched() = @lock revise_lock haskey(watched_files, dirname)
     try
         stillwatching = true
         while stillwatching
             if !isdir(dirname)
-                status = await_watched_path(isdir, dirname, dirname)
+                status = await_watched_path(isdir, dirwatched, dirname)
                 if status !== :reappeared
                     if status === :gone
                         with_logger(SimpleLogger(stderr)) do
@@ -1380,11 +1383,17 @@ function revise_file_queued(pkgdata::PkgData, filename)
             wl.file_ctimes[filebase] = ctime(file)
         end
     end
+    # A `revise` that finds the file's `include` removed untracks it; the watch
+    # then ends without the "not an existing file" warning.
+    filewatched() = @lock revise_lock begin
+        wl = get(watched_files, dirfull, nothing)
+        wl !== nothing && haskey(wl.trackedfiles, filebase)
+    end
     try
         stillwatching = true
         while stillwatching
             if !fileexists(file)
-                status = await_watched_path(fileexists, file, dirfull)
+                status = await_watched_path(fileexists, filewatched, file)
                 if status !== :reappeared
                     if status === :gone
                         with_logger(SimpleLogger(stderr)) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6573,6 +6573,23 @@ do_test("Removed include, missing file") && @testset "Removed include, missing f
                              (pkgdata, joinpath("src", "gone.jl")))
     @test !Revise.pkgfileless((pkgdata, joinpath("src", "gone.jl")),
                               (pkgdata, joinpath("src", "GoneInclude.jl")))
+    # The per-file watcher (`watching_files[]` mode) finds "gone.jl" untracked and
+    # must end quietly, rather than warning once `watch_reappear_grace` expires
+    # (possibly during a later testset's stderr capture).
+    old_grace = Revise.watch_reappear_grace[]
+    Revise.watch_reappear_grace[] = 0.0
+    warnfile = randtmp()
+    try
+        open(warnfile, "w") do io
+            redirect_stderr(io) do
+                sleep(0.5)
+            end
+        end
+        @test !occursin("is not an existing file", read(warnfile, String))
+    finally
+        Revise.watch_reappear_grace[] = old_grace
+        rm(warnfile; force=true)
+    end
 
     rm_precompile("GoneInclude")
     pop!(LOAD_PATH)
@@ -7327,24 +7344,25 @@ do_test("watch reappearance") && @testset "watch reappearance" begin
     dir = mktempdir()
     key = dir
     Revise.watched_files[key] = Revise.WatchList()
+    watched() = haskey(Revise.watched_files, key)
     old_grace = Revise.watch_reappear_grace[]
     try
         # Present: resume immediately.
-        @test Revise.await_watched_path(isdir, dir, key) === :reappeared
+        @test Revise.await_watched_path(isdir, watched, dir) === :reappeared
         # Missing but reappears within the grace period: resume.
         rm(dir; recursive=true)
         recreate = @async (sleep(0.3); mkdir(dir))
         Revise.watch_reappear_grace[] = 5.0
-        @test Revise.await_watched_path(isdir, dir, key) === :reappeared
+        @test Revise.await_watched_path(isdir, watched, dir) === :reappeared
         wait(recreate)
         # Missing past the grace period: give up (and the caller warns).
         rm(dir; recursive=true)
         Revise.watch_reappear_grace[] = 0.2
-        @test Revise.await_watched_path(isdir, dir, key) === :gone
+        @test Revise.await_watched_path(isdir, watched, dir) === :gone
         # Missing and no longer registered (package moved/removed): give up quietly.
         Revise.watch_reappear_grace[] = 5.0
         delete!(Revise.watched_files, key)
-        @test Revise.await_watched_path(isdir, dir, key) === :removed
+        @test Revise.await_watched_path(isdir, watched, dir) === :removed
     finally
         Revise.watch_reappear_grace[] = old_grace
         haskey(Revise.watched_files, key) && delete!(Revise.watched_files, key)


### PR DESCRIPTION
`await_watched_path` now takes a `stillwatched` predicate instead of a `watched_files` key. The per-file watcher (`watching_files[]` mode) uses it to check its entry in the directory's `trackedfiles`, so a file that a `revise` untracked (its `include` was removed while the file was already gone from disk) ends its watch without the "is not an existing file" warning. The warning stays for files that vanish while still tracked.

The `watch_reappear_grace` delay meant the stray warning could surface in an unrelated later testset's stderr capture, failing the `REVISE_TESTS_WATCH_FILES` CI pass intermittently. The "Removed include, missing file" testset now asserts the watcher goes quiet.

Assisted-by: Claude Fable 5.1 <noreply@anthropic.com>